### PR TITLE
Add .editorconfig with Kotlin official style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt,kts}]
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ktlint_code_style = ktlint_official
+ktlint_standard_no-wildcard-imports = enabled
+ktlint_standard_trailing-comma-on-call-site = enabled
+ktlint_standard_trailing-comma-on-declaration-site = enabled
+ktlint_standard_max-line-length = enabled
+max_line_length = 140
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,xml}]
+indent_size = 2


### PR DESCRIPTION
## Summary
- Adds `.editorconfig` with `ktlint_official` code style
- Enforces no-wildcard-imports, trailing commas, 140-char max line length
- Standard formatting for YAML, JSON, and Markdown files

## Test plan
- [x] Config-only change, no code impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository-wide code formatting configuration standards for consistent whitespace, indentation, and line endings across multiple file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->