### PR TITLE
Define role schema (system-level and org-level roles)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -1,0 +1,57 @@
+package com.froilan.synectix.config
+
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.repository.RoleRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+@Component
+@Order(1)
+class RoleSeeder(
+    private val roleRepository: RoleRepository,
+) : ApplicationRunner {
+    private val log = LoggerFactory.getLogger(RoleSeeder::class.java)
+
+    override fun run(args: ApplicationArguments) {
+        val defaultRoles =
+            listOf(
+                Role(
+                    name = "SUPER_ADMIN",
+                    description = "System-wide administrator with full access",
+                    level = RoleLevel.SYSTEM,
+                ),
+                Role(
+                    name = "OWNER",
+                    description = "Organization owner with full org-level access",
+                    level = RoleLevel.ORGANIZATION,
+                    isDefault = true,
+                ),
+                Role(
+                    name = "ADMIN",
+                    description = "Organization administrator",
+                    level = RoleLevel.ORGANIZATION,
+                ),
+                Role(
+                    name = "MEMBER",
+                    description = "Standard organization member",
+                    level = RoleLevel.ORGANIZATION,
+                ),
+                Role(
+                    name = "VIEWER",
+                    description = "Read-only organization access",
+                    level = RoleLevel.ORGANIZATION,
+                ),
+            )
+
+        defaultRoles.forEach { role ->
+            if (!roleRepository.existsByName(role.name)) {
+                roleRepository.save(role)
+                log.info("Seeded role: {} ({})", role.name, role.level)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -34,7 +34,7 @@ class TokenAuthenticationFilter(
                     val userOpt = userRepository.findById(sessionToken.userId)
                     if (userOpt.isPresent && userOpt.get().isActive) {
                         val user = userOpt.get()
-                        val authorities = user.roles.map { SimpleGrantedAuthority("ROLE_$it") }
+                        val authorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
                         val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
                         SecurityContextHolder.getContext().authentication = authentication
                     }

--- a/src/main/kotlin/com/froilan/synectix/model/Role.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Role.kt
@@ -1,0 +1,30 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class RoleLevel {
+    SYSTEM,
+    ORGANIZATION,
+}
+
+@Document(collection = "roles")
+data class Role(
+    @Id
+    val uuid: String = UUID.randomUUID().toString(),
+    @Indexed(unique = true)
+    val name: String,
+    val description: String,
+    val level: RoleLevel,
+    val isDefault: Boolean = false,
+    val permissions: List<String> = emptyList(),
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/RoleAssignment.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/RoleAssignment.kt
@@ -1,0 +1,6 @@
+package com.froilan.synectix.model
+
+data class RoleAssignment(
+    val role: String,
+    val organizationId: String? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/User.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/User.kt
@@ -21,9 +21,15 @@ data class User(
     val passwordHash: String,
     val isActive: Boolean = true,
     val organizationId: String,
-    val roles: List<String> = listOf("USER"),
+    val roleAssignments: List<RoleAssignment> = emptyList(),
     @CreatedDate
     var createdAt: LocalDateTime? = null,
     @LastModifiedDate
     var updatedAt: LocalDateTime? = null,
 )
+
+fun User.effectiveRoleNames(): List<String> = roleAssignments.map { it.role }
+
+fun User.orgRoleNames(orgId: String): List<String> = roleAssignments.filter { it.organizationId == orgId }.map { it.role }
+
+fun User.systemRoleNames(): List<String> = roleAssignments.filter { it.organizationId == null }.map { it.role }

--- a/src/main/kotlin/com/froilan/synectix/repository/RoleRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/RoleRepository.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleLevel
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface RoleRepository : MongoRepository<Role, String> {
+    fun findByName(name: String): Optional<Role>
+
+    fun findByLevel(level: RoleLevel): List<Role>
+
+    fun existsByName(name: String): Boolean
+}

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -6,8 +6,10 @@ import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.model.Organizations
 import com.froilan.synectix.model.PasswordResetToken
 import com.froilan.synectix.model.RefreshToken
+import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
+import com.froilan.synectix.model.effectiveRoleNames
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
@@ -71,6 +73,10 @@ class AuthService(
                     lastName = request.lastName,
                     email = request.email.lowercase(Locale.ROOT),
                     organizationId = savedOrganization.uuid,
+                    roleAssignments =
+                        listOf(
+                            RoleAssignment(role = "OWNER", organizationId = savedOrganization.uuid),
+                        ),
                 )
             return userRepository.save(user)
         } catch (e: DuplicateKeyException) {
@@ -138,7 +144,7 @@ class AuthService(
             accessToken = accessTokenStr,
             refreshToken = refreshTokenStr,
             username = user.username,
-            roles = user.roles,
+            roles = user.effectiveRoleNames(),
             expiresAt = expiryAt.toString(),
             refreshTokenExpiresAt = refreshExpiryAt.toString(),
         )
@@ -206,7 +212,7 @@ class AuthService(
             accessToken = accessTokenStr,
             refreshToken = refreshTokenStr,
             username = user.username,
-            roles = user.roles,
+            roles = user.effectiveRoleNames(),
             expiresAt = expiryAt.toString(),
             refreshTokenExpiresAt = refreshExpiryAt.toString(),
         )

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -1,0 +1,96 @@
+package com.froilan.synectix.config
+
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.repository.RoleRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.springframework.boot.ApplicationArguments
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RoleSeederTest {
+    private lateinit var roleRepository: RoleRepository
+    private lateinit var roleSeeder: RoleSeeder
+
+    @BeforeEach
+    fun setup() {
+        roleRepository = mock(RoleRepository::class.java)
+        roleSeeder = RoleSeeder(roleRepository)
+    }
+
+    @Test
+    fun `should seed all default roles when none exist`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val seededNames = captor.allValues.map { it.name }.toSet()
+        assertEquals(setOf("SUPER_ADMIN", "OWNER", "ADMIN", "MEMBER", "VIEWER"), seededNames)
+    }
+
+    @Test
+    fun `should not duplicate roles when they already exist`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(true)
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        verify(roleRepository, never()).save(any<Role>())
+    }
+
+    @Test
+    fun `should seed SUPER_ADMIN as system-level role`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val superAdmin = captor.allValues.first { it.name == "SUPER_ADMIN" }
+        assertEquals(RoleLevel.SYSTEM, superAdmin.level)
+    }
+
+    @Test
+    fun `should seed org-level roles with correct level`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val orgRoles = captor.allValues.filter { it.name in setOf("OWNER", "ADMIN", "MEMBER", "VIEWER") }
+        assertTrue(orgRoles.all { it.level == RoleLevel.ORGANIZATION })
+    }
+
+    @Test
+    fun `should mark OWNER as default role`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val owner = captor.allValues.first { it.name == "OWNER" }
+        assertTrue(owner.isDefault)
+
+        val nonDefaults = captor.allValues.filter { it.name != "OWNER" }
+        assertTrue(nonDefaults.none { it.isDefault })
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -273,7 +273,7 @@ class AuthControllerTest {
                 accessToken = "generated-token-123",
                 refreshToken = "generated-refresh-token-123",
                 username = "testuser",
-                roles = listOf("USER"),
+                roles = listOf("OWNER"),
                 expiresAt = LocalDateTime.now().plusHours(24).toString(),
                 refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
             )
@@ -288,7 +288,7 @@ class AuthControllerTest {
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.accessToken").value(authResponse.accessToken))
             .andExpect(jsonPath("$.username").value(authResponse.username))
-            .andExpect(jsonPath("$.roles[0]").value("USER"))
+            .andExpect(jsonPath("$.roles[0]").value("OWNER"))
             .andExpect(jsonPath("$.expiresAt").exists())
     }
 
@@ -386,7 +386,7 @@ class AuthControllerTest {
                 accessToken = "new-access-token-456",
                 refreshToken = "new-refresh-token-789",
                 username = "testuser",
-                roles = listOf("USER"),
+                roles = listOf("OWNER"),
                 expiresAt = LocalDateTime.now().plusHours(24).toString(),
                 refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
             )

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.aspect.LoggingAspect
 import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
 import com.froilan.synectix.repository.OrganizationRepository
@@ -71,13 +72,14 @@ class SessionControllerTest {
             lastName = "User",
             passwordHash = "encoded",
             organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
         )
 
     private val currentToken = "current-bearer-token"
 
     @BeforeEach
     fun setup() {
-        val authorities = testUser.roles.map { SimpleGrantedAuthority("ROLE_$it") }
+        val authorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
         val authentication = UsernamePasswordAuthenticationToken(testUser, null, authorities)
         SecurityContextHolder.getContext().authentication = authentication
     }

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -5,8 +5,10 @@ import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.model.Organizations
 import com.froilan.synectix.model.PasswordResetToken
 import com.froilan.synectix.model.RefreshToken
+import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
+import com.froilan.synectix.model.effectiveRoleNames
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
@@ -117,6 +119,7 @@ class AuthServiceTest {
         verify(userRepository, times(1)).save(userCaptor.capture())
         assertEquals(encodedPassword, userCaptor.firstValue.passwordHash)
         assertEquals(savedOrg.uuid, userCaptor.firstValue.organizationId)
+        assertEquals(listOf(RoleAssignment("OWNER", savedOrg.uuid)), userCaptor.firstValue.roleAssignments)
     }
 
     @Test
@@ -206,7 +209,11 @@ class AuthServiceTest {
                 lastName = "User",
                 passwordHash = "encodedPassword",
                 organizationId = "org-123",
-                roles = listOf("USER", "ADMIN"),
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("MEMBER", "org-123"),
+                        RoleAssignment("ADMIN", "org-123"),
+                    ),
             )
         val savedToken = createMockSessionToken()
 
@@ -219,7 +226,7 @@ class AuthServiceTest {
 
         assertNotNull(result)
         assertEquals(user.username, result.username)
-        assertEquals(user.roles, result.roles)
+        assertEquals(user.effectiveRoleNames(), result.roles)
         assertNotNull(result.accessToken)
         assertNotNull(result.expiresAt)
 
@@ -685,6 +692,7 @@ class AuthServiceTest {
             lastName = "User",
             passwordHash = "encodedPassword",
             organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("MEMBER", "org-123")),
         )
 
     private fun createMockSessionToken() =


### PR DESCRIPTION
## Summary
- Add `Role` document model with `RoleLevel` enum (SYSTEM, ORGANIZATION) and `RoleRepository`
- Add `RoleAssignment` embedded model replacing flat `List<String>` roles on `User`
- Org creator receives `OWNER` role assignment on signup
- Idempotent `RoleSeeder` seeds default roles (SUPER_ADMIN, OWNER, ADMIN, MEMBER, VIEWER) on startup
- Update `TokenAuthenticationFilter`, `AuthService`, and all related tests

## Test plan
- [x] All 74 tests pass (1 pre-existing context-load failure due to no local MongoDB)
- [x] ktlint passes
- [ ] Verify role seeder logs on fresh app start
- [ ] Verify signup returns `OWNER` in roles response

Closes #15