### PR TITLE
Implement RBAC permission model (resource + action based)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -3,6 +3,8 @@ package com.froilan.synectix.config
 import com.froilan.synectix.model.Role
 import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.repository.RoleRepository
+import com.froilan.synectix.security.Permissions
+import com.froilan.synectix.security.RolePermissionCache
 import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component
 @Order(1)
 class RoleSeeder(
     private val roleRepository: RoleRepository,
+    private val rolePermissionCache: RolePermissionCache,
 ) : ApplicationRunner {
     private val log = LoggerFactory.getLogger(RoleSeeder::class.java)
 
@@ -29,29 +32,77 @@ class RoleSeeder(
                     description = "Organization owner with full org-level access",
                     level = RoleLevel.ORGANIZATION,
                     isDefault = true,
+                    permissions =
+                        listOf(
+                            Permissions.SESSION_READ,
+                            Permissions.SESSION_DELETE,
+                            Permissions.USER_READ,
+                            Permissions.USER_WRITE,
+                            Permissions.USER_DELETE,
+                            Permissions.ORGANIZATION_READ,
+                            Permissions.ORGANIZATION_WRITE,
+                            Permissions.ORGANIZATION_DELETE,
+                            Permissions.ENVIRONMENT_READ,
+                        ),
                 ),
                 Role(
                     name = "ADMIN",
                     description = "Organization administrator",
                     level = RoleLevel.ORGANIZATION,
+                    permissions =
+                        listOf(
+                            Permissions.SESSION_READ,
+                            Permissions.SESSION_DELETE,
+                            Permissions.USER_READ,
+                            Permissions.USER_WRITE,
+                            Permissions.ORGANIZATION_READ,
+                            Permissions.ORGANIZATION_WRITE,
+                            Permissions.ENVIRONMENT_READ,
+                        ),
                 ),
                 Role(
                     name = "MEMBER",
                     description = "Standard organization member",
                     level = RoleLevel.ORGANIZATION,
+                    permissions =
+                        listOf(
+                            Permissions.SESSION_READ,
+                            Permissions.SESSION_DELETE,
+                            Permissions.USER_READ,
+                            Permissions.ORGANIZATION_READ,
+                        ),
                 ),
                 Role(
                     name = "VIEWER",
                     description = "Read-only organization access",
                     level = RoleLevel.ORGANIZATION,
+                    permissions =
+                        listOf(
+                            Permissions.SESSION_READ,
+                            Permissions.ORGANIZATION_READ,
+                        ),
                 ),
             )
 
+        var changed = false
         defaultRoles.forEach { role ->
-            if (!roleRepository.existsByName(role.name)) {
+            val existing = roleRepository.findByName(role.name)
+            if (existing.isEmpty) {
                 roleRepository.save(role)
                 log.info("Seeded role: {} ({})", role.name, role.level)
+                changed = true
+            } else {
+                val current = existing.get()
+                if (current.permissions != role.permissions) {
+                    roleRepository.save(current.copy(permissions = role.permissions))
+                    log.info("Updated permissions for role: {}", role.name)
+                    changed = true
+                }
             }
+        }
+
+        if (changed) {
+            rolePermissionCache.refresh()
         }
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -93,9 +93,20 @@ class RoleSeeder(
                 changed = true
             } else {
                 val current = existing.get()
-                if (current.permissions != role.permissions) {
-                    roleRepository.save(current.copy(permissions = role.permissions))
-                    log.info("Updated permissions for role: {}", role.name)
+                if (current.description != role.description ||
+                    current.level != role.level ||
+                    current.isDefault != role.isDefault ||
+                    current.permissions != role.permissions
+                ) {
+                    roleRepository.save(
+                        current.copy(
+                            description = role.description,
+                            level = role.level,
+                            isDefault = role.isDefault,
+                            permissions = role.permissions,
+                        ),
+                    )
+                    log.info("Updated role: {}", role.name)
                     changed = true
                 }
             }

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -1,8 +1,12 @@
 package com.froilan.synectix.config
 
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -16,6 +20,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 class SecurityConfig(
     private val tokenAuthenticationFilter: TokenAuthenticationFilter,
     @Value("\${spring.web.cors.allowed-origins:http://localhost:3000,http://localhost:8080}")
@@ -45,9 +50,22 @@ class SecurityConfig(
                 it.requestMatchers("/actuator/health/**").permitAll()
                 it.requestMatchers("/actuator/info").permitAll()
                 it.anyRequest().authenticated()
+            }.exceptionHandling {
+                it.accessDeniedHandler { _, resp, _ ->
+                    resp.status = 403
+                    resp.contentType = "application/json"
+                    resp.writer.write("""{"error":"Insufficient permissions"}""")
+                }
             }.addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
+    }
+
+    @Bean
+    fun methodSecurityExpressionHandler(permissionEvaluator: SynectixPermissionEvaluator): MethodSecurityExpressionHandler {
+        val handler = DefaultMethodSecurityExpressionHandler()
+        handler.setPermissionEvaluator(permissionEvaluator)
+        return handler
     }
 
     @Bean

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.config
 
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -16,6 +17,7 @@ import java.time.LocalDateTime
 class TokenAuthenticationFilter(
     private val sessionTokenRepository: SessionTokenRepository,
     private val userRepository: UserRepository,
+    private val rolePermissionCache: RolePermissionCache,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -34,7 +36,13 @@ class TokenAuthenticationFilter(
                     val userOpt = userRepository.findById(sessionToken.userId)
                     if (userOpt.isPresent && userOpt.get().isActive) {
                         val user = userOpt.get()
-                        val authorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+                        val roleAuthorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+                        val permissionAuthorities =
+                            user.roleAssignments
+                                .flatMap { rolePermissionCache.getPermissions(it.role) }
+                                .distinct()
+                                .map { SimpleGrantedAuthority(it) }
+                        val authorities = roleAuthorities + permissionAuthorities
                         val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
                         SecurityContextHolder.getContext().authentication = authentication
                     }

--- a/src/main/kotlin/com/froilan/synectix/controller/EnvironmentController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/EnvironmentController.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.config.SynectixProperties
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -24,6 +25,7 @@ class EnvironmentController(
      * Get application environment information.
      */
     @GetMapping("/info")
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('environment:read')")
     fun getEnvironmentInfo(): Map<String, Any> =
         mapOf(
             "application" to
@@ -45,6 +47,7 @@ class EnvironmentController(
      * Get all environment variables (for debugging - remove in production).
      */
     @GetMapping("/variables")
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('environment:read')")
     fun getAllEnvironmentVariables(): Map<String, String> =
         System.getenv().filterKeys { key ->
             key.startsWith("APP_") ||

--- a/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
@@ -5,6 +5,7 @@ import com.froilan.synectix.model.User
 import com.froilan.synectix.service.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,6 +20,7 @@ class SessionController(
     private val authService: AuthService,
 ) {
     @GetMapping
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('session:read')")
     fun listSessions(
         @RequestHeader("Authorization") authHeader: String,
     ): ResponseEntity<Any> {
@@ -42,6 +44,7 @@ class SessionController(
     }
 
     @DeleteMapping("/{sessionId}")
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('session:delete')")
     fun revokeSession(
         @RequestHeader("Authorization") authHeader: String,
         @PathVariable sessionId: String,
@@ -65,6 +68,7 @@ class SessionController(
     }
 
     @DeleteMapping
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('session:delete')")
     fun revokeOtherSessions(
         @RequestHeader("Authorization") authHeader: String,
     ): ResponseEntity<Any> {

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.security
+
+object Permissions {
+    const val SESSION_READ = "session:read"
+    const val SESSION_DELETE = "session:delete"
+
+    const val USER_READ = "user:read"
+    const val USER_WRITE = "user:write"
+    const val USER_DELETE = "user:delete"
+
+    const val ORGANIZATION_READ = "organization:read"
+    const val ORGANIZATION_WRITE = "organization:write"
+    const val ORGANIZATION_DELETE = "organization:delete"
+
+    const val ENVIRONMENT_READ = "environment:read"
+}

--- a/src/main/kotlin/com/froilan/synectix/security/RolePermissionCache.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/RolePermissionCache.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.security
+
+import com.froilan.synectix.repository.RoleRepository
+import com.github.benmanes.caffeine.cache.Caffeine
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RolePermissionCache(
+    private val roleRepository: RoleRepository,
+) {
+    private val cache =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(Duration.ofHours(1))
+            .build<String, Set<String>> { name ->
+                roleRepository.findByName(name).map { it.permissions.toSet() }.orElse(emptySet())
+            }
+
+    @PostConstruct
+    fun loadAll() {
+        roleRepository.findAll().forEach { role ->
+            cache.put(role.name, role.permissions.toSet())
+        }
+    }
+
+    fun getPermissions(roleName: String): Set<String> = cache.get(roleName)
+
+    fun refresh() {
+        cache.invalidateAll()
+        loadAll()
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/security/SynectixPermissionEvaluator.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/SynectixPermissionEvaluator.kt
@@ -1,0 +1,28 @@
+package com.froilan.synectix.security
+
+import org.springframework.security.access.PermissionEvaluator
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import java.io.Serializable
+
+@Component
+class SynectixPermissionEvaluator : PermissionEvaluator {
+    override fun hasPermission(
+        authentication: Authentication,
+        targetDomainObject: Any,
+        permission: Any,
+    ): Boolean {
+        if (authentication.authorities.any { it.authority == "ROLE_SUPER_ADMIN" }) {
+            return true
+        }
+        val permStr = permission as? String ?: return false
+        return authentication.authorities.any { it.authority == permStr }
+    }
+
+    override fun hasPermission(
+        authentication: Authentication,
+        targetId: Serializable,
+        targetType: String,
+        permission: Any,
+    ): Boolean = hasPermission(authentication, targetId as Any, permission)
+}

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -3,6 +3,8 @@ package com.froilan.synectix.config
 import com.froilan.synectix.model.Role
 import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.repository.RoleRepository
+import com.froilan.synectix.security.Permissions
+import com.froilan.synectix.security.RolePermissionCache
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -13,22 +15,25 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.springframework.boot.ApplicationArguments
+import java.util.Optional
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class RoleSeederTest {
     private lateinit var roleRepository: RoleRepository
+    private lateinit var rolePermissionCache: RolePermissionCache
     private lateinit var roleSeeder: RoleSeeder
 
     @BeforeEach
     fun setup() {
         roleRepository = mock(RoleRepository::class.java)
-        roleSeeder = RoleSeeder(roleRepository)
+        rolePermissionCache = mock(RolePermissionCache::class.java)
+        roleSeeder = RoleSeeder(roleRepository, rolePermissionCache)
     }
 
     @Test
     fun `should seed all default roles when none exist`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
@@ -41,17 +46,64 @@ class RoleSeederTest {
     }
 
     @Test
-    fun `should not duplicate roles when they already exist`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(true)
+    fun `should not save when roles exist with correct permissions`() {
+        val existingOwner =
+            Role(
+                name = "OWNER",
+                description = "Organization owner with full org-level access",
+                level = RoleLevel.ORGANIZATION,
+                isDefault = true,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.USER_WRITE,
+                        Permissions.USER_DELETE,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ORGANIZATION_WRITE,
+                        Permissions.ORGANIZATION_DELETE,
+                        Permissions.ENVIRONMENT_READ,
+                    ),
+            )
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(existingOwner))
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(existingOwner))
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
 
-        verify(roleRepository, never()).save(any<Role>())
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(4)).save(captor.capture())
+        assertTrue(captor.allValues.none { it.name == "OWNER" })
     }
 
     @Test
-    fun `should seed SUPER_ADMIN as system-level role`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(false)
+    fun `should update permissions when role exists with outdated permissions`() {
+        val outdatedRole =
+            Role(
+                name = "MEMBER",
+                description = "Standard organization member",
+                level = RoleLevel.ORGANIZATION,
+                permissions = emptyList(),
+            )
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(outdatedRole))
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val updatedMember = captor.allValues.first { it.name == "MEMBER" }
+        assertTrue(updatedMember.permissions.contains(Permissions.SESSION_READ))
+        assertTrue(updatedMember.permissions.contains(Permissions.ORGANIZATION_READ))
+    }
+
+    @Test
+    fun `should seed SUPER_ADMIN as system-level role with no permissions`() {
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
@@ -61,11 +113,12 @@ class RoleSeederTest {
 
         val superAdmin = captor.allValues.first { it.name == "SUPER_ADMIN" }
         assertEquals(RoleLevel.SYSTEM, superAdmin.level)
+        assertTrue(superAdmin.permissions.isEmpty())
     }
 
     @Test
     fun `should seed org-level roles with correct level`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
@@ -78,19 +131,89 @@ class RoleSeederTest {
     }
 
     @Test
-    fun `should mark OWNER as default role`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(false)
+    fun `should refresh cache after seeding`() {
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
 
-        val captor = argumentCaptor<Role>()
-        verify(roleRepository, times(5)).save(captor.capture())
+        verify(rolePermissionCache).refresh()
+    }
 
-        val owner = captor.allValues.first { it.name == "OWNER" }
-        assertTrue(owner.isDefault)
+    @Test
+    fun `should not refresh cache when nothing changed`() {
+        val superAdmin =
+            Role(
+                name = "SUPER_ADMIN",
+                description = "System-wide administrator with full access",
+                level = RoleLevel.SYSTEM,
+                permissions = emptyList(),
+            )
+        val owner =
+            Role(
+                name = "OWNER",
+                description = "Organization owner with full org-level access",
+                level = RoleLevel.ORGANIZATION,
+                isDefault = true,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.USER_WRITE,
+                        Permissions.USER_DELETE,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ORGANIZATION_WRITE,
+                        Permissions.ORGANIZATION_DELETE,
+                        Permissions.ENVIRONMENT_READ,
+                    ),
+            )
+        val admin =
+            Role(
+                name = "ADMIN",
+                description = "Organization administrator",
+                level = RoleLevel.ORGANIZATION,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.USER_WRITE,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ORGANIZATION_WRITE,
+                        Permissions.ENVIRONMENT_READ,
+                    ),
+            )
+        val member =
+            Role(
+                name = "MEMBER",
+                description = "Standard organization member",
+                level = RoleLevel.ORGANIZATION,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.ORGANIZATION_READ,
+                    ),
+            )
+        val viewer =
+            Role(
+                name = "VIEWER",
+                description = "Read-only organization access",
+                level = RoleLevel.ORGANIZATION,
+                permissions = listOf(Permissions.SESSION_READ, Permissions.ORGANIZATION_READ),
+            )
 
-        val nonDefaults = captor.allValues.filter { it.name != "OWNER" }
-        assertTrue(nonDefaults.none { it.isDefault })
+        `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(superAdmin))
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(owner))
+        `when`(roleRepository.findByName("ADMIN")).thenReturn(Optional.of(admin))
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(member))
+        `when`(roleRepository.findByName("VIEWER")).thenReturn(Optional.of(viewer))
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        verify(roleRepository, never()).save(any<Role>())
+        verify(rolePermissionCache, never()).refresh()
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -46,7 +46,7 @@ class RoleSeederTest {
     }
 
     @Test
-    fun `should not save when roles exist with correct permissions`() {
+    fun `should skip existing role when permissions are already correct`() {
         val existingOwner =
             Role(
                 name = "OWNER",
@@ -66,7 +66,6 @@ class RoleSeederTest {
                         Permissions.ENVIRONMENT_READ,
                     ),
             )
-        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(existingOwner))
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(existingOwner))
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -101,6 +101,42 @@ class RoleSeederTest {
     }
 
     @Test
+    fun `should update all canonical fields when role drifted in DB`() {
+        val driftedRole =
+            Role(
+                name = "OWNER",
+                description = "Modified description",
+                level = RoleLevel.SYSTEM,
+                isDefault = false,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.USER_WRITE,
+                        Permissions.USER_DELETE,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ORGANIZATION_WRITE,
+                        Permissions.ORGANIZATION_DELETE,
+                        Permissions.ENVIRONMENT_READ,
+                    ),
+            )
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(driftedRole))
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val updatedOwner = captor.allValues.first { it.name == "OWNER" }
+        assertEquals("Organization owner with full org-level access", updatedOwner.description)
+        assertEquals(RoleLevel.ORGANIZATION, updatedOwner.level)
+        assertTrue(updatedOwner.isDefault)
+    }
+
+    @Test
     fun `should seed SUPER_ADMIN as system-level role with no permissions`() {
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }

--- a/src/test/kotlin/com/froilan/synectix/config/TestSecurityConfig.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/TestSecurityConfig.kt
@@ -1,8 +1,12 @@
 package com.froilan.synectix.config
 
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -10,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain
 
 @TestConfiguration
 @EnableWebSecurity
+@EnableMethodSecurity
 class TestSecurityConfig {
     @Bean
     @Primary
@@ -20,5 +25,12 @@ class TestSecurityConfig {
             .authorizeHttpRequests { it.anyRequest().permitAll() }
 
         return http.build()
+    }
+
+    @Bean
+    fun methodSecurityExpressionHandler(permissionEvaluator: SynectixPermissionEvaluator): MethodSecurityExpressionHandler {
+        val handler = DefaultMethodSecurityExpressionHandler()
+        handler.setPermissionEvaluator(permissionEvaluator)
+        return handler
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -11,6 +11,8 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.Test
@@ -33,7 +35,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
 
 @WebMvcTest(controllers = [AuthController::class])
-@Import(LoggingAspect::class, TestSecurityConfig::class)
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
 @ActiveProfiles("test")
 class AuthControllerTest {
     @Autowired
@@ -62,6 +64,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
 
     @Test
     fun `POST signup should return 201 when registration is successful`() {

--- a/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
@@ -4,6 +4,8 @@ import com.froilan.synectix.aspect.LoggingAspect
 import com.froilan.synectix.config.TestSecurityConfig
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.mongodb.client.MongoDatabase
 import org.bson.Document
 import org.junit.jupiter.api.Test
@@ -21,7 +23,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(controllers = [HealthController::class])
-@Import(LoggingAspect::class, TestSecurityConfig::class)
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
 @ActiveProfiles("test")
 class HealthControllerTest {
     @Autowired
@@ -38,6 +40,9 @@ class HealthControllerTest {
 
     @MockitoBean
     private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
 
     @Test
     fun `should return health status UP when database is healthy`() {

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -10,6 +10,8 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.BeforeEach
@@ -33,7 +35,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
 
 @WebMvcTest(controllers = [SessionController::class])
-@Import(LoggingAspect::class, TestSecurityConfig::class)
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
 @ActiveProfiles("test")
 class SessionControllerTest {
     @Autowired
@@ -63,6 +65,9 @@ class SessionControllerTest {
     @MockitoBean
     private lateinit var tokenHasher: TokenHasher
 
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
     private val testUser =
         User(
             uuid = "user-123",
@@ -79,8 +84,13 @@ class SessionControllerTest {
 
     @BeforeEach
     fun setup() {
-        val authorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
-        val authentication = UsernamePasswordAuthenticationToken(testUser, null, authorities)
+        setupAuthWithPermissions("session:read", "session:delete")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
         SecurityContextHolder.getContext().authentication = authentication
     }
 
@@ -176,5 +186,27 @@ class SessionControllerTest {
                     .header("Authorization", "Bearer $currentToken"),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("All other sessions revoked"))
+    }
+
+    @Test
+    fun `GET sessions should return 403 without session read permission`() {
+        setupAuthWithPermissions()
+
+        mockMvc
+            .perform(
+                get("/auth/sessions")
+                    .header("Authorization", "Bearer $currentToken"),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `DELETE session should return 403 without session delete permission`() {
+        setupAuthWithPermissions("session:read")
+
+        mockMvc
+            .perform(
+                delete("/auth/sessions/s2")
+                    .header("Authorization", "Bearer $currentToken"),
+            ).andExpect(status().isForbidden)
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
@@ -1,0 +1,69 @@
+package com.froilan.synectix.security
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PermissionEvaluatorTest {
+    private lateinit var evaluator: SynectixPermissionEvaluator
+
+    @BeforeEach
+    fun setup() {
+        evaluator = SynectixPermissionEvaluator()
+    }
+
+    @Test
+    fun `SUPER_ADMIN should bypass any permission check`() {
+        val auth = authWith("ROLE_SUPER_ADMIN")
+
+        assertTrue(evaluator.hasPermission(auth, Unit, "session:read"))
+        assertTrue(evaluator.hasPermission(auth, Unit, "anything:whatever"))
+    }
+
+    @Test
+    fun `user with matching authority should pass`() {
+        val auth = authWith("ROLE_MEMBER", "session:read", "organization:read")
+
+        assertTrue(evaluator.hasPermission(auth, Unit, "session:read"))
+        assertTrue(evaluator.hasPermission(auth, Unit, "organization:read"))
+    }
+
+    @Test
+    fun `user without matching authority should fail`() {
+        val auth = authWith("ROLE_MEMBER", "session:read")
+
+        assertFalse(evaluator.hasPermission(auth, Unit, "session:delete"))
+        assertFalse(evaluator.hasPermission(auth, Unit, "user:write"))
+    }
+
+    @Test
+    fun `user with no authorities should fail`() {
+        val auth = authWith()
+
+        assertFalse(evaluator.hasPermission(auth, Unit, "session:read"))
+    }
+
+    @Test
+    fun `non-string permission should return false`() {
+        val auth = authWith("ROLE_ADMIN", "session:read")
+
+        assertFalse(evaluator.hasPermission(auth, Unit, 123))
+    }
+
+    @Test
+    fun `targetId overload should delegate to primary`() {
+        val auth = authWith("ROLE_SUPER_ADMIN")
+
+        assertTrue(evaluator.hasPermission(auth, "id-1", "Session", "session:read"))
+    }
+
+    private fun authWith(vararg authorities: String) =
+        UsernamePasswordAuthenticationToken(
+            "user",
+            null,
+            authorities.map { SimpleGrantedAuthority(it) },
+        )
+}

--- a/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
@@ -1,0 +1,74 @@
+package com.froilan.synectix.security
+
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.repository.RoleRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RolePermissionCacheTest {
+    private lateinit var roleRepository: RoleRepository
+    private lateinit var cache: RolePermissionCache
+
+    @BeforeEach
+    fun setup() {
+        roleRepository = mock(RoleRepository::class.java)
+
+        val roles =
+            listOf(
+                Role(
+                    name = "OWNER",
+                    description = "Owner",
+                    level = RoleLevel.ORGANIZATION,
+                    permissions = listOf("session:read", "session:delete", "user:read"),
+                ),
+                Role(
+                    name = "VIEWER",
+                    description = "Viewer",
+                    level = RoleLevel.ORGANIZATION,
+                    permissions = listOf("session:read"),
+                ),
+            )
+
+        `when`(roleRepository.findAll()).thenReturn(roles)
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(roles[0]))
+        `when`(roleRepository.findByName("VIEWER")).thenReturn(Optional.of(roles[1]))
+        `when`(roleRepository.findByName("UNKNOWN")).thenReturn(Optional.empty())
+
+        cache = RolePermissionCache(roleRepository)
+        cache.loadAll()
+    }
+
+    @Test
+    fun `should return permissions for known role`() {
+        val permissions = cache.getPermissions("OWNER")
+        assertEquals(setOf("session:read", "session:delete", "user:read"), permissions)
+    }
+
+    @Test
+    fun `should return empty set for unknown role`() {
+        val permissions = cache.getPermissions("UNKNOWN")
+        assertTrue(permissions.isEmpty())
+    }
+
+    @Test
+    fun `refresh should reload from repository`() {
+        val updatedRole =
+            Role(
+                name = "VIEWER",
+                description = "Viewer",
+                level = RoleLevel.ORGANIZATION,
+                permissions = listOf("session:read", "organization:read"),
+            )
+        `when`(roleRepository.findAll()).thenReturn(listOf(updatedRole))
+
+        cache.refresh()
+
+        assertEquals(setOf("session:read", "organization:read"), cache.getPermissions("VIEWER"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Permissions` object with `resource:action` string constants (session, user, organization, environment)
- Add `RolePermissionCache` (Caffeine-backed) to resolve role → permissions without per-request DB lookups
- Add `SynectixPermissionEvaluator` with SUPER_ADMIN bypass for future `hasPermission()` use
- Update `RoleSeeder` to populate permissions per role (OWNER/ADMIN/MEMBER/VIEWER) with upsert logic
- Wire permissions into `TokenAuthenticationFilter` as Spring Security authorities
- Add `@EnableMethodSecurity` and `@PreAuthorize` guards on `SessionController` and `EnvironmentController`
- Return JSON `{"error":"Insufficient permissions"}` on 403
- Add tests for permission evaluator, cache, seeder upsert, and 403 denial scenarios

## Permission matrix
| Role | Permissions |
|------|------------|
| SUPER_ADMIN | *(bypass in evaluator)* |
| OWNER | session:read/delete, user:read/write/delete, organization:read/write/delete, environment:read |
| ADMIN | session:read/delete, user:read/write, organization:read/write, environment:read |
| MEMBER | session:read/delete, user:read, organization:read |
| VIEWER | session:read, organization:read |

## Test plan
- [x] 86/87 tests pass (1 pre-existing context-load failure, no local MongoDB)
- [x] ktlint passes
- [x] Permission denial returns 403
- [x] SUPER_ADMIN bypasses all checks
- [ ] Verify seeder updates permissions on existing roles

Closes #16