### PR TITLE
Release: Role schema, RBAC permissions, and code quality fixes

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/EnvironmentInitializer.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/EnvironmentInitializer.kt
@@ -45,6 +45,9 @@ class EnvironmentInitializer : ApplicationContextInitializer<ConfigurableApplica
                 log.warn("Could not load .env file: {}", e.message)
             } catch (e: IllegalStateException) {
                 log.warn("Could not load .env file: {}", e.message)
+            } catch (e: Exception) {
+                // Broad catch intentional: .env loading must never block startup
+                log.error("Unexpected error loading .env file: {}", e.message)
             }
         } else {
             log.info("No .env file found in project root: {}", envFile.absolutePath)

--- a/src/main/kotlin/com/froilan/synectix/config/EnvironmentInitializer.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/EnvironmentInitializer.kt
@@ -1,17 +1,21 @@
 package com.froilan.synectix.config
 
 import io.github.cdimascio.dotenv.Dotenv
+import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.core.env.MapPropertySource
 import java.io.File
+import java.io.IOException
 
 /**
  * Initializer to load environment variables from .env file in the project root.
  * This runs before the Spring application context is created.
  */
 class EnvironmentInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    private val log = LoggerFactory.getLogger(EnvironmentInitializer::class.java)
+
     override fun initialize(applicationContext: ConfigurableApplicationContext) {
         val environment: ConfigurableEnvironment = applicationContext.environment
 
@@ -36,12 +40,14 @@ class EnvironmentInitializer : ApplicationContextInitializer<ConfigurableApplica
                 val propertySource = MapPropertySource("dotenv", envMap)
                 environment.propertySources.addFirst(propertySource)
 
-                println("Loaded ${envMap.size} environment variables from .env file")
-            } catch (e: Exception) {
-                println("Warning: Could not load .env file: ${e.message}")
+                log.info("Loaded {} environment variables from .env file", envMap.size)
+            } catch (e: IOException) {
+                log.warn("Could not load .env file: {}", e.message)
+            } catch (e: IllegalStateException) {
+                log.warn("Could not load .env file: {}", e.message)
             }
         } else {
-            println("No .env file found in project root: ${envFile.absolutePath}")
+            log.info("No .env file found in project root: {}", envFile.absolutePath)
         }
     }
 

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -3,6 +3,8 @@ package com.froilan.synectix.config
 import com.froilan.synectix.model.Role
 import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.repository.RoleRepository
+import com.froilan.synectix.security.Permissions
+import com.froilan.synectix.security.RolePermissionCache
 import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component
 @Order(1)
 class RoleSeeder(
     private val roleRepository: RoleRepository,
+    private val rolePermissionCache: RolePermissionCache,
 ) : ApplicationRunner {
     private val log = LoggerFactory.getLogger(RoleSeeder::class.java)
 
@@ -29,29 +32,88 @@ class RoleSeeder(
                     description = "Organization owner with full org-level access",
                     level = RoleLevel.ORGANIZATION,
                     isDefault = true,
+                    permissions =
+                        listOf(
+                            Permissions.SESSION_READ,
+                            Permissions.SESSION_DELETE,
+                            Permissions.USER_READ,
+                            Permissions.USER_WRITE,
+                            Permissions.USER_DELETE,
+                            Permissions.ORGANIZATION_READ,
+                            Permissions.ORGANIZATION_WRITE,
+                            Permissions.ORGANIZATION_DELETE,
+                            Permissions.ENVIRONMENT_READ,
+                        ),
                 ),
                 Role(
                     name = "ADMIN",
                     description = "Organization administrator",
                     level = RoleLevel.ORGANIZATION,
+                    permissions =
+                        listOf(
+                            Permissions.SESSION_READ,
+                            Permissions.SESSION_DELETE,
+                            Permissions.USER_READ,
+                            Permissions.USER_WRITE,
+                            Permissions.ORGANIZATION_READ,
+                            Permissions.ORGANIZATION_WRITE,
+                            Permissions.ENVIRONMENT_READ,
+                        ),
                 ),
                 Role(
                     name = "MEMBER",
                     description = "Standard organization member",
                     level = RoleLevel.ORGANIZATION,
+                    permissions =
+                        listOf(
+                            Permissions.SESSION_READ,
+                            Permissions.SESSION_DELETE,
+                            Permissions.USER_READ,
+                            Permissions.ORGANIZATION_READ,
+                        ),
                 ),
                 Role(
                     name = "VIEWER",
                     description = "Read-only organization access",
                     level = RoleLevel.ORGANIZATION,
+                    permissions =
+                        listOf(
+                            Permissions.SESSION_READ,
+                            Permissions.ORGANIZATION_READ,
+                        ),
                 ),
             )
 
+        var changed = false
         defaultRoles.forEach { role ->
-            if (!roleRepository.existsByName(role.name)) {
+            val existing = roleRepository.findByName(role.name)
+            if (existing.isEmpty) {
                 roleRepository.save(role)
                 log.info("Seeded role: {} ({})", role.name, role.level)
+                changed = true
+            } else {
+                val current = existing.get()
+                if (current.description != role.description ||
+                    current.level != role.level ||
+                    current.isDefault != role.isDefault ||
+                    current.permissions != role.permissions
+                ) {
+                    roleRepository.save(
+                        current.copy(
+                            description = role.description,
+                            level = role.level,
+                            isDefault = role.isDefault,
+                            permissions = role.permissions,
+                        ),
+                    )
+                    log.info("Updated role: {}", role.name)
+                    changed = true
+                }
             }
+        }
+
+        if (changed) {
+            rolePermissionCache.refresh()
         }
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -42,7 +42,6 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_READ,
                             Permissions.ORGANIZATION_WRITE,
                             Permissions.ORGANIZATION_DELETE,
-                            Permissions.ENVIRONMENT_READ,
                         ),
                 ),
                 Role(
@@ -57,7 +56,6 @@ class RoleSeeder(
                             Permissions.USER_WRITE,
                             Permissions.ORGANIZATION_READ,
                             Permissions.ORGANIZATION_WRITE,
-                            Permissions.ENVIRONMENT_READ,
                         ),
                 ),
                 Role(

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -94,7 +94,7 @@ class RoleSeeder(
                 if (current.description != role.description ||
                     current.level != role.level ||
                     current.isDefault != role.isDefault ||
-                    current.permissions != role.permissions
+                    current.permissions.toSet() != role.permissions.toSet()
                 ) {
                     roleRepository.save(
                         current.copy(

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -1,0 +1,57 @@
+package com.froilan.synectix.config
+
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.repository.RoleRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+@Component
+@Order(1)
+class RoleSeeder(
+    private val roleRepository: RoleRepository,
+) : ApplicationRunner {
+    private val log = LoggerFactory.getLogger(RoleSeeder::class.java)
+
+    override fun run(args: ApplicationArguments) {
+        val defaultRoles =
+            listOf(
+                Role(
+                    name = "SUPER_ADMIN",
+                    description = "System-wide administrator with full access",
+                    level = RoleLevel.SYSTEM,
+                ),
+                Role(
+                    name = "OWNER",
+                    description = "Organization owner with full org-level access",
+                    level = RoleLevel.ORGANIZATION,
+                    isDefault = true,
+                ),
+                Role(
+                    name = "ADMIN",
+                    description = "Organization administrator",
+                    level = RoleLevel.ORGANIZATION,
+                ),
+                Role(
+                    name = "MEMBER",
+                    description = "Standard organization member",
+                    level = RoleLevel.ORGANIZATION,
+                ),
+                Role(
+                    name = "VIEWER",
+                    description = "Read-only organization access",
+                    level = RoleLevel.ORGANIZATION,
+                ),
+            )
+
+        defaultRoles.forEach { role ->
+            if (!roleRepository.existsByName(role.name)) {
+                roleRepository.save(role)
+                log.info("Seeded role: {} ({})", role.name, role.level)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -1,8 +1,12 @@
 package com.froilan.synectix.config
 
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -16,6 +20,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 class SecurityConfig(
     private val tokenAuthenticationFilter: TokenAuthenticationFilter,
     @Value("\${spring.web.cors.allowed-origins:http://localhost:3000,http://localhost:8080}")
@@ -45,9 +50,22 @@ class SecurityConfig(
                 it.requestMatchers("/actuator/health/**").permitAll()
                 it.requestMatchers("/actuator/info").permitAll()
                 it.anyRequest().authenticated()
+            }.exceptionHandling {
+                it.accessDeniedHandler { _, resp, _ ->
+                    resp.status = 403
+                    resp.contentType = "application/json"
+                    resp.writer.write("""{"error":"Insufficient permissions"}""")
+                }
             }.addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
 
         return http.build()
+    }
+
+    @Bean
+    fun methodSecurityExpressionHandler(permissionEvaluator: SynectixPermissionEvaluator): MethodSecurityExpressionHandler {
+        val handler = DefaultMethodSecurityExpressionHandler()
+        handler.setPermissionEvaluator(permissionEvaluator)
+        return handler
     }
 
     @Bean

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -29,11 +29,11 @@ class SecurityConfig(
     @Bean
     fun passwordEncoder(): PasswordEncoder =
         Argon2PasswordEncoder(
-            16,
-            32,
-            1,
-            65536,
-            3,
+            16, // saltLength
+            32, // hashLength
+            1, // parallelism
+            65536, // memory (KB)
+            3, // iterations
         )
 
     @Bean

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.config
 
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -16,6 +17,7 @@ import java.time.LocalDateTime
 class TokenAuthenticationFilter(
     private val sessionTokenRepository: SessionTokenRepository,
     private val userRepository: UserRepository,
+    private val rolePermissionCache: RolePermissionCache,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -34,7 +36,13 @@ class TokenAuthenticationFilter(
                     val userOpt = userRepository.findById(sessionToken.userId)
                     if (userOpt.isPresent && userOpt.get().isActive) {
                         val user = userOpt.get()
-                        val authorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+                        val roleAuthorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+                        val permissionAuthorities =
+                            user.roleAssignments
+                                .flatMap { rolePermissionCache.getPermissions(it.role) }
+                                .distinct()
+                                .map { SimpleGrantedAuthority(it) }
+                        val authorities = roleAuthorities + permissionAuthorities
                         val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
                         SecurityContextHolder.getContext().authentication = authentication
                     }

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -34,7 +34,7 @@ class TokenAuthenticationFilter(
                     val userOpt = userRepository.findById(sessionToken.userId)
                     if (userOpt.isPresent && userOpt.get().isActive) {
                         val user = userOpt.get()
-                        val authorities = user.roles.map { SimpleGrantedAuthority("ROLE_$it") }
+                        val authorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
                         val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
                         SecurityContextHolder.getContext().authentication = authentication
                     }

--- a/src/main/kotlin/com/froilan/synectix/controller/EnvironmentController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/EnvironmentController.kt
@@ -14,13 +14,9 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/environment")
 class EnvironmentController(
     private val synectixProperties: SynectixProperties,
+    @Value("\${APP_ENVIRONMENT:development}") private val environment: String,
+    @Value("\${SERVER_PORT:8080}") private val serverPort: String,
 ) {
-    @Value("\${APP_ENVIRONMENT:development}")
-    private lateinit var environment: String
-
-    @Value("\${SERVER_PORT:8080}")
-    private lateinit var serverPort: String
-
     /**
      * Get application environment information.
      */

--- a/src/main/kotlin/com/froilan/synectix/controller/EnvironmentController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/EnvironmentController.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.config.SynectixProperties
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -24,6 +25,7 @@ class EnvironmentController(
      * Get application environment information.
      */
     @GetMapping("/info")
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('environment:read')")
     fun getEnvironmentInfo(): Map<String, Any> =
         mapOf(
             "application" to
@@ -45,6 +47,7 @@ class EnvironmentController(
      * Get all environment variables (for debugging - remove in production).
      */
     @GetMapping("/variables")
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('environment:read')")
     fun getAllEnvironmentVariables(): Map<String, String> =
         System.getenv().filterKeys { key ->
             key.startsWith("APP_") ||

--- a/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
@@ -3,6 +3,7 @@ package com.froilan.synectix.controller
 import com.froilan.synectix.annotation.LogLevel
 import com.froilan.synectix.annotation.Loggable
 import com.mongodb.MongoException
+import org.slf4j.LoggerFactory
 import org.springframework.dao.DataAccessException
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.http.ResponseEntity
@@ -17,6 +18,8 @@ import java.time.LocalDateTime
 class HealthController(
     private val mongoTemplate: MongoTemplate,
 ) {
+    private val log = LoggerFactory.getLogger(HealthController::class.java)
+
     @GetMapping
     fun health(): ResponseEntity<Map<String, Any>> {
         val healthData =
@@ -104,6 +107,13 @@ class HealthController(
             mapOf(
                 "status" to "DOWN",
                 "error" to (e.message ?: "Unknown database error"),
+            )
+        } catch (e: Exception) {
+            // Broad catch intentional: health endpoint must always return structured UP/DOWN
+            log.error("Unexpected error during health check", e)
+            mapOf(
+                "status" to "DOWN",
+                "error" to (e.message ?: "Unknown error"),
             )
         }
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
@@ -2,7 +2,8 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.annotation.LogLevel
 import com.froilan.synectix.annotation.Loggable
-import org.springframework.beans.factory.annotation.Autowired
+import com.mongodb.MongoException
+import org.springframework.dao.DataAccessException
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -14,7 +15,7 @@ import java.time.LocalDateTime
 @RequestMapping("/health")
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.DEBUG)
 class HealthController(
-    @Autowired private val mongoTemplate: MongoTemplate,
+    private val mongoTemplate: MongoTemplate,
 ) {
     @GetMapping
     fun health(): ResponseEntity<Map<String, Any>> {
@@ -94,7 +95,12 @@ class HealthController(
                 "status_detail" to "Connected",
                 "databaseName" to db.name,
             )
-        } catch (e: Exception) {
+        } catch (e: MongoException) {
+            mapOf(
+                "status" to "DOWN",
+                "error" to (e.message ?: "Unknown database error"),
+            )
+        } catch (e: DataAccessException) {
             mapOf(
                 "status" to "DOWN",
                 "error" to (e.message ?: "Unknown database error"),

--- a/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
@@ -5,6 +5,7 @@ import com.froilan.synectix.model.User
 import com.froilan.synectix.service.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -19,6 +20,7 @@ class SessionController(
     private val authService: AuthService,
 ) {
     @GetMapping
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('session:read')")
     fun listSessions(
         @RequestHeader("Authorization") authHeader: String,
     ): ResponseEntity<Any> {
@@ -42,6 +44,7 @@ class SessionController(
     }
 
     @DeleteMapping("/{sessionId}")
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('session:delete')")
     fun revokeSession(
         @RequestHeader("Authorization") authHeader: String,
         @PathVariable sessionId: String,
@@ -65,6 +68,7 @@ class SessionController(
     }
 
     @DeleteMapping
+    @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('session:delete')")
     fun revokeOtherSessions(
         @RequestHeader("Authorization") authHeader: String,
     ): ResponseEntity<Any> {

--- a/src/main/kotlin/com/froilan/synectix/model/Role.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Role.kt
@@ -1,0 +1,30 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class RoleLevel {
+    SYSTEM,
+    ORGANIZATION,
+}
+
+@Document(collection = "roles")
+data class Role(
+    @Id
+    val uuid: String = UUID.randomUUID().toString(),
+    @Indexed(unique = true)
+    val name: String,
+    val description: String,
+    val level: RoleLevel,
+    val isDefault: Boolean = false,
+    val permissions: List<String> = emptyList(),
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/RoleAssignment.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/RoleAssignment.kt
@@ -1,0 +1,6 @@
+package com.froilan.synectix.model
+
+data class RoleAssignment(
+    val role: String,
+    val organizationId: String? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/User.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/User.kt
@@ -28,7 +28,7 @@ data class User(
     var updatedAt: LocalDateTime? = null,
 )
 
-fun User.effectiveRoleNames(): List<String> = roleAssignments.map { it.role }
+fun User.effectiveRoleNames(): List<String> = roleAssignments.map { it.role }.distinct()
 
 fun User.orgRoleNames(orgId: String): List<String> = roleAssignments.filter { it.organizationId == orgId }.map { it.role }
 

--- a/src/main/kotlin/com/froilan/synectix/model/User.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/User.kt
@@ -21,9 +21,15 @@ data class User(
     val passwordHash: String,
     val isActive: Boolean = true,
     val organizationId: String,
-    val roles: List<String> = listOf("USER"),
+    val roleAssignments: List<RoleAssignment> = emptyList(),
     @CreatedDate
     var createdAt: LocalDateTime? = null,
     @LastModifiedDate
     var updatedAt: LocalDateTime? = null,
 )
+
+fun User.effectiveRoleNames(): List<String> = roleAssignments.map { it.role }
+
+fun User.orgRoleNames(orgId: String): List<String> = roleAssignments.filter { it.organizationId == orgId }.map { it.role }
+
+fun User.systemRoleNames(): List<String> = roleAssignments.filter { it.organizationId == null }.map { it.role }

--- a/src/main/kotlin/com/froilan/synectix/repository/RoleRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/RoleRepository.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleLevel
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface RoleRepository : MongoRepository<Role, String> {
+    fun findByName(name: String): Optional<Role>
+
+    fun findByLevel(level: RoleLevel): List<Role>
+
+    fun existsByName(name: String): Boolean
+}

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.security
+
+object Permissions {
+    const val SESSION_READ = "session:read"
+    const val SESSION_DELETE = "session:delete"
+
+    const val USER_READ = "user:read"
+    const val USER_WRITE = "user:write"
+    const val USER_DELETE = "user:delete"
+
+    const val ORGANIZATION_READ = "organization:read"
+    const val ORGANIZATION_WRITE = "organization:write"
+    const val ORGANIZATION_DELETE = "organization:delete"
+
+    const val ENVIRONMENT_READ = "environment:read"
+}

--- a/src/main/kotlin/com/froilan/synectix/security/RolePermissionCache.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/RolePermissionCache.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.security
+
+import com.froilan.synectix.repository.RoleRepository
+import com.github.benmanes.caffeine.cache.Caffeine
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RolePermissionCache(
+    private val roleRepository: RoleRepository,
+) {
+    private val cache =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(Duration.ofHours(1))
+            .build<String, Set<String>> { name ->
+                roleRepository.findByName(name).map { it.permissions.toSet() }.orElse(emptySet())
+            }
+
+    @PostConstruct
+    fun loadAll() {
+        roleRepository.findAll().forEach { role ->
+            cache.put(role.name, role.permissions.toSet())
+        }
+    }
+
+    fun getPermissions(roleName: String): Set<String> = cache.get(roleName)
+
+    fun refresh() {
+        cache.invalidateAll()
+        loadAll()
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/security/SynectixPermissionEvaluator.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/SynectixPermissionEvaluator.kt
@@ -1,0 +1,28 @@
+package com.froilan.synectix.security
+
+import org.springframework.security.access.PermissionEvaluator
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import java.io.Serializable
+
+@Component
+class SynectixPermissionEvaluator : PermissionEvaluator {
+    override fun hasPermission(
+        authentication: Authentication,
+        targetDomainObject: Any,
+        permission: Any,
+    ): Boolean {
+        if (authentication.authorities.any { it.authority == "ROLE_SUPER_ADMIN" }) {
+            return true
+        }
+        val permStr = permission as? String ?: return false
+        return authentication.authorities.any { it.authority == permStr }
+    }
+
+    override fun hasPermission(
+        authentication: Authentication,
+        targetId: Serializable,
+        targetType: String,
+        permission: Any,
+    ): Boolean = hasPermission(authentication, targetId as Any, permission)
+}

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -6,8 +6,10 @@ import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.model.Organizations
 import com.froilan.synectix.model.PasswordResetToken
 import com.froilan.synectix.model.RefreshToken
+import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
+import com.froilan.synectix.model.effectiveRoleNames
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
@@ -71,6 +73,10 @@ class AuthService(
                     lastName = request.lastName,
                     email = request.email.lowercase(Locale.ROOT),
                     organizationId = savedOrganization.uuid,
+                    roleAssignments =
+                        listOf(
+                            RoleAssignment(role = "OWNER", organizationId = savedOrganization.uuid),
+                        ),
                 )
             return userRepository.save(user)
         } catch (e: DuplicateKeyException) {
@@ -138,7 +144,7 @@ class AuthService(
             accessToken = accessTokenStr,
             refreshToken = refreshTokenStr,
             username = user.username,
-            roles = user.roles,
+            roles = user.effectiveRoleNames(),
             expiresAt = expiryAt.toString(),
             refreshTokenExpiresAt = refreshExpiryAt.toString(),
         )
@@ -206,7 +212,7 @@ class AuthService(
             accessToken = accessTokenStr,
             refreshToken = refreshTokenStr,
             username = user.username,
-            roles = user.roles,
+            roles = user.effectiveRoleNames(),
             expiresAt = expiryAt.toString(),
             refreshTokenExpiresAt = refreshExpiryAt.toString(),
         )

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -1,0 +1,96 @@
+package com.froilan.synectix.config
+
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.repository.RoleRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.springframework.boot.ApplicationArguments
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RoleSeederTest {
+    private lateinit var roleRepository: RoleRepository
+    private lateinit var roleSeeder: RoleSeeder
+
+    @BeforeEach
+    fun setup() {
+        roleRepository = mock(RoleRepository::class.java)
+        roleSeeder = RoleSeeder(roleRepository)
+    }
+
+    @Test
+    fun `should seed all default roles when none exist`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val seededNames = captor.allValues.map { it.name }.toSet()
+        assertEquals(setOf("SUPER_ADMIN", "OWNER", "ADMIN", "MEMBER", "VIEWER"), seededNames)
+    }
+
+    @Test
+    fun `should not duplicate roles when they already exist`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(true)
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        verify(roleRepository, never()).save(any<Role>())
+    }
+
+    @Test
+    fun `should seed SUPER_ADMIN as system-level role`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val superAdmin = captor.allValues.first { it.name == "SUPER_ADMIN" }
+        assertEquals(RoleLevel.SYSTEM, superAdmin.level)
+    }
+
+    @Test
+    fun `should seed org-level roles with correct level`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val orgRoles = captor.allValues.filter { it.name in setOf("OWNER", "ADMIN", "MEMBER", "VIEWER") }
+        assertTrue(orgRoles.all { it.level == RoleLevel.ORGANIZATION })
+    }
+
+    @Test
+    fun `should mark OWNER as default role`() {
+        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val owner = captor.allValues.first { it.name == "OWNER" }
+        assertTrue(owner.isDefault)
+
+        val nonDefaults = captor.allValues.filter { it.name != "OWNER" }
+        assertTrue(nonDefaults.none { it.isDefault })
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -3,6 +3,8 @@ package com.froilan.synectix.config
 import com.froilan.synectix.model.Role
 import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.repository.RoleRepository
+import com.froilan.synectix.security.Permissions
+import com.froilan.synectix.security.RolePermissionCache
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -13,22 +15,25 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.springframework.boot.ApplicationArguments
+import java.util.Optional
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class RoleSeederTest {
     private lateinit var roleRepository: RoleRepository
+    private lateinit var rolePermissionCache: RolePermissionCache
     private lateinit var roleSeeder: RoleSeeder
 
     @BeforeEach
     fun setup() {
         roleRepository = mock(RoleRepository::class.java)
-        roleSeeder = RoleSeeder(roleRepository)
+        rolePermissionCache = mock(RolePermissionCache::class.java)
+        roleSeeder = RoleSeeder(roleRepository, rolePermissionCache)
     }
 
     @Test
     fun `should seed all default roles when none exist`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
@@ -41,17 +46,99 @@ class RoleSeederTest {
     }
 
     @Test
-    fun `should not duplicate roles when they already exist`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(true)
+    fun `should skip existing role when permissions are already correct`() {
+        val existingOwner =
+            Role(
+                name = "OWNER",
+                description = "Organization owner with full org-level access",
+                level = RoleLevel.ORGANIZATION,
+                isDefault = true,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.USER_WRITE,
+                        Permissions.USER_DELETE,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ORGANIZATION_WRITE,
+                        Permissions.ORGANIZATION_DELETE,
+                        Permissions.ENVIRONMENT_READ,
+                    ),
+            )
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(existingOwner))
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
 
-        verify(roleRepository, never()).save(any<Role>())
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(4)).save(captor.capture())
+        assertTrue(captor.allValues.none { it.name == "OWNER" })
     }
 
     @Test
-    fun `should seed SUPER_ADMIN as system-level role`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(false)
+    fun `should update permissions when role exists with outdated permissions`() {
+        val outdatedRole =
+            Role(
+                name = "MEMBER",
+                description = "Standard organization member",
+                level = RoleLevel.ORGANIZATION,
+                permissions = emptyList(),
+            )
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(outdatedRole))
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val updatedMember = captor.allValues.first { it.name == "MEMBER" }
+        assertTrue(updatedMember.permissions.contains(Permissions.SESSION_READ))
+        assertTrue(updatedMember.permissions.contains(Permissions.ORGANIZATION_READ))
+    }
+
+    @Test
+    fun `should update all canonical fields when role drifted in DB`() {
+        val driftedRole =
+            Role(
+                name = "OWNER",
+                description = "Modified description",
+                level = RoleLevel.SYSTEM,
+                isDefault = false,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.USER_WRITE,
+                        Permissions.USER_DELETE,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ORGANIZATION_WRITE,
+                        Permissions.ORGANIZATION_DELETE,
+                        Permissions.ENVIRONMENT_READ,
+                    ),
+            )
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(driftedRole))
+        `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        val captor = argumentCaptor<Role>()
+        verify(roleRepository, times(5)).save(captor.capture())
+
+        val updatedOwner = captor.allValues.first { it.name == "OWNER" }
+        assertEquals("Organization owner with full org-level access", updatedOwner.description)
+        assertEquals(RoleLevel.ORGANIZATION, updatedOwner.level)
+        assertTrue(updatedOwner.isDefault)
+    }
+
+    @Test
+    fun `should seed SUPER_ADMIN as system-level role with no permissions`() {
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
@@ -61,11 +148,12 @@ class RoleSeederTest {
 
         val superAdmin = captor.allValues.first { it.name == "SUPER_ADMIN" }
         assertEquals(RoleLevel.SYSTEM, superAdmin.level)
+        assertTrue(superAdmin.permissions.isEmpty())
     }
 
     @Test
     fun `should seed org-level roles with correct level`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(false)
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
@@ -78,19 +166,89 @@ class RoleSeederTest {
     }
 
     @Test
-    fun `should mark OWNER as default role`() {
-        `when`(roleRepository.existsByName(any())).thenReturn(false)
+    fun `should refresh cache after seeding`() {
+        `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
         `when`(roleRepository.save(any<Role>())).thenAnswer { it.arguments[0] }
 
         roleSeeder.run(mock(ApplicationArguments::class.java))
 
-        val captor = argumentCaptor<Role>()
-        verify(roleRepository, times(5)).save(captor.capture())
+        verify(rolePermissionCache).refresh()
+    }
 
-        val owner = captor.allValues.first { it.name == "OWNER" }
-        assertTrue(owner.isDefault)
+    @Test
+    fun `should not refresh cache when nothing changed`() {
+        val superAdmin =
+            Role(
+                name = "SUPER_ADMIN",
+                description = "System-wide administrator with full access",
+                level = RoleLevel.SYSTEM,
+                permissions = emptyList(),
+            )
+        val owner =
+            Role(
+                name = "OWNER",
+                description = "Organization owner with full org-level access",
+                level = RoleLevel.ORGANIZATION,
+                isDefault = true,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.USER_WRITE,
+                        Permissions.USER_DELETE,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ORGANIZATION_WRITE,
+                        Permissions.ORGANIZATION_DELETE,
+                        Permissions.ENVIRONMENT_READ,
+                    ),
+            )
+        val admin =
+            Role(
+                name = "ADMIN",
+                description = "Organization administrator",
+                level = RoleLevel.ORGANIZATION,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.USER_WRITE,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ORGANIZATION_WRITE,
+                        Permissions.ENVIRONMENT_READ,
+                    ),
+            )
+        val member =
+            Role(
+                name = "MEMBER",
+                description = "Standard organization member",
+                level = RoleLevel.ORGANIZATION,
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.SESSION_DELETE,
+                        Permissions.USER_READ,
+                        Permissions.ORGANIZATION_READ,
+                    ),
+            )
+        val viewer =
+            Role(
+                name = "VIEWER",
+                description = "Read-only organization access",
+                level = RoleLevel.ORGANIZATION,
+                permissions = listOf(Permissions.SESSION_READ, Permissions.ORGANIZATION_READ),
+            )
 
-        val nonDefaults = captor.allValues.filter { it.name != "OWNER" }
-        assertTrue(nonDefaults.none { it.isDefault })
+        `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(superAdmin))
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(owner))
+        `when`(roleRepository.findByName("ADMIN")).thenReturn(Optional.of(admin))
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(member))
+        `when`(roleRepository.findByName("VIEWER")).thenReturn(Optional.of(viewer))
+
+        roleSeeder.run(mock(ApplicationArguments::class.java))
+
+        verify(roleRepository, never()).save(any<Role>())
+        verify(rolePermissionCache, never()).refresh()
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -63,7 +63,6 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
-                        Permissions.ENVIRONMENT_READ,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -118,7 +117,6 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
-                        Permissions.ENVIRONMENT_READ,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -200,7 +198,6 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
-                        Permissions.ENVIRONMENT_READ,
                     ),
             )
         val admin =
@@ -216,7 +213,6 @@ class RoleSeederTest {
                         Permissions.USER_WRITE,
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
-                        Permissions.ENVIRONMENT_READ,
                     ),
             )
         val member =

--- a/src/test/kotlin/com/froilan/synectix/config/TestSecurityConfig.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/TestSecurityConfig.kt
@@ -1,8 +1,12 @@
 package com.froilan.synectix.config
 
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -10,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain
 
 @TestConfiguration
 @EnableWebSecurity
+@EnableMethodSecurity
 class TestSecurityConfig {
     @Bean
     @Primary
@@ -20,5 +25,12 @@ class TestSecurityConfig {
             .authorizeHttpRequests { it.anyRequest().permitAll() }
 
         return http.build()
+    }
+
+    @Bean
+    fun methodSecurityExpressionHandler(permissionEvaluator: SynectixPermissionEvaluator): MethodSecurityExpressionHandler {
+        val handler = DefaultMethodSecurityExpressionHandler()
+        handler.setPermissionEvaluator(permissionEvaluator)
+        return handler
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -107,10 +107,7 @@ class AuthControllerTest {
                 post("/auth/signup")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestJson),
-            ).andDo { result ->
-                println("Response status: ${result.response.status}")
-                println("Response body: ${result.response.contentAsString}")
-            }.andExpect(status().isCreated)
+            ).andExpect(status().isCreated)
             .andExpect(jsonPath("$.message").value("User registered successfully"))
             .andExpect(jsonPath("$.userId").value(savedUser.uuid))
     }

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -273,7 +273,7 @@ class AuthControllerTest {
                 accessToken = "generated-token-123",
                 refreshToken = "generated-refresh-token-123",
                 username = "testuser",
-                roles = listOf("USER"),
+                roles = listOf("OWNER"),
                 expiresAt = LocalDateTime.now().plusHours(24).toString(),
                 refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
             )
@@ -288,7 +288,7 @@ class AuthControllerTest {
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.accessToken").value(authResponse.accessToken))
             .andExpect(jsonPath("$.username").value(authResponse.username))
-            .andExpect(jsonPath("$.roles[0]").value("USER"))
+            .andExpect(jsonPath("$.roles[0]").value("OWNER"))
             .andExpect(jsonPath("$.expiresAt").exists())
     }
 
@@ -386,7 +386,7 @@ class AuthControllerTest {
                 accessToken = "new-access-token-456",
                 refreshToken = "new-refresh-token-789",
                 username = "testuser",
-                roles = listOf("USER"),
+                roles = listOf("OWNER"),
                 expiresAt = LocalDateTime.now().plusHours(24).toString(),
                 refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
             )

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -11,6 +11,8 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.Test
@@ -33,7 +35,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
 
 @WebMvcTest(controllers = [AuthController::class])
-@Import(LoggingAspect::class, TestSecurityConfig::class)
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
 @ActiveProfiles("test")
 class AuthControllerTest {
     @Autowired
@@ -62,6 +64,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
 
     @Test
     fun `POST signup should return 201 when registration is successful`() {

--- a/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
@@ -14,6 +14,7 @@ import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
+import org.springframework.dao.DataAccessResourceFailureException
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -88,7 +89,7 @@ class HealthControllerTest {
 
     @Test
     fun `should return service unavailable when database is down`() {
-        `when`(mongoTemplate.db).thenThrow(RuntimeException("Database connection failed"))
+        `when`(mongoTemplate.db).thenThrow(DataAccessResourceFailureException("Database connection failed"))
 
         mockMvc
             .perform(get("/health"))

--- a/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
@@ -4,6 +4,8 @@ import com.froilan.synectix.aspect.LoggingAspect
 import com.froilan.synectix.config.TestSecurityConfig
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.mongodb.client.MongoDatabase
 import org.bson.Document
 import org.junit.jupiter.api.Test
@@ -21,7 +23,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(controllers = [HealthController::class])
-@Import(LoggingAspect::class, TestSecurityConfig::class)
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
 @ActiveProfiles("test")
 class HealthControllerTest {
     @Autowired
@@ -38,6 +40,9 @@ class HealthControllerTest {
 
     @MockitoBean
     private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
 
     @Test
     fun `should return health status UP when database is healthy`() {

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.aspect.LoggingAspect
 import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
 import com.froilan.synectix.repository.OrganizationRepository
@@ -71,13 +72,14 @@ class SessionControllerTest {
             lastName = "User",
             passwordHash = "encoded",
             organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
         )
 
     private val currentToken = "current-bearer-token"
 
     @BeforeEach
     fun setup() {
-        val authorities = testUser.roles.map { SimpleGrantedAuthority("ROLE_$it") }
+        val authorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
         val authentication = UsernamePasswordAuthenticationToken(testUser, null, authorities)
         SecurityContextHolder.getContext().authentication = authentication
     }

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -10,6 +10,8 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.BeforeEach
@@ -33,7 +35,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
 
 @WebMvcTest(controllers = [SessionController::class])
-@Import(LoggingAspect::class, TestSecurityConfig::class)
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
 @ActiveProfiles("test")
 class SessionControllerTest {
     @Autowired
@@ -63,6 +65,9 @@ class SessionControllerTest {
     @MockitoBean
     private lateinit var tokenHasher: TokenHasher
 
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
     private val testUser =
         User(
             uuid = "user-123",
@@ -79,8 +84,13 @@ class SessionControllerTest {
 
     @BeforeEach
     fun setup() {
-        val authorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
-        val authentication = UsernamePasswordAuthenticationToken(testUser, null, authorities)
+        setupAuthWithPermissions("session:read", "session:delete")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
         SecurityContextHolder.getContext().authentication = authentication
     }
 
@@ -176,5 +186,27 @@ class SessionControllerTest {
                     .header("Authorization", "Bearer $currentToken"),
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("All other sessions revoked"))
+    }
+
+    @Test
+    fun `GET sessions should return 403 without session read permission`() {
+        setupAuthWithPermissions()
+
+        mockMvc
+            .perform(
+                get("/auth/sessions")
+                    .header("Authorization", "Bearer $currentToken"),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `DELETE session should return 403 without session delete permission`() {
+        setupAuthWithPermissions("session:read")
+
+        mockMvc
+            .perform(
+                delete("/auth/sessions/s2")
+                    .header("Authorization", "Bearer $currentToken"),
+            ).andExpect(status().isForbidden)
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
@@ -1,0 +1,69 @@
+package com.froilan.synectix.security
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PermissionEvaluatorTest {
+    private lateinit var evaluator: SynectixPermissionEvaluator
+
+    @BeforeEach
+    fun setup() {
+        evaluator = SynectixPermissionEvaluator()
+    }
+
+    @Test
+    fun `SUPER_ADMIN should bypass any permission check`() {
+        val auth = authWith("ROLE_SUPER_ADMIN")
+
+        assertTrue(evaluator.hasPermission(auth, Unit, "session:read"))
+        assertTrue(evaluator.hasPermission(auth, Unit, "anything:whatever"))
+    }
+
+    @Test
+    fun `user with matching authority should pass`() {
+        val auth = authWith("ROLE_MEMBER", "session:read", "organization:read")
+
+        assertTrue(evaluator.hasPermission(auth, Unit, "session:read"))
+        assertTrue(evaluator.hasPermission(auth, Unit, "organization:read"))
+    }
+
+    @Test
+    fun `user without matching authority should fail`() {
+        val auth = authWith("ROLE_MEMBER", "session:read")
+
+        assertFalse(evaluator.hasPermission(auth, Unit, "session:delete"))
+        assertFalse(evaluator.hasPermission(auth, Unit, "user:write"))
+    }
+
+    @Test
+    fun `user with no authorities should fail`() {
+        val auth = authWith()
+
+        assertFalse(evaluator.hasPermission(auth, Unit, "session:read"))
+    }
+
+    @Test
+    fun `non-string permission should return false`() {
+        val auth = authWith("ROLE_ADMIN", "session:read")
+
+        assertFalse(evaluator.hasPermission(auth, Unit, 123))
+    }
+
+    @Test
+    fun `targetId overload should delegate to primary`() {
+        val auth = authWith("ROLE_SUPER_ADMIN")
+
+        assertTrue(evaluator.hasPermission(auth, "id-1", "Session", "session:read"))
+    }
+
+    private fun authWith(vararg authorities: String) =
+        UsernamePasswordAuthenticationToken(
+            "user",
+            null,
+            authorities.map { SimpleGrantedAuthority(it) },
+        )
+}

--- a/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
@@ -1,0 +1,74 @@
+package com.froilan.synectix.security
+
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.repository.RoleRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RolePermissionCacheTest {
+    private lateinit var roleRepository: RoleRepository
+    private lateinit var cache: RolePermissionCache
+
+    @BeforeEach
+    fun setup() {
+        roleRepository = mock(RoleRepository::class.java)
+
+        val roles =
+            listOf(
+                Role(
+                    name = "OWNER",
+                    description = "Owner",
+                    level = RoleLevel.ORGANIZATION,
+                    permissions = listOf("session:read", "session:delete", "user:read"),
+                ),
+                Role(
+                    name = "VIEWER",
+                    description = "Viewer",
+                    level = RoleLevel.ORGANIZATION,
+                    permissions = listOf("session:read"),
+                ),
+            )
+
+        `when`(roleRepository.findAll()).thenReturn(roles)
+        `when`(roleRepository.findByName("OWNER")).thenReturn(Optional.of(roles[0]))
+        `when`(roleRepository.findByName("VIEWER")).thenReturn(Optional.of(roles[1]))
+        `when`(roleRepository.findByName("UNKNOWN")).thenReturn(Optional.empty())
+
+        cache = RolePermissionCache(roleRepository)
+        cache.loadAll()
+    }
+
+    @Test
+    fun `should return permissions for known role`() {
+        val permissions = cache.getPermissions("OWNER")
+        assertEquals(setOf("session:read", "session:delete", "user:read"), permissions)
+    }
+
+    @Test
+    fun `should return empty set for unknown role`() {
+        val permissions = cache.getPermissions("UNKNOWN")
+        assertTrue(permissions.isEmpty())
+    }
+
+    @Test
+    fun `refresh should reload from repository`() {
+        val updatedRole =
+            Role(
+                name = "VIEWER",
+                description = "Viewer",
+                level = RoleLevel.ORGANIZATION,
+                permissions = listOf("session:read", "organization:read"),
+            )
+        `when`(roleRepository.findAll()).thenReturn(listOf(updatedRole))
+
+        cache.refresh()
+
+        assertEquals(setOf("session:read", "organization:read"), cache.getPermissions("VIEWER"))
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -5,8 +5,10 @@ import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.model.Organizations
 import com.froilan.synectix.model.PasswordResetToken
 import com.froilan.synectix.model.RefreshToken
+import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
+import com.froilan.synectix.model.effectiveRoleNames
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
@@ -117,6 +119,7 @@ class AuthServiceTest {
         verify(userRepository, times(1)).save(userCaptor.capture())
         assertEquals(encodedPassword, userCaptor.firstValue.passwordHash)
         assertEquals(savedOrg.uuid, userCaptor.firstValue.organizationId)
+        assertEquals(listOf(RoleAssignment("OWNER", savedOrg.uuid)), userCaptor.firstValue.roleAssignments)
     }
 
     @Test
@@ -206,7 +209,11 @@ class AuthServiceTest {
                 lastName = "User",
                 passwordHash = "encodedPassword",
                 organizationId = "org-123",
-                roles = listOf("USER", "ADMIN"),
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("MEMBER", "org-123"),
+                        RoleAssignment("ADMIN", "org-123"),
+                    ),
             )
         val savedToken = createMockSessionToken()
 
@@ -219,7 +226,7 @@ class AuthServiceTest {
 
         assertNotNull(result)
         assertEquals(user.username, result.username)
-        assertEquals(user.roles, result.roles)
+        assertEquals(user.effectiveRoleNames(), result.roles)
         assertNotNull(result.accessToken)
         assertNotNull(result.expiresAt)
 
@@ -685,6 +692,7 @@ class AuthServiceTest {
             lastName = "User",
             passwordHash = "encodedPassword",
             organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("MEMBER", "org-123")),
         )
 
     private fun createMockSessionToken() =

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -32,6 +32,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -321,7 +322,7 @@ class AuthServiceTest {
         val result1 = authService.login(request)
         val result2 = authService.login(request)
 
-        assertTrue(result1.accessToken != result2.accessToken)
+        assertNotEquals(result1.accessToken, result2.accessToken)
         assertTrue(result1.accessToken.matches(Regex("^[A-Za-z0-9_-]+$")))
     }
 
@@ -364,8 +365,8 @@ class AuthServiceTest {
 
         assertNotNull(result.accessToken)
         assertNotNull(result.refreshToken)
-        assertTrue(result.accessToken != oldSessionToken.token)
-        assertTrue(result.refreshToken != oldRefreshTokenStr)
+        assertNotEquals(oldSessionToken.token, result.accessToken)
+        assertNotEquals(oldRefreshTokenStr, result.refreshToken)
 
         verify(sessionTokenRepository).deleteById(oldSessionToken.id)
     }
@@ -571,8 +572,8 @@ class AuthServiceTest {
 
         val result = authService.forgotPassword(user.email)
 
-        assertNotNull(result)
-        assertTrue(result!!.isNotEmpty())
+        val token = assertNotNull(result)
+        assertTrue(token.isNotEmpty())
         verify(passwordResetTokenRepository).deleteByUserId(user.uuid)
         verify(passwordResetTokenRepository).save(any<PasswordResetToken>())
     }


### PR DESCRIPTION
## Summary
Promotes staging to production with the following changes:

- **#84** — Define role schema with system-level and org-level roles
- **#85** — Implement RBAC permission model (resource + action based)
- **#87** — Fix Kotlin best practice violations across codebase

## Changes
- Role document model with `RoleLevel` enum (SYSTEM, ORGANIZATION)
- `RoleAssignment` embedded in User, replacing flat string roles
- Idempotent `RoleSeeder` with canonical field sync on startup
- Permission constants (`resource:action` format) with Caffeine-backed cache
- `SynectixPermissionEvaluator` with SUPER_ADMIN bypass
- `@EnableMethodSecurity` + `@PreAuthorize` on SessionController and EnvironmentController
- 403 JSON response for insufficient permissions
- Code quality: removed `@Autowired`, constructor injection, narrowed exceptions, replaced `println` with SLF4J

## Test plan
- [x] All tests pass (except pre-existing contextLoads requiring MongoDB)
- [x] ktlint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-based RBAC with role assignments, default roles, and automatic seeding.
  * Authorities now include both roles and aggregated permissions.
  * In-memory role→permission cache with eager load and refresh.

* **Security**
  * Method- and endpoint-level authorization enabled with a custom permission evaluator.
  * Access rules added to session/environment endpoints and auth responses now reflect effective roles.

* **Chores**
  * Startup and health routines use structured logging and finer-grained error handling.

* **Tests**
  * Added/updated tests for seeding, permissions, cache, evaluator, auth flows, and health.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->