### PR TITLE
Add user invitation flow with token-based onboarding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,10 @@ tasks.named<Jar>("jar") {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+    systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+    systemProperty("junit.jupiter.execution.parallel.mode.default", "same_thread")
+    systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
 }
 
 ktlint {

--- a/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
@@ -30,6 +30,8 @@ class MongoConfig : AbstractMongoClientConfiguration() {
     @Value("\${spring.data.mongodb.uri}")
     private lateinit var mongoUri: String
 
+    override fun autoIndexCreation(): Boolean = true
+
     override fun getDatabaseName(): String {
         val connectionString = ConnectionString(mongoUri)
         return connectionString.database ?: "synectix"

--- a/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
@@ -4,14 +4,23 @@ import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
 import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.IndexOptions
+import com.mongodb.client.model.Indexes
+import org.bson.Document
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.data.mongodb.MongoDatabaseFactory
 import org.springframework.data.mongodb.MongoTransactionManager
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration
 import org.springframework.data.mongodb.config.EnableMongoAuditing
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.stereotype.Component
 
 @Configuration
 @EnableMongoAuditing
@@ -50,5 +59,28 @@ class MongoConfig : AbstractMongoClientConfiguration() {
         )
 
         return MongoClients.create(settings)
+    }
+}
+
+@Component
+@Order(0)
+class MongoIndexInitializer(
+    private val mongoTemplate: MongoTemplate,
+) : ApplicationRunner {
+    private val log = LoggerFactory.getLogger(MongoIndexInitializer::class.java)
+
+    override fun run(args: ApplicationArguments) {
+        val collection = mongoTemplate.getCollection("invitations")
+        collection.createIndex(
+            Indexes.compoundIndex(
+                Document("email", 1),
+                Document("organizationId", 1),
+            ),
+            IndexOptions()
+                .unique(true)
+                .partialFilterExpression(Filters.eq("status", "PENDING"))
+                .name("unique_pending_invitation_per_email_org"),
+        )
+        log.info("Ensured partial unique index on invitations(email, organizationId) where status=PENDING")
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -42,6 +42,8 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_READ,
                             Permissions.ORGANIZATION_WRITE,
                             Permissions.ORGANIZATION_DELETE,
+                            Permissions.INVITATION_READ,
+                            Permissions.INVITATION_WRITE,
                         ),
                 ),
                 Role(
@@ -56,6 +58,8 @@ class RoleSeeder(
                             Permissions.USER_WRITE,
                             Permissions.ORGANIZATION_READ,
                             Permissions.ORGANIZATION_WRITE,
+                            Permissions.INVITATION_READ,
+                            Permissions.INVITATION_WRITE,
                         ),
                 ),
                 Role(
@@ -68,6 +72,7 @@ class RoleSeeder(
                             Permissions.SESSION_DELETE,
                             Permissions.USER_READ,
                             Permissions.ORGANIZATION_READ,
+                            Permissions.INVITATION_READ,
                         ),
                 ),
                 Role(

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -45,6 +46,9 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 it.requestMatchers("/auth/change-password").authenticated()
                 it.requestMatchers("/auth/sessions", "/auth/sessions/**").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/auth/invitations").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/auth/invitations").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/auth/invitations/*").authenticated()
                 it.requestMatchers("/auth/**").permitAll()
                 it.requestMatchers("/health/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -4,10 +4,10 @@ import com.froilan.synectix.security.SynectixPermissionEvaluator
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
-import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy

--- a/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
@@ -1,0 +1,101 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.AcceptInvitationRequest
+import com.froilan.synectix.dto.CreateInvitationRequest
+import com.froilan.synectix.dto.InvitationResponse
+import com.froilan.synectix.model.User
+import com.froilan.synectix.service.InvitationService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth/invitations")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class InvitationController(
+    private val invitationService: InvitationService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('invitation:write')")
+    fun createInvitation(
+        @Valid @RequestBody request: CreateInvitationRequest,
+    ): ResponseEntity<Any> {
+        val user = extractUser() ?: return unauthorized()
+
+        return try {
+            val token = invitationService.invite(request, user)
+            ResponseEntity.status(HttpStatus.CREATED).body(
+                mapOf("message" to "Invitation created", "token" to token),
+            )
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('invitation:read')")
+    fun listInvitations(): ResponseEntity<Any> {
+        val user = extractUser() ?: return unauthorized()
+
+        val invitations =
+            invitationService.listInvitations(user.organizationId).map { invitation ->
+                InvitationResponse(
+                    id = invitation.id,
+                    email = invitation.email,
+                    role = invitation.role,
+                    status = invitation.status.name,
+                    invitedBy = invitation.invitedBy,
+                    expiresAt = invitation.expiryAt.toString(),
+                    createdAt = invitation.createdAt?.toString(),
+                )
+            }
+        return ResponseEntity.ok(invitations)
+    }
+
+    @PostMapping("/accept")
+    fun acceptInvitation(
+        @Valid @RequestBody request: AcceptInvitationRequest,
+    ): ResponseEntity<Any> =
+        try {
+            invitationService.acceptInvitation(request)
+            ResponseEntity.ok(mapOf("message" to "Invitation accepted successfully"))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+        }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('invitation:write')")
+    fun revokeInvitation(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val user = extractUser() ?: return unauthorized()
+
+        return try {
+            invitationService.revokeInvitation(id, user)
+            ResponseEntity.ok(mapOf("message" to "Invitation revoked"))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+        }
+    }
+
+    private fun extractUser(): User? {
+        val authentication = SecurityContextHolder.getContext().authentication
+        return authentication?.principal as? User
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
@@ -39,7 +39,7 @@ class InvitationController(
                 mapOf("message" to "Invitation created", "token" to token),
             )
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation request")))
         }
     }
 
@@ -71,7 +71,7 @@ class InvitationController(
             invitationService.acceptInvitation(request)
             ResponseEntity.ok(mapOf("message" to "Invitation accepted successfully"))
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation token")))
         }
 
     @DeleteMapping("/{id}")
@@ -85,7 +85,7 @@ class InvitationController(
             invitationService.revokeInvitation(id, user)
             ResponseEntity.ok(mapOf("message" to "Invitation revoked"))
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to e.message))
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation operation")))
         }
     }
 

--- a/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
@@ -5,6 +5,7 @@ import com.froilan.synectix.annotation.Loggable
 import com.froilan.synectix.dto.AcceptInvitationRequest
 import com.froilan.synectix.dto.CreateInvitationRequest
 import com.froilan.synectix.dto.InvitationResponse
+import com.froilan.synectix.dto.ValidateInvitationRequest
 import com.froilan.synectix.model.User
 import com.froilan.synectix.service.InvitationService
 import jakarta.validation.Valid
@@ -62,6 +63,17 @@ class InvitationController(
             }
         return ResponseEntity.ok(invitations)
     }
+
+    @PostMapping("/validate")
+    fun validateInvitation(
+        @Valid @RequestBody request: ValidateInvitationRequest,
+    ): ResponseEntity<Any> =
+        try {
+            val result = invitationService.validateInvitation(request.token)
+            ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation token")))
+        }
 
     @PostMapping("/accept")
     fun acceptInvitation(

--- a/src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt
@@ -15,16 +15,12 @@ data class CreateInvitationRequest(
 data class AcceptInvitationRequest(
     @field:NotBlank(message = "Invitation token is required")
     val token: String,
-    @field:NotBlank(message = "Username is required")
     @field:Size(min = 3, max = 50, message = "Username must be between 3 and 50 characters")
-    val username: String,
-    @field:NotBlank(message = "Password is required")
+    val username: String? = null,
     @field:Size(min = 8, message = "Password must be at least 8 characters")
-    val password: String,
-    @field:NotBlank(message = "First name is required")
-    val firstName: String,
-    @field:NotBlank(message = "Last name is required")
-    val lastName: String,
+    val password: String? = null,
+    val firstName: String? = null,
+    val lastName: String? = null,
 )
 
 data class InvitationResponse(

--- a/src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt
@@ -23,6 +23,18 @@ data class AcceptInvitationRequest(
     val lastName: String? = null,
 )
 
+data class ValidateInvitationRequest(
+    @field:NotBlank(message = "Invitation token is required")
+    val token: String,
+)
+
+data class ValidateInvitationResponse(
+    val email: String,
+    val role: String,
+    val organizationId: String,
+    val existingUser: Boolean,
+)
+
 data class InvitationResponse(
     val id: String,
     val email: String,

--- a/src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt
@@ -1,0 +1,38 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateInvitationRequest(
+    @field:NotBlank(message = "Email is required")
+    @field:Email(message = "Email must be valid")
+    val email: String,
+    @field:NotBlank(message = "Role is required")
+    val role: String,
+)
+
+data class AcceptInvitationRequest(
+    @field:NotBlank(message = "Invitation token is required")
+    val token: String,
+    @field:NotBlank(message = "Username is required")
+    @field:Size(min = 3, max = 50, message = "Username must be between 3 and 50 characters")
+    val username: String,
+    @field:NotBlank(message = "Password is required")
+    @field:Size(min = 8, message = "Password must be at least 8 characters")
+    val password: String,
+    @field:NotBlank(message = "First name is required")
+    val firstName: String,
+    @field:NotBlank(message = "Last name is required")
+    val lastName: String,
+)
+
+data class InvitationResponse(
+    val id: String,
+    val email: String,
+    val role: String,
+    val status: String,
+    val invitedBy: String,
+    val expiresAt: String,
+    val createdAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Invitation.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Invitation.kt
@@ -1,0 +1,33 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class InvitationStatus {
+    PENDING,
+    ACCEPTED,
+    EXPIRED,
+    REVOKED,
+}
+
+@Document(collection = "invitations")
+data class Invitation(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    @Indexed
+    val email: String,
+    val organizationId: String,
+    val role: String,
+    @Indexed(unique = true)
+    val tokenHash: String,
+    val invitedBy: String,
+    val status: InvitationStatus = InvitationStatus.PENDING,
+    @Indexed(expireAfterSeconds = 0)
+    val expiryAt: LocalDateTime,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
@@ -1,0 +1,23 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Invitation
+import com.froilan.synectix.model.InvitationStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface InvitationRepository : MongoRepository<Invitation, String> {
+    fun findByTokenHash(tokenHash: String): Optional<Invitation>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: InvitationStatus,
+    ): List<Invitation>
+
+    fun findByEmailAndOrganizationIdAndStatus(
+        email: String,
+        organizationId: String,
+        status: InvitationStatus,
+    ): Optional<Invitation>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
@@ -11,9 +11,10 @@ import java.util.Optional
 interface InvitationRepository : MongoRepository<Invitation, String> {
     fun findByTokenHash(tokenHash: String): Optional<Invitation>
 
-    fun findByOrganizationIdAndStatus(
+    fun findByOrganizationIdAndStatusAndExpiryAtAfter(
         organizationId: String,
         status: InvitationStatus,
+        expiryAt: LocalDateTime,
     ): List<Invitation>
 
     fun findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(

--- a/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
@@ -23,4 +23,10 @@ interface InvitationRepository : MongoRepository<Invitation, String> {
         status: InvitationStatus,
         expiryAt: LocalDateTime,
     ): Optional<Invitation>
+
+    fun findByEmailAndOrganizationIdAndStatus(
+        email: String,
+        organizationId: String,
+        status: InvitationStatus,
+    ): Optional<Invitation>
 }

--- a/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
@@ -4,6 +4,7 @@ import com.froilan.synectix.model.Invitation
 import com.froilan.synectix.model.InvitationStatus
 import org.springframework.data.mongodb.repository.MongoRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.Optional
 
 @Repository
@@ -15,9 +16,10 @@ interface InvitationRepository : MongoRepository<Invitation, String> {
         status: InvitationStatus,
     ): List<Invitation>
 
-    fun findByEmailAndOrganizationIdAndStatus(
+    fun findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(
         email: String,
         organizationId: String,
         status: InvitationStatus,
+        expiryAt: LocalDateTime,
     ): Optional<Invitation>
 }

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -13,4 +13,7 @@ object Permissions {
     const val ORGANIZATION_DELETE = "organization:delete"
 
     const val ENVIRONMENT_READ = "environment:read"
+
+    const val INVITATION_READ = "invitation:read"
+    const val INVITATION_WRITE = "invitation:write"
 }

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -24,10 +24,8 @@ import org.springframework.data.mongodb.core.query.Query
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.security.SecureRandom
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
-import java.util.Base64
 import java.util.Locale
 
 @Service
@@ -47,8 +45,6 @@ class AuthService(
     @Value("\${security.password-reset.expiration-minutes:60}")
     private val resetTokenExpiryMinutes: Long,
 ) {
-    private val secureRandom = SecureRandom()
-
     @Transactional
     fun register(request: RegisterRequest): User {
         try {
@@ -340,9 +336,5 @@ class AuthService(
         }
     }
 
-    private fun generateToken(): String {
-        val bytes = ByteArray(32)
-        secureRandom.nextBytes(bytes)
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
-    }
+    private fun generateToken(): String = tokenHasher.generate()
 }

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -126,6 +126,14 @@ class InvitationService(
             return userRepository.save(updatedUser)
         }
 
+        if (request.username.isNullOrBlank() ||
+            request.password.isNullOrBlank() ||
+            request.firstName.isNullOrBlank() ||
+            request.lastName.isNullOrBlank()
+        ) {
+            throw IllegalArgumentException("Username, password, first name, and last name are required for new users")
+        }
+
         val newUser =
             User(
                 username = request.username,

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -54,10 +54,11 @@ class InvitationService(
         }
 
         val existing =
-            invitationRepository.findByEmailAndOrganizationIdAndStatus(
+            invitationRepository.findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(
                 normalizedEmail,
                 inviter.organizationId,
                 InvitationStatus.PENDING,
+                LocalDateTime.now(),
             )
         if (existing.isPresent) {
             throw IllegalArgumentException("An invitation has already been sent to this email")

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -75,7 +75,11 @@ class InvitationService(
                 invitedBy = inviter.uuid,
                 expiryAt = LocalDateTime.now().plusHours(invitationExpiryHours),
             )
-        invitationRepository.save(invitation)
+        try {
+            invitationRepository.save(invitation)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException("An invitation has already been sent to this email")
+        }
 
         return rawToken
     }

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.RoleRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.util.TokenHasher
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.mongodb.core.FindAndModifyOptions
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.query.Criteria
@@ -144,7 +145,19 @@ class InvitationService(
                         ),
                     ),
             )
-        return userRepository.save(newUser)
+        return try {
+            userRepository.save(newUser)
+        } catch (e: DuplicateKeyException) {
+            val errorMessage = e.message ?: ""
+            when {
+                errorMessage.contains("username", ignoreCase = true) ->
+                    throw IllegalArgumentException("Username already exists")
+                errorMessage.contains("email", ignoreCase = true) ->
+                    throw IllegalArgumentException("Email already exists")
+                else ->
+                    throw IllegalArgumentException("Duplicate entry: ${e.message}")
+            }
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -1,0 +1,175 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AcceptInvitationRequest
+import com.froilan.synectix.dto.CreateInvitationRequest
+import com.froilan.synectix.model.Invitation
+import com.froilan.synectix.model.InvitationStatus
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.RoleRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.util.TokenHasher
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.mongodb.core.FindAndModifyOptions
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.security.SecureRandom
+import java.time.LocalDateTime
+import java.util.Base64
+import java.util.Locale
+
+@Service
+class InvitationService(
+    private val invitationRepository: InvitationRepository,
+    private val userRepository: UserRepository,
+    private val roleRepository: RoleRepository,
+    private val mongoTemplate: MongoTemplate,
+    private val tokenHasher: TokenHasher,
+    private val passwordEncoder: PasswordEncoder,
+    @Value("\${security.invitation.expiration-hours:72}")
+    private val invitationExpiryHours: Long,
+) {
+    private val secureRandom = SecureRandom()
+
+    @Transactional
+    fun invite(
+        request: CreateInvitationRequest,
+        inviter: User,
+    ): String {
+        val normalizedEmail = request.email.lowercase(Locale.ROOT)
+
+        val role =
+            roleRepository.findByName(request.role).orElseThrow {
+                IllegalArgumentException("Role '${request.role}' does not exist")
+            }
+        if (role.level != RoleLevel.ORGANIZATION) {
+            throw IllegalArgumentException("Cannot invite with system-level role")
+        }
+
+        val existing =
+            invitationRepository.findByEmailAndOrganizationIdAndStatus(
+                normalizedEmail,
+                inviter.organizationId,
+                InvitationStatus.PENDING,
+            )
+        if (existing.isPresent) {
+            throw IllegalArgumentException("An invitation has already been sent to this email")
+        }
+
+        val rawToken = generateToken()
+        val invitation =
+            Invitation(
+                email = normalizedEmail,
+                organizationId = inviter.organizationId,
+                role = request.role,
+                tokenHash = tokenHasher.hash(rawToken),
+                invitedBy = inviter.uuid,
+                expiryAt = LocalDateTime.now().plusHours(invitationExpiryHours),
+            )
+        invitationRepository.save(invitation)
+
+        return rawToken
+    }
+
+    @Transactional
+    fun acceptInvitation(request: AcceptInvitationRequest): User {
+        val tokenHash = tokenHasher.hash(request.token)
+
+        val invitation =
+            invitationRepository.findByTokenHash(tokenHash).orElseThrow {
+                IllegalArgumentException("Invalid or expired invitation token")
+            }
+
+        if (!invitation.expiryAt.isAfter(LocalDateTime.now())) {
+            throw IllegalArgumentException("Invalid or expired invitation token")
+        }
+
+        val accepted =
+            mongoTemplate.findAndModify(
+                Query.query(
+                    Criteria
+                        .where("tokenHash")
+                        .`is`(tokenHash)
+                        .and("status")
+                        .`is`(InvitationStatus.PENDING),
+                ),
+                Update.update("status", InvitationStatus.ACCEPTED),
+                FindAndModifyOptions.options().returnNew(true),
+                Invitation::class.java,
+            ) ?: throw IllegalArgumentException("Invalid or expired invitation token")
+
+        val existingUser = userRepository.findByEmail(accepted.email)
+        if (existingUser.isPresent) {
+            val user = existingUser.get()
+            val alreadyHasRole =
+                user.roleAssignments.any {
+                    it.role == accepted.role && it.organizationId == accepted.organizationId
+                }
+            if (alreadyHasRole) {
+                return user
+            }
+            val updatedUser =
+                user.copy(
+                    roleAssignments =
+                        user.roleAssignments +
+                            RoleAssignment(
+                                role = accepted.role,
+                                organizationId = accepted.organizationId,
+                            ),
+                )
+            return userRepository.save(updatedUser)
+        }
+
+        val newUser =
+            User(
+                username = request.username,
+                email = accepted.email,
+                firstName = request.firstName,
+                lastName = request.lastName,
+                passwordHash = passwordEncoder.encode(request.password) as String,
+                organizationId = accepted.organizationId,
+                roleAssignments =
+                    listOf(
+                        RoleAssignment(
+                            role = accepted.role,
+                            organizationId = accepted.organizationId,
+                        ),
+                    ),
+            )
+        return userRepository.save(newUser)
+    }
+
+    @Transactional
+    fun revokeInvitation(
+        invitationId: String,
+        user: User,
+    ) {
+        val invitation =
+            invitationRepository.findById(invitationId).orElseThrow {
+                IllegalArgumentException("Invitation not found")
+            }
+        if (invitation.organizationId != user.organizationId) {
+            throw IllegalArgumentException("Invitation not found")
+        }
+        if (invitation.status != InvitationStatus.PENDING) {
+            throw IllegalArgumentException("Invitation is not pending")
+        }
+        invitationRepository.save(invitation.copy(status = InvitationStatus.REVOKED))
+    }
+
+    fun listInvitations(organizationId: String): List<Invitation> =
+        invitationRepository.findByOrganizationIdAndStatus(organizationId, InvitationStatus.PENDING)
+
+    private fun generateToken(): String {
+        val bytes = ByteArray(32)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -22,9 +22,7 @@ import org.springframework.data.mongodb.core.query.Update
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.security.SecureRandom
 import java.time.LocalDateTime
-import java.util.Base64
 import java.util.Locale
 
 @Service
@@ -38,8 +36,6 @@ class InvitationService(
     @Value("\${security.invitation.expiration-hours:72}")
     private val invitationExpiryHours: Long,
 ) {
-    private val secureRandom = SecureRandom()
-
     @Transactional
     fun invite(
         request: CreateInvitationRequest,
@@ -69,7 +65,7 @@ class InvitationService(
             invitationRepository.save(pendingInvitation.copy(status = InvitationStatus.EXPIRED))
         }
 
-        val rawToken = generateToken()
+        val rawToken = tokenHasher.generate()
         val invitation =
             Invitation(
                 email = normalizedEmail,
@@ -211,10 +207,4 @@ class InvitationService(
             InvitationStatus.PENDING,
             LocalDateTime.now(),
         )
-
-    private fun generateToken(): String {
-        val bytes = ByteArray(32)
-        secureRandom.nextBytes(bytes)
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
-    }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -56,14 +56,17 @@ class InvitationService(
         }
 
         val existing =
-            invitationRepository.findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(
+            invitationRepository.findByEmailAndOrganizationIdAndStatus(
                 normalizedEmail,
                 inviter.organizationId,
                 InvitationStatus.PENDING,
-                LocalDateTime.now(),
             )
         if (existing.isPresent) {
-            throw IllegalArgumentException("An invitation has already been sent to this email")
+            val pendingInvitation = existing.get()
+            if (pendingInvitation.expiryAt.isAfter(LocalDateTime.now())) {
+                throw IllegalArgumentException("An invitation has already been sent to this email")
+            }
+            invitationRepository.save(pendingInvitation.copy(status = InvitationStatus.EXPIRED))
         }
 
         val rawToken = generateToken()

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.AcceptInvitationRequest
 import com.froilan.synectix.dto.CreateInvitationRequest
+import com.froilan.synectix.dto.ValidateInvitationResponse
 import com.froilan.synectix.model.Invitation
 import com.froilan.synectix.model.InvitationStatus
 import com.froilan.synectix.model.RoleAssignment
@@ -82,6 +83,24 @@ class InvitationService(
         }
 
         return rawToken
+    }
+
+    fun validateInvitation(token: String): ValidateInvitationResponse {
+        val tokenHash = tokenHasher.hash(token)
+        val invitation =
+            invitationRepository.findByTokenHash(tokenHash).orElseThrow {
+                IllegalArgumentException("Invalid or expired invitation token")
+            }
+        if (invitation.status != InvitationStatus.PENDING || !invitation.expiryAt.isAfter(LocalDateTime.now())) {
+            throw IllegalArgumentException("Invalid or expired invitation token")
+        }
+        val existingUser = userRepository.findByEmail(invitation.email).isPresent
+        return ValidateInvitationResponse(
+            email = invitation.email,
+            role = invitation.role,
+            organizationId = invitation.organizationId,
+            existingUser = existingUser,
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -179,7 +179,11 @@ class InvitationService(
     }
 
     fun listInvitations(organizationId: String): List<Invitation> =
-        invitationRepository.findByOrganizationIdAndStatus(organizationId, InvitationStatus.PENDING)
+        invitationRepository.findByOrganizationIdAndStatusAndExpiryAtAfter(
+            organizationId,
+            InvitationStatus.PENDING,
+            LocalDateTime.now(),
+        )
 
     private fun generateToken(): String {
         val bytes = ByteArray(32)

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -70,7 +70,7 @@ class InvitationService(
             Invitation(
                 email = normalizedEmail,
                 organizationId = inviter.organizationId,
-                role = request.role,
+                role = role.name,
                 tokenHash = tokenHasher.hash(rawToken),
                 invitedBy = inviter.uuid,
                 expiryAt = LocalDateTime.now().plusHours(invitationExpiryHours),
@@ -84,15 +84,6 @@ class InvitationService(
     fun acceptInvitation(request: AcceptInvitationRequest): User {
         val tokenHash = tokenHasher.hash(request.token)
 
-        val invitation =
-            invitationRepository.findByTokenHash(tokenHash).orElseThrow {
-                IllegalArgumentException("Invalid or expired invitation token")
-            }
-
-        if (!invitation.expiryAt.isAfter(LocalDateTime.now())) {
-            throw IllegalArgumentException("Invalid or expired invitation token")
-        }
-
         val accepted =
             mongoTemplate.findAndModify(
                 Query.query(
@@ -100,7 +91,9 @@ class InvitationService(
                         .where("tokenHash")
                         .`is`(tokenHash)
                         .and("status")
-                        .`is`(InvitationStatus.PENDING),
+                        .`is`(InvitationStatus.PENDING)
+                        .and("expiryAt")
+                        .gt(LocalDateTime.now()),
                 ),
                 Update.update("status", InvitationStatus.ACCEPTED),
                 FindAndModifyOptions.options().returnNew(true),

--- a/src/main/kotlin/com/froilan/synectix/util/TokenHasher.kt
+++ b/src/main/kotlin/com/froilan/synectix/util/TokenHasher.kt
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
+import java.security.SecureRandom
+import java.util.Base64
 import java.util.HexFormat
 
 @Component
@@ -23,6 +25,14 @@ class TokenHasher(
                 e,
             )
         }
+    }
+
+    private val secureRandom = SecureRandom()
+
+    fun generate(byteLength: Int = 32): String {
+        val bytes = ByteArray(byteLength)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
     }
 
     fun hash(token: String): String {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,8 @@ management.info.env.enabled=true
 security.jwt.secret=${JWT_SECRET}
 security.jwt.expiration=${JWT_EXPIRATION:86400000}
 security.jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION:2592000000}
+security.invitation.expiration-hours=${INVITATION_EXPIRATION_HOURS:72}
+security.password-reset.expiration-minutes=${PASSWORD_RESET_EXPIRATION_MINUTES:60}
 
 # Proxy / forwarded headers (set to "framework" when behind a reverse proxy)
 server.forward-headers-strategy=${FORWARD_HEADERS_STRATEGY:none}

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -63,6 +63,8 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
+                        Permissions.INVITATION_READ,
+                        Permissions.INVITATION_WRITE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -117,6 +119,8 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
+                        Permissions.INVITATION_READ,
+                        Permissions.INVITATION_WRITE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -198,6 +202,8 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
+                        Permissions.INVITATION_READ,
+                        Permissions.INVITATION_WRITE,
                     ),
             )
         val admin =
@@ -213,6 +219,8 @@ class RoleSeederTest {
                         Permissions.USER_WRITE,
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
+                        Permissions.INVITATION_READ,
+                        Permissions.INVITATION_WRITE,
                     ),
             )
         val member =
@@ -226,6 +234,7 @@ class RoleSeederTest {
                         Permissions.SESSION_DELETE,
                         Permissions.USER_READ,
                         Permissions.ORGANIZATION_READ,
+                        Permissions.INVITATION_READ,
                     ),
             )
         val viewer =

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.aspect.LoggingAspect
 import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.dto.ValidateInvitationResponse
 import com.froilan.synectix.model.Invitation
 import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.User
@@ -165,6 +166,42 @@ class InvitationControllerTest {
             .andExpect(jsonPath("$[0].email").value("user1@example.com"))
             .andExpect(jsonPath("$[0].role").value("MEMBER"))
             .andExpect(jsonPath("$[0].status").value("PENDING"))
+    }
+
+    @Test
+    fun `POST invitations validate should return invitation details`() {
+        val response =
+            ValidateInvitationResponse(
+                email = "invited@example.com",
+                role = "MEMBER",
+                organizationId = "org-123",
+                existingUser = false,
+            )
+        `when`(invitationService.validateInvitation(any())).thenReturn(response)
+
+        mockMvc
+            .perform(
+                post("/auth/invitations/validate")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"token": "valid-token"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.email").value("invited@example.com"))
+            .andExpect(jsonPath("$.role").value("MEMBER"))
+            .andExpect(jsonPath("$.existingUser").value(false))
+    }
+
+    @Test
+    fun `POST invitations validate should return 400 for invalid token`() {
+        `when`(invitationService.validateInvitation(any()))
+            .thenThrow(IllegalArgumentException("Invalid or expired invitation token"))
+
+        mockMvc
+            .perform(
+                post("/auth/invitations/validate")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"token": "bad-token"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invalid or expired invitation token"))
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -1,0 +1,256 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.model.Invitation
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.InvitationService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+@WebMvcTest(controllers = [InvitationController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class InvitationControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var invitationService: InvitationService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("invitation:read", "invitation:write")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    @Test
+    fun `POST invitations should return 201 when invitation is created`() {
+        `when`(invitationService.invite(any(), any())).thenReturn("raw-token-123")
+
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "newuser@example.com", "role": "MEMBER"}"""),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.message").value("Invitation created"))
+            .andExpect(jsonPath("$.token").value("raw-token-123"))
+    }
+
+    @Test
+    fun `POST invitations should return 400 when email is invalid`() {
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "not-an-email", "role": "MEMBER"}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST invitations should return 400 when role is blank`() {
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "user@example.com", "role": ""}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST invitations should return 400 when duplicate invitation exists`() {
+        `when`(invitationService.invite(any(), any()))
+            .thenThrow(IllegalArgumentException("An invitation has already been sent to this email"))
+
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "existing@example.com", "role": "MEMBER"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("An invitation has already been sent to this email"))
+    }
+
+    @Test
+    fun `GET invitations should return 200 with invitation list`() {
+        val invitations =
+            listOf(
+                Invitation(
+                    id = "inv-1",
+                    email = "user1@example.com",
+                    organizationId = "org-123",
+                    role = "MEMBER",
+                    tokenHash = "hash1",
+                    invitedBy = "user-123",
+                    expiryAt = LocalDateTime.now().plusHours(72),
+                ),
+            )
+        `when`(invitationService.listInvitations("org-123")).thenReturn(invitations)
+
+        mockMvc
+            .perform(get("/auth/invitations"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].email").value("user1@example.com"))
+            .andExpect(jsonPath("$[0].role").value("MEMBER"))
+            .andExpect(jsonPath("$[0].status").value("PENDING"))
+    }
+
+    @Test
+    fun `POST invitations accept should return 200 when accepted`() {
+        `when`(invitationService.acceptInvitation(any())).thenReturn(testUser)
+
+        mockMvc
+            .perform(
+                post("/auth/invitations/accept")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "token": "valid-token",
+                            "username": "newuser",
+                            "password": "SecurePass123!",
+                            "firstName": "New",
+                            "lastName": "User"
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("Invitation accepted successfully"))
+    }
+
+    @Test
+    fun `POST invitations accept should return 400 with invalid token`() {
+        `when`(invitationService.acceptInvitation(any()))
+            .thenThrow(IllegalArgumentException("Invalid or expired invitation token"))
+
+        mockMvc
+            .perform(
+                post("/auth/invitations/accept")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "token": "invalid",
+                            "username": "newuser",
+                            "password": "SecurePass123!",
+                            "firstName": "New",
+                            "lastName": "User"
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invalid or expired invitation token"))
+    }
+
+    @Test
+    fun `DELETE invitation should return 200 when revoked`() {
+        mockMvc
+            .perform(delete("/auth/invitations/inv-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("Invitation revoked"))
+    }
+
+    @Test
+    fun `DELETE invitation should return 400 when not pending`() {
+        `when`(invitationService.revokeInvitation(any(), any()))
+            .thenThrow(IllegalArgumentException("Invitation is not pending"))
+
+        mockMvc
+            .perform(delete("/auth/invitations/inv-123"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invitation is not pending"))
+    }
+
+    @Test
+    fun `POST invitations should return 403 without invitation write permission`() {
+        setupAuthWithPermissions("invitation:read")
+
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "user@example.com", "role": "MEMBER"}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GET invitations should return 403 without invitation read permission`() {
+        setupAuthWithPermissions()
+
+        mockMvc
+            .perform(get("/auth/invitations"))
+            .andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -31,6 +31,7 @@ import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
+import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
@@ -59,6 +60,7 @@ class AuthServiceTest {
         passwordEncoder = mock(PasswordEncoder::class.java)
 
         `when`(tokenHasher.hash(any())).thenAnswer { "hashed-${it.arguments[0]}" }
+        `when`(tokenHasher.generate(any())).thenAnswer { UUID.randomUUID().toString() }
 
         authService =
             AuthService(

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -22,6 +22,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.mongodb.core.FindAndModifyOptions
 import org.springframework.data.mongodb.core.MongoTemplate
@@ -71,7 +72,7 @@ class InvitationServiceTest {
         val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
 
         `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
-        `when`(invitationRepository.findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(any(), any(), any(), any()))
+        `when`(invitationRepository.findByEmailAndOrganizationIdAndStatus(any(), any(), any()))
             .thenReturn(Optional.empty())
         `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
 
@@ -113,24 +114,57 @@ class InvitationServiceTest {
     }
 
     @Test
-    fun `invite should throw when pending invitation already exists`() {
+    fun `invite should throw when active pending invitation already exists`() {
         val request = CreateInvitationRequest(email = "existing@example.com", role = "MEMBER")
         val inviter = createMockUser()
         val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
-        val existingInvitation = createMockInvitation()
+        val existingInvitation = createMockInvitation(email = "existing@example.com")
 
         `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
         `when`(
-            invitationRepository.findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(
+            invitationRepository.findByEmailAndOrganizationIdAndStatus(
                 eq("existing@example.com"),
                 eq(inviter.organizationId),
                 eq(InvitationStatus.PENDING),
-                any(),
             ),
         ).thenReturn(Optional.of(existingInvitation))
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
         assertEquals("An invitation has already been sent to this email", exception.message)
+    }
+
+    @Test
+    fun `invite should expire old invitation and create new one when previous expired`() {
+        val request = CreateInvitationRequest(email = "reinvite@example.com", role = "MEMBER")
+        val inviter = createMockUser()
+        val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
+        val expiredInvitation =
+            createMockInvitation(
+                email = "reinvite@example.com",
+                expiryAt = LocalDateTime.now().minusHours(1),
+            )
+
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
+        `when`(
+            invitationRepository.findByEmailAndOrganizationIdAndStatus(
+                eq("reinvite@example.com"),
+                eq(inviter.organizationId),
+                eq(InvitationStatus.PENDING),
+            ),
+        ).thenReturn(Optional.of(expiredInvitation))
+        `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
+
+        val token = invitationService.invite(request, inviter)
+
+        assertNotNull(token)
+        val captor = argumentCaptor<Invitation>()
+        verify(invitationRepository, times(2)).save(captor.capture())
+
+        val expired = captor.allValues.first { it.status == InvitationStatus.EXPIRED }
+        assertEquals(expiredInvitation.id, expired.id)
+
+        val newInvite = captor.allValues.first { it.status == InvitationStatus.PENDING }
+        assertEquals("reinvite@example.com", newInvite.email)
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -166,15 +166,8 @@ class InvitationServiceTest {
     }
 
     @Test
-    fun `acceptInvitation should add role to existing user`() {
-        val request =
-            AcceptInvitationRequest(
-                token = "raw-token",
-                username = "ignored",
-                password = "ignored",
-                firstName = "ignored",
-                lastName = "ignored",
-            )
+    fun `acceptInvitation should add role to existing user with only token`() {
+        val request = AcceptInvitationRequest(token = "raw-token")
         val invitation = createMockInvitation(role = "ADMIN")
         val accepted = invitation.copy(status = InvitationStatus.ACCEPTED)
         val existingUser =
@@ -218,6 +211,19 @@ class InvitationServiceTest {
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
         assertEquals("Invalid or expired invitation token", exception.message)
+    }
+
+    @Test
+    fun `acceptInvitation should throw when new user missing required fields`() {
+        val request = AcceptInvitationRequest(token = "raw-token")
+        val invitation = createMockInvitation()
+
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        assertEquals("Username, password, first name, and last name are required for new users", exception.message)
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -9,7 +9,6 @@ import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.model.User
 import com.froilan.synectix.repository.InvitationRepository
-import org.springframework.dao.DuplicateKeyException
 import com.froilan.synectix.repository.RoleRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.util.TokenHasher
@@ -23,6 +22,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.mongodb.core.FindAndModifyOptions
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -328,7 +328,7 @@ class InvitationServiceTest {
     fun `listInvitations should return pending invitations for org`() {
         val invitations = listOf(createMockInvitation(), createMockInvitation(email = "other@example.com"))
 
-        `when`(invitationRepository.findByOrganizationIdAndStatus("org-123", InvitationStatus.PENDING))
+        `when`(invitationRepository.findByOrganizationIdAndStatusAndExpiryAtAfter(eq("org-123"), eq(InvitationStatus.PENDING), any()))
             .thenReturn(invitations)
 
         val result = invitationService.listInvitations("org-123")

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -134,6 +134,42 @@ class InvitationServiceTest {
     }
 
     @Test
+    fun `validateInvitation should return invitation details with existingUser false`() {
+        val invitation = createMockInvitation()
+
+        `when`(invitationRepository.findByTokenHash("hashed-valid-token")).thenReturn(Optional.of(invitation))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
+
+        val result = invitationService.validateInvitation("valid-token")
+
+        assertEquals(invitation.email, result.email)
+        assertEquals(invitation.role, result.role)
+        assertEquals(invitation.organizationId, result.organizationId)
+        assertEquals(false, result.existingUser)
+    }
+
+    @Test
+    fun `validateInvitation should return existingUser true when email registered`() {
+        val invitation = createMockInvitation()
+        val existingUser = createMockUser().copy(email = invitation.email)
+
+        `when`(invitationRepository.findByTokenHash("hashed-valid-token")).thenReturn(Optional.of(invitation))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.of(existingUser))
+
+        val result = invitationService.validateInvitation("valid-token")
+
+        assertEquals(true, result.existingUser)
+    }
+
+    @Test
+    fun `validateInvitation should throw for invalid token`() {
+        `when`(invitationRepository.findByTokenHash("hashed-bad-token")).thenReturn(Optional.empty())
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.validateInvitation("bad-token") }
+        assertEquals("Invalid or expired invitation token", exception.message)
+    }
+
+    @Test
     fun `acceptInvitation should create new user when email not registered`() {
         val request =
             AcceptInvitationRequest(

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -144,10 +144,10 @@ class InvitationServiceTest {
                 lastName = "User",
             )
         val invitation = createMockInvitation()
+        val accepted = invitation.copy(status = InvitationStatus.ACCEPTED)
 
-        `when`(invitationRepository.findByTokenHash("hashed-raw-token")).thenReturn(Optional.of(invitation))
         `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
-            .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
+            .thenReturn(accepted)
         `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
         `when`(passwordEncoder.encode("SecurePass123!")).thenReturn("encodedPassword")
         `when`(userRepository.save(any<User>())).thenAnswer { it.arguments[0] }
@@ -176,6 +176,7 @@ class InvitationServiceTest {
                 lastName = "ignored",
             )
         val invitation = createMockInvitation(role = "ADMIN")
+        val accepted = invitation.copy(status = InvitationStatus.ACCEPTED)
         val existingUser =
             User(
                 uuid = "existing-user",
@@ -188,9 +189,8 @@ class InvitationServiceTest {
                 roleAssignments = listOf(RoleAssignment("MEMBER", "other-org")),
             )
 
-        `when`(invitationRepository.findByTokenHash("hashed-raw-token")).thenReturn(Optional.of(invitation))
         `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
-            .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
+            .thenReturn(accepted)
         `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.of(existingUser))
         `when`(userRepository.save(any<User>())).thenAnswer { it.arguments[0] }
 
@@ -203,7 +203,7 @@ class InvitationServiceTest {
     }
 
     @Test
-    fun `acceptInvitation should throw for invalid token`() {
+    fun `acceptInvitation should throw for invalid or expired token`() {
         val request =
             AcceptInvitationRequest(
                 token = "invalid",
@@ -213,43 +213,6 @@ class InvitationServiceTest {
                 lastName = "L",
             )
 
-        `when`(invitationRepository.findByTokenHash("hashed-invalid")).thenReturn(Optional.empty())
-
-        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
-        assertEquals("Invalid or expired invitation token", exception.message)
-    }
-
-    @Test
-    fun `acceptInvitation should throw for expired invitation`() {
-        val request =
-            AcceptInvitationRequest(
-                token = "expired-token",
-                username = "user",
-                password = "password123",
-                firstName = "F",
-                lastName = "L",
-            )
-        val expiredInvitation = createMockInvitation(expiryAt = LocalDateTime.now().minusHours(1))
-
-        `when`(invitationRepository.findByTokenHash("hashed-expired-token")).thenReturn(Optional.of(expiredInvitation))
-
-        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
-        assertEquals("Invalid or expired invitation token", exception.message)
-    }
-
-    @Test
-    fun `acceptInvitation should throw when already accepted (race condition)`() {
-        val request =
-            AcceptInvitationRequest(
-                token = "used-token",
-                username = "user",
-                password = "password123",
-                firstName = "F",
-                lastName = "L",
-            )
-        val invitation = createMockInvitation()
-
-        `when`(invitationRepository.findByTokenHash("hashed-used-token")).thenReturn(Optional.of(invitation))
         `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
             .thenReturn(null)
 
@@ -269,7 +232,6 @@ class InvitationServiceTest {
             )
         val invitation = createMockInvitation()
 
-        `when`(invitationRepository.findByTokenHash("hashed-raw-token")).thenReturn(Optional.of(invitation))
         `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
             .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
         `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -70,7 +70,7 @@ class InvitationServiceTest {
         val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
 
         `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
-        `when`(invitationRepository.findByEmailAndOrganizationIdAndStatus(any(), any(), any()))
+        `when`(invitationRepository.findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(any(), any(), any(), any()))
             .thenReturn(Optional.empty())
         `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
 
@@ -120,10 +120,11 @@ class InvitationServiceTest {
 
         `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
         `when`(
-            invitationRepository.findByEmailAndOrganizationIdAndStatus(
-                "existing@example.com",
-                inviter.organizationId,
-                InvitationStatus.PENDING,
+            invitationRepository.findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(
+                eq("existing@example.com"),
+                eq(inviter.organizationId),
+                eq(InvitationStatus.PENDING),
+                any(),
             ),
         ).thenReturn(Optional.of(existingInvitation))
 

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -9,6 +9,7 @@ import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.model.User
 import com.froilan.synectix.repository.InvitationRepository
+import org.springframework.dao.DuplicateKeyException
 import com.froilan.synectix.repository.RoleRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.util.TokenHasher
@@ -254,6 +255,30 @@ class InvitationServiceTest {
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
         assertEquals("Invalid or expired invitation token", exception.message)
+    }
+
+    @Test
+    fun `acceptInvitation should throw when username already exists`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "raw-token",
+                username = "taken",
+                password = "SecurePass123!",
+                firstName = "New",
+                lastName = "User",
+            )
+        val invitation = createMockInvitation()
+
+        `when`(invitationRepository.findByTokenHash("hashed-raw-token")).thenReturn(Optional.of(invitation))
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
+        `when`(passwordEncoder.encode("SecurePass123!")).thenReturn("encodedPassword")
+        `when`(userRepository.save(any<User>()))
+            .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.users index: username"))
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        assertEquals("Username already exists", exception.message)
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -1,0 +1,341 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AcceptInvitationRequest
+import com.froilan.synectix.dto.CreateInvitationRequest
+import com.froilan.synectix.model.Invitation
+import com.froilan.synectix.model.InvitationStatus
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.RoleRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.springframework.data.mongodb.core.FindAndModifyOptions
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.LocalDateTime
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class InvitationServiceTest {
+    private lateinit var invitationService: InvitationService
+    private lateinit var invitationRepository: InvitationRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var roleRepository: RoleRepository
+    private lateinit var mongoTemplate: MongoTemplate
+    private lateinit var tokenHasher: TokenHasher
+    private lateinit var passwordEncoder: PasswordEncoder
+
+    @BeforeEach
+    fun setup() {
+        invitationRepository = mock(InvitationRepository::class.java)
+        userRepository = mock(UserRepository::class.java)
+        roleRepository = mock(RoleRepository::class.java)
+        mongoTemplate = mock(MongoTemplate::class.java)
+        tokenHasher = mock(TokenHasher::class.java)
+        passwordEncoder = mock(PasswordEncoder::class.java)
+
+        `when`(tokenHasher.hash(any())).thenAnswer { "hashed-${it.arguments[0]}" }
+
+        invitationService =
+            InvitationService(
+                invitationRepository = invitationRepository,
+                userRepository = userRepository,
+                roleRepository = roleRepository,
+                mongoTemplate = mongoTemplate,
+                tokenHasher = tokenHasher,
+                passwordEncoder = passwordEncoder,
+                invitationExpiryHours = 72L,
+            )
+    }
+
+    @Test
+    fun `invite should create invitation and return raw token`() {
+        val request = CreateInvitationRequest(email = "newuser@example.com", role = "MEMBER")
+        val inviter = createMockUser()
+        val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
+
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
+        `when`(invitationRepository.findByEmailAndOrganizationIdAndStatus(any(), any(), any()))
+            .thenReturn(Optional.empty())
+        `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
+
+        val token = invitationService.invite(request, inviter)
+
+        assertNotNull(token)
+        assertTrue(token.isNotEmpty())
+
+        val captor = argumentCaptor<Invitation>()
+        verify(invitationRepository).save(captor.capture())
+        assertEquals("newuser@example.com", captor.firstValue.email)
+        assertEquals("MEMBER", captor.firstValue.role)
+        assertEquals(inviter.organizationId, captor.firstValue.organizationId)
+        assertEquals(inviter.uuid, captor.firstValue.invitedBy)
+        assertEquals(InvitationStatus.PENDING, captor.firstValue.status)
+    }
+
+    @Test
+    fun `invite should throw when role does not exist`() {
+        val request = CreateInvitationRequest(email = "newuser@example.com", role = "NONEXISTENT")
+        val inviter = createMockUser()
+
+        `when`(roleRepository.findByName("NONEXISTENT")).thenReturn(Optional.empty())
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        assertEquals("Role 'NONEXISTENT' does not exist", exception.message)
+    }
+
+    @Test
+    fun `invite should throw when role is system level`() {
+        val request = CreateInvitationRequest(email = "newuser@example.com", role = "SUPER_ADMIN")
+        val inviter = createMockUser()
+        val systemRole = Role(name = "SUPER_ADMIN", description = "System admin", level = RoleLevel.SYSTEM)
+
+        `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(systemRole))
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        assertEquals("Cannot invite with system-level role", exception.message)
+    }
+
+    @Test
+    fun `invite should throw when pending invitation already exists`() {
+        val request = CreateInvitationRequest(email = "existing@example.com", role = "MEMBER")
+        val inviter = createMockUser()
+        val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
+        val existingInvitation = createMockInvitation()
+
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
+        `when`(
+            invitationRepository.findByEmailAndOrganizationIdAndStatus(
+                "existing@example.com",
+                inviter.organizationId,
+                InvitationStatus.PENDING,
+            ),
+        ).thenReturn(Optional.of(existingInvitation))
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        assertEquals("An invitation has already been sent to this email", exception.message)
+    }
+
+    @Test
+    fun `acceptInvitation should create new user when email not registered`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "raw-token",
+                username = "newuser",
+                password = "SecurePass123!",
+                firstName = "New",
+                lastName = "User",
+            )
+        val invitation = createMockInvitation()
+
+        `when`(invitationRepository.findByTokenHash("hashed-raw-token")).thenReturn(Optional.of(invitation))
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
+        `when`(passwordEncoder.encode("SecurePass123!")).thenReturn("encodedPassword")
+        `when`(userRepository.save(any<User>())).thenAnswer { it.arguments[0] }
+
+        val result = invitationService.acceptInvitation(request)
+
+        assertNotNull(result)
+        assertEquals("newuser", result.username)
+        assertEquals(invitation.email, result.email)
+        assertEquals(invitation.organizationId, result.organizationId)
+
+        val userCaptor = argumentCaptor<User>()
+        verify(userRepository).save(userCaptor.capture())
+        assertEquals("MEMBER", userCaptor.firstValue.roleAssignments[0].role)
+        assertEquals(invitation.organizationId, userCaptor.firstValue.roleAssignments[0].organizationId)
+    }
+
+    @Test
+    fun `acceptInvitation should add role to existing user`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "raw-token",
+                username = "ignored",
+                password = "ignored",
+                firstName = "ignored",
+                lastName = "ignored",
+            )
+        val invitation = createMockInvitation(role = "ADMIN")
+        val existingUser =
+            User(
+                uuid = "existing-user",
+                username = "existinguser",
+                email = invitation.email,
+                firstName = "Existing",
+                lastName = "User",
+                passwordHash = "existingHash",
+                organizationId = "other-org",
+                roleAssignments = listOf(RoleAssignment("MEMBER", "other-org")),
+            )
+
+        `when`(invitationRepository.findByTokenHash("hashed-raw-token")).thenReturn(Optional.of(invitation))
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.of(existingUser))
+        `when`(userRepository.save(any<User>())).thenAnswer { it.arguments[0] }
+
+        val result = invitationService.acceptInvitation(request)
+
+        assertEquals(2, result.roleAssignments.size)
+        assertTrue(result.roleAssignments.any { it.role == "ADMIN" && it.organizationId == invitation.organizationId })
+
+        verify(passwordEncoder, never()).encode(any())
+    }
+
+    @Test
+    fun `acceptInvitation should throw for invalid token`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "invalid",
+                username = "user",
+                password = "password123",
+                firstName = "F",
+                lastName = "L",
+            )
+
+        `when`(invitationRepository.findByTokenHash("hashed-invalid")).thenReturn(Optional.empty())
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        assertEquals("Invalid or expired invitation token", exception.message)
+    }
+
+    @Test
+    fun `acceptInvitation should throw for expired invitation`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "expired-token",
+                username = "user",
+                password = "password123",
+                firstName = "F",
+                lastName = "L",
+            )
+        val expiredInvitation = createMockInvitation(expiryAt = LocalDateTime.now().minusHours(1))
+
+        `when`(invitationRepository.findByTokenHash("hashed-expired-token")).thenReturn(Optional.of(expiredInvitation))
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        assertEquals("Invalid or expired invitation token", exception.message)
+    }
+
+    @Test
+    fun `acceptInvitation should throw when already accepted (race condition)`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "used-token",
+                username = "user",
+                password = "password123",
+                firstName = "F",
+                lastName = "L",
+            )
+        val invitation = createMockInvitation()
+
+        `when`(invitationRepository.findByTokenHash("hashed-used-token")).thenReturn(Optional.of(invitation))
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(null)
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        assertEquals("Invalid or expired invitation token", exception.message)
+    }
+
+    @Test
+    fun `revokeInvitation should update status to REVOKED`() {
+        val user = createMockUser()
+        val invitation = createMockInvitation()
+
+        `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
+        `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
+
+        invitationService.revokeInvitation(invitation.id, user)
+
+        val captor = argumentCaptor<Invitation>()
+        verify(invitationRepository).save(captor.capture())
+        assertEquals(InvitationStatus.REVOKED, captor.firstValue.status)
+    }
+
+    @Test
+    fun `revokeInvitation should throw when invitation not in same org`() {
+        val user = createMockUser()
+        val invitation = createMockInvitation(organizationId = "other-org")
+
+        `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invitationService.revokeInvitation(invitation.id, user)
+            }
+        assertEquals("Invitation not found", exception.message)
+    }
+
+    @Test
+    fun `revokeInvitation should throw when invitation is not pending`() {
+        val user = createMockUser()
+        val invitation = createMockInvitation(status = InvitationStatus.ACCEPTED)
+
+        `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invitationService.revokeInvitation(invitation.id, user)
+            }
+        assertEquals("Invitation is not pending", exception.message)
+    }
+
+    @Test
+    fun `listInvitations should return pending invitations for org`() {
+        val invitations = listOf(createMockInvitation(), createMockInvitation(email = "other@example.com"))
+
+        `when`(invitationRepository.findByOrganizationIdAndStatus("org-123", InvitationStatus.PENDING))
+            .thenReturn(invitations)
+
+        val result = invitationService.listInvitations("org-123")
+
+        assertEquals(2, result.size)
+    }
+
+    private fun createMockUser() =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encodedPassword",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    private fun createMockInvitation(
+        email: String = "invited@example.com",
+        role: String = "MEMBER",
+        organizationId: String = "org-123",
+        status: InvitationStatus = InvitationStatus.PENDING,
+        expiryAt: LocalDateTime = LocalDateTime.now().plusHours(72),
+    ) = Invitation(
+        id = "inv-123",
+        email = email,
+        organizationId = organizationId,
+        role = role,
+        tokenHash = "hashed-token",
+        invitedBy = "user-123",
+        status = status,
+        expiryAt = expiryAt,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -52,6 +52,7 @@ class InvitationServiceTest {
         passwordEncoder = mock(PasswordEncoder::class.java)
 
         `when`(tokenHasher.hash(any())).thenAnswer { "hashed-${it.arguments[0]}" }
+        `when`(tokenHasher.generate(any())).thenReturn("generated-test-token")
 
         invitationService =
             InvitationService(


### PR DESCRIPTION
## Summary
- Add `Invitation` model with status tracking (PENDING/ACCEPTED/EXPIRED/REVOKED) and TTL auto-cleanup
- Add `InvitationService` with invite, validate, accept, revoke, and list operations
- Add `InvitationController` with 5 endpoints:
  - `POST /api/auth/invitations` — create invitation (requires `invitation:write`)
  - `GET /api/auth/invitations` — list org invitations (requires `invitation:read`)
  - `POST /api/auth/invitations/validate` — validate token and check if invitee exists (public)
  - `POST /api/auth/invitations/accept` — accept and create/join account (public)
  - `DELETE /api/auth/invitations/{id}` — revoke invitation (requires `invitation:write`)
- Add `INVITATION_READ` and `INVITATION_WRITE` permissions to OWNER, ADMIN (write), MEMBER (read only)
- SUPER_ADMIN abstracted out of invitation flow (org-level operation only)
- Accept flow handles both new users (requires registration fields) and existing users (token only)
- Validate endpoint lets clients determine which form to show before accepting
- Atomic accept via single `findAndModify` with status + expiry check (no TOCTOU)
- Partial unique index on (email, orgId) where status=PENDING prevents duplicate race condition
- DuplicateKeyException catch on user creation for username/email collisions
- Duplicate/list queries filter by expiryAt > now to avoid TTL cleanup lag
- Enable `autoIndexCreation` for all `@Indexed` annotations (was silently disabled)
- Enable JUnit class-level parallel test execution + Gradle `maxParallelForks`

## Test plan
- [x] 116/117 tests pass (1 pre-existing context-load failure)
- [x] ktlint passes
- [x] Service tests: invite, validate (new + existing user), accept (new + existing), reject bad/system role, reject duplicate, reject expired/used token, reject missing fields for new user, username collision, revoke, list
- [x] Controller tests: 201 create, 400 validation, 200 validate/list/accept/revoke, 403 permission denial

Closes #17