### PR TITLE
Add multi-org membership and org switching

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -49,6 +49,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/auth/invitations").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/auth/invitations").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/auth/invitations/*").authenticated()
+                it.requestMatchers("/auth/organizations", "/auth/organizations/**").authenticated()
                 it.requestMatchers("/auth/**").permitAll()
                 it.requestMatchers("/health/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -36,14 +36,20 @@ class TokenAuthenticationFilter(
                     val userOpt = userRepository.findById(sessionToken.userId)
                     if (userOpt.isPresent && userOpt.get().isActive) {
                         val user = userOpt.get()
-                        val roleAuthorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+                        val activeOrgId = sessionToken.organizationId ?: user.organizationId
+                        val activeRoleAssignments =
+                            user.roleAssignments.filter {
+                                it.organizationId == activeOrgId || it.organizationId == null
+                            }
+                        val roleAuthorities = activeRoleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
                         val permissionAuthorities =
-                            user.roleAssignments
+                            activeRoleAssignments
                                 .flatMap { rolePermissionCache.getPermissions(it.role) }
                                 .distinct()
                                 .map { SimpleGrantedAuthority(it) }
                         val authorities = roleAuthorities + permissionAuthorities
                         val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
+                        authentication.details = sessionToken
                         SecurityContextHolder.getContext().authentication = authentication
                     }
                 } else {

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -3,6 +3,7 @@ package com.froilan.synectix.config
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -41,7 +42,11 @@ class TokenAuthenticationFilter(
                             user.roleAssignments.filter {
                                 it.organizationId == activeOrgId || it.organizationId == null
                             }
-                        val roleAuthorities = activeRoleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+                        val roleAuthorities =
+                            activeRoleAssignments
+                                .map { it.role }
+                                .distinct()
+                                .map { SimpleGrantedAuthority("ROLE_$it") }
                         val permissionAuthorities =
                             activeRoleAssignments
                                 .flatMap { rolePermissionCache.getPermissions(it.role) }
@@ -49,7 +54,11 @@ class TokenAuthenticationFilter(
                                 .map { SimpleGrantedAuthority(it) }
                         val authorities = roleAuthorities + permissionAuthorities
                         val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
-                        authentication.details = sessionToken
+                        authentication.details =
+                            SessionContext(
+                                sessionId = sessionToken.id,
+                                organizationId = activeOrgId,
+                            )
                         SecurityContextHolder.getContext().authentication = authentication
                     }
                 } else {

--- a/src/main/kotlin/com/froilan/synectix/controller/AuthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AuthController.kt
@@ -8,6 +8,8 @@ import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RefreshRequest
 import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.dto.ResetPasswordRequest
+import com.froilan.synectix.dto.SwitchOrganizationRequest
+import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
 import com.froilan.synectix.service.AuthService
 import com.github.benmanes.caffeine.cache.Caffeine
@@ -17,6 +19,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -171,6 +174,50 @@ class AuthController(
         } catch (e: IllegalArgumentException) {
             ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Password reset failed")))
         }
+
+    @GetMapping("/organizations")
+    fun listOrganizations(): ResponseEntity<Any> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val user =
+            authentication?.principal as? User
+                ?: return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(mapOf("error" to "Authentication required"))
+        val sessionToken =
+            authentication.details as? SessionToken
+                ?: return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(mapOf("error" to "Authentication required"))
+
+        val orgs = authService.listUserOrganizations(user, sessionToken.organizationId ?: user.organizationId)
+        return ResponseEntity.ok(orgs)
+    }
+
+    @PostMapping("/organizations/switch")
+    fun switchOrganization(
+        @Valid @RequestBody request: SwitchOrganizationRequest,
+        httpRequest: HttpServletRequest,
+    ): ResponseEntity<Any> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val user =
+            authentication?.principal as? User
+                ?: return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(mapOf("error" to "Authentication required"))
+
+        return try {
+            val response =
+                authService.switchOrganization(
+                    user = user,
+                    targetOrgId = request.organizationId,
+                    ipAddress = httpRequest.remoteAddr?.take(MAX_IP_LENGTH),
+                    userAgent = httpRequest.getHeader("User-Agent")?.take(MAX_USER_AGENT_LENGTH),
+                )
+            ResponseEntity.ok(response)
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Organization switch failed")))
+        }
+    }
 
     @PostMapping("/logout")
     fun logout(

--- a/src/main/kotlin/com/froilan/synectix/controller/AuthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AuthController.kt
@@ -9,8 +9,8 @@ import com.froilan.synectix.dto.RefreshRequest
 import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.dto.ResetPasswordRequest
 import com.froilan.synectix.dto.SwitchOrganizationRequest
-import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.AuthService
 import com.github.benmanes.caffeine.cache.Caffeine
 import jakarta.servlet.http.HttpServletRequest
@@ -183,13 +183,13 @@ class AuthController(
                 ?: return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
                     .body(mapOf("error" to "Authentication required"))
-        val sessionToken =
-            authentication.details as? SessionToken
+        val sessionContext =
+            authentication.details as? SessionContext
                 ?: return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
                     .body(mapOf("error" to "Authentication required"))
 
-        val orgs = authService.listUserOrganizations(user, sessionToken.organizationId ?: user.organizationId)
+        val orgs = authService.listUserOrganizations(user, sessionContext.organizationId)
         return ResponseEntity.ok(orgs)
     }
 

--- a/src/main/kotlin/com/froilan/synectix/dto/AuthDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/AuthDtos.kt
@@ -83,6 +83,20 @@ data class AuthResponse(
     val refreshToken: String,
     val username: String,
     val roles: List<String>,
+    val organizationId: String,
     val expiresAt: String,
     val refreshTokenExpiresAt: String,
+)
+
+data class SwitchOrganizationRequest(
+    @field:NotBlank(message = "Organization ID is required")
+    val organizationId: String,
+)
+
+data class UserOrganizationResponse(
+    val organizationId: String,
+    val name: String,
+    val orgSlug: String,
+    val roles: List<String>,
+    val isCurrent: Boolean,
 )

--- a/src/main/kotlin/com/froilan/synectix/dto/AuthDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/AuthDtos.kt
@@ -99,4 +99,5 @@ data class UserOrganizationResponse(
     val orgSlug: String,
     val roles: List<String>,
     val isCurrent: Boolean,
+    val isActive: Boolean,
 )

--- a/src/main/kotlin/com/froilan/synectix/model/SessionToken.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/SessionToken.kt
@@ -13,6 +13,7 @@ data class SessionToken(
     @Indexed(unique = true)
     val token: String,
     val userId: String,
+    val organizationId: String? = null,
     @Indexed(expireAfterSeconds = 0)
     val expiryAt: LocalDateTime,
     val ipAddress: String? = null,

--- a/src/main/kotlin/com/froilan/synectix/security/SessionContext.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/SessionContext.kt
@@ -1,0 +1,6 @@
+package com.froilan.synectix.security
+
+data class SessionContext(
+    val sessionId: String,
+    val organizationId: String,
+)

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -409,7 +409,6 @@ class AuthService(
         val orgsById =
             organizationRepository
                 .findAllById(orgIds)
-                .filter { it.isActive }
                 .associateBy { it.uuid }
 
         return orgIds.mapNotNull { orgId ->
@@ -418,8 +417,9 @@ class AuthService(
                 organizationId = orgId,
                 name = org.name,
                 orgSlug = org.orgSlug,
-                roles = user.orgRoleNames(orgId),
+                roles = user.orgRoleNames(orgId).distinct(),
                 isCurrent = orgId == currentOrgId,
+                isActive = org.isActive,
             )
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -411,15 +411,15 @@ class AuthService(
                 .findAllById(orgIds)
                 .associateBy { it.uuid }
 
-        return orgIds.mapNotNull { orgId ->
-            val org = orgsById[orgId] ?: return@mapNotNull null
+        return orgIds.map { orgId ->
+            val org = orgsById[orgId]
             UserOrganizationResponse(
                 organizationId = orgId,
-                name = org.name,
-                orgSlug = org.orgSlug,
+                name = org?.name ?: "Unknown",
+                orgSlug = org?.orgSlug ?: "unknown",
                 roles = user.orgRoleNames(orgId).distinct(),
                 isCurrent = orgId == currentOrgId,
-                isActive = org.isActive,
+                isActive = org?.isActive ?: false,
             )
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -3,13 +3,15 @@ package com.froilan.synectix.service
 import com.froilan.synectix.dto.AuthResponse
 import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RegisterRequest
+import com.froilan.synectix.dto.UserOrganizationResponse
 import com.froilan.synectix.model.Organizations
 import com.froilan.synectix.model.PasswordResetToken
 import com.froilan.synectix.model.RefreshToken
 import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
-import com.froilan.synectix.model.effectiveRoleNames
+import com.froilan.synectix.model.orgRoleNames
+import com.froilan.synectix.model.systemRoleNames
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
@@ -114,11 +116,13 @@ class AuthService(
         val accessTokenStr = generateToken()
         val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
 
+        val orgId = user.organizationId
         val sessionToken =
             SessionToken(
                 token = accessTokenStr,
                 expiryAt = expiryAt,
                 userId = user.uuid,
+                organizationId = orgId,
                 ipAddress = ipAddress,
                 userAgent = userAgent,
             )
@@ -136,11 +140,13 @@ class AuthService(
             )
         refreshTokenRepository.save(refreshToken)
 
+        val roles = (user.orgRoleNames(orgId) + user.systemRoleNames()).distinct()
         return AuthResponse(
             accessToken = accessTokenStr,
             refreshToken = refreshTokenStr,
             username = user.username,
-            roles = user.effectiveRoleNames(),
+            roles = roles,
+            organizationId = orgId,
             expiresAt = expiryAt.toString(),
             refreshTokenExpiresAt = refreshExpiryAt.toString(),
         )
@@ -167,6 +173,9 @@ class AuthService(
             throw IllegalArgumentException("User account is inactive")
         }
 
+        val oldSession = sessionTokenRepository.findById(existing.sessionTokenId).orElse(null)
+        val orgId = oldSession?.organizationId ?: user.organizationId
+
         val accessTokenStr = generateToken()
         val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
 
@@ -175,6 +184,7 @@ class AuthService(
                 token = accessTokenStr,
                 expiryAt = expiryAt,
                 userId = user.uuid,
+                organizationId = orgId,
             )
         val savedSession = sessionTokenRepository.save(sessionToken)
 
@@ -204,11 +214,13 @@ class AuthService(
 
         sessionTokenRepository.deleteById(existing.sessionTokenId)
 
+        val roles = (user.orgRoleNames(orgId) + user.systemRoleNames()).distinct()
         return AuthResponse(
             accessToken = accessTokenStr,
             refreshToken = refreshTokenStr,
             username = user.username,
-            roles = user.effectiveRoleNames(),
+            roles = roles,
+            organizationId = orgId,
             expiresAt = expiryAt.toString(),
             refreshTokenExpiresAt = refreshExpiryAt.toString(),
         )
@@ -325,6 +337,91 @@ class AuthService(
         val sessionIds = otherSessions.map { it.id }
         refreshTokenRepository.deleteBySessionTokenIdIn(sessionIds)
         sessionTokenRepository.deleteAllById(sessionIds)
+    }
+
+    @Transactional
+    fun switchOrganization(
+        user: User,
+        targetOrgId: String,
+        ipAddress: String? = null,
+        userAgent: String? = null,
+    ): AuthResponse {
+        val orgRoles = user.orgRoleNames(targetOrgId)
+        if (orgRoles.isEmpty()) {
+            throw IllegalArgumentException("You do not have access to this organization")
+        }
+
+        val org =
+            organizationRepository.findById(targetOrgId).orElseThrow {
+                IllegalArgumentException("Organization not found")
+            }
+        if (!org.isActive) {
+            throw IllegalArgumentException("Organization is not active")
+        }
+
+        val accessTokenStr = generateToken()
+        val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
+
+        val sessionToken =
+            SessionToken(
+                token = accessTokenStr,
+                expiryAt = expiryAt,
+                userId = user.uuid,
+                organizationId = targetOrgId,
+                ipAddress = ipAddress,
+                userAgent = userAgent,
+            )
+        val savedSession = sessionTokenRepository.save(sessionToken)
+
+        val refreshTokenStr = generateToken()
+        val refreshExpiryAt = LocalDateTime.now().plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+
+        val refreshToken =
+            RefreshToken(
+                tokenHash = tokenHasher.hash(refreshTokenStr),
+                userId = user.uuid,
+                sessionTokenId = savedSession.id,
+                expiryAt = refreshExpiryAt,
+            )
+        refreshTokenRepository.save(refreshToken)
+
+        val roles = (orgRoles + user.systemRoleNames()).distinct()
+        return AuthResponse(
+            accessToken = accessTokenStr,
+            refreshToken = refreshTokenStr,
+            username = user.username,
+            roles = roles,
+            organizationId = targetOrgId,
+            expiresAt = expiryAt.toString(),
+            refreshTokenExpiresAt = refreshExpiryAt.toString(),
+        )
+    }
+
+    fun listUserOrganizations(
+        user: User,
+        currentOrgId: String,
+    ): List<UserOrganizationResponse> {
+        val orgIds =
+            user.roleAssignments
+                .mapNotNull { it.organizationId }
+                .distinct()
+
+        val orgsById =
+            organizationRepository
+                .findAllById(orgIds)
+                .filter { it.isActive }
+                .associateBy { it.uuid }
+
+        return orgIds.mapNotNull { orgId ->
+            val org = orgsById[orgId] ?: return@mapNotNull null
+            UserOrganizationResponse(
+                organizationId = orgId,
+                name = org.name,
+                orgSlug = org.orgSlug,
+                roles = user.orgRoleNames(orgId),
+                isCurrent = orgId == currentOrgId,
+            )
+        }
     }
 
     @Transactional

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -7,7 +7,6 @@ import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.dto.UserOrganizationResponse
 import com.froilan.synectix.model.RoleAssignment
-import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
@@ -15,6 +14,7 @@ import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
@@ -644,13 +644,7 @@ class AuthControllerTest {
                 organizationId = "org-123",
                 roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
             )
-        val session =
-            SessionToken(
-                token = "test-token",
-                userId = user.uuid,
-                organizationId = "org-123",
-                expiryAt = LocalDateTime.now().plusHours(24),
-            )
+        val session = SessionContext(sessionId = "session-123", organizationId = "org-123")
         setupAuth(user, session)
 
         val orgs =
@@ -692,13 +686,7 @@ class AuthControllerTest {
                         RoleAssignment("MEMBER", "org-456"),
                     ),
             )
-        val session =
-            SessionToken(
-                token = "test-token",
-                userId = user.uuid,
-                organizationId = "org-123",
-                expiryAt = LocalDateTime.now().plusHours(24),
-            )
+        val session = SessionContext(sessionId = "session-123", organizationId = "org-123")
         setupAuth(user, session)
 
         val switchResponse =
@@ -737,13 +725,7 @@ class AuthControllerTest {
                 organizationId = "org-123",
                 roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
             )
-        val session =
-            SessionToken(
-                token = "test-token",
-                userId = user.uuid,
-                organizationId = "org-123",
-                expiryAt = LocalDateTime.now().plusHours(24),
-            )
+        val session = SessionContext(sessionId = "session-123", organizationId = "org-123")
         setupAuth(user, session)
 
         `when`(authService.switchOrganization(any(), any(), anyOrNull(), anyOrNull()))
@@ -760,7 +742,7 @@ class AuthControllerTest {
 
     private fun setupAuth(
         user: User,
-        session: SessionToken,
+        session: SessionContext,
     ) {
         val authorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
         val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -276,6 +276,7 @@ class AuthControllerTest {
                 refreshToken = "generated-refresh-token-123",
                 username = "testuser",
                 roles = listOf("OWNER"),
+                organizationId = "org-123",
                 expiresAt = LocalDateTime.now().plusHours(24).toString(),
                 refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
             )
@@ -389,6 +390,7 @@ class AuthControllerTest {
                 refreshToken = "new-refresh-token-789",
                 username = "testuser",
                 roles = listOf("OWNER"),
+                organizationId = "org-123",
                 expiresAt = LocalDateTime.now().plusHours(24).toString(),
                 refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
             )

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -5,6 +5,9 @@ import com.froilan.synectix.config.TestSecurityConfig
 import com.froilan.synectix.dto.AuthResponse
 import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RegisterRequest
+import com.froilan.synectix.dto.UserOrganizationResponse
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
@@ -25,10 +28,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -622,5 +629,142 @@ class AuthControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestJson),
             ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET organizations should return org list for authenticated user`() {
+        val user =
+            User(
+                uuid = "user-123",
+                username = "testuser",
+                email = "test@example.com",
+                firstName = "Test",
+                lastName = "User",
+                passwordHash = "encoded",
+                organizationId = "org-123",
+                roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+            )
+        val session =
+            SessionToken(
+                token = "test-token",
+                userId = user.uuid,
+                organizationId = "org-123",
+                expiryAt = LocalDateTime.now().plusHours(24),
+            )
+        setupAuth(user, session)
+
+        val orgs =
+            listOf(
+                UserOrganizationResponse(
+                    organizationId = "org-123",
+                    name = "Test Org",
+                    orgSlug = "test-org",
+                    roles = listOf("OWNER"),
+                    isCurrent = true,
+                    isActive = true,
+                ),
+            )
+        `when`(authService.listUserOrganizations(any(), any())).thenReturn(orgs)
+
+        mockMvc
+            .perform(get("/auth/organizations"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].organizationId").value("org-123"))
+            .andExpect(jsonPath("$[0].current").value(true))
+            .andExpect(jsonPath("$[0].active").value(true))
+    }
+
+    @Test
+    fun `POST organizations switch should return new token pair`() {
+        val user =
+            User(
+                uuid = "user-123",
+                username = "testuser",
+                email = "test@example.com",
+                firstName = "Test",
+                lastName = "User",
+                passwordHash = "encoded",
+                organizationId = "org-123",
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("OWNER", "org-123"),
+                        RoleAssignment("MEMBER", "org-456"),
+                    ),
+            )
+        val session =
+            SessionToken(
+                token = "test-token",
+                userId = user.uuid,
+                organizationId = "org-123",
+                expiryAt = LocalDateTime.now().plusHours(24),
+            )
+        setupAuth(user, session)
+
+        val switchResponse =
+            AuthResponse(
+                accessToken = "new-token",
+                refreshToken = "new-refresh",
+                username = "testuser",
+                roles = listOf("MEMBER"),
+                organizationId = "org-456",
+                expiresAt = LocalDateTime.now().plusHours(24).toString(),
+                refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
+            )
+        `when`(authService.switchOrganization(any(), any(), anyOrNull(), anyOrNull())).thenReturn(switchResponse)
+
+        mockMvc
+            .perform(
+                post("/auth/organizations/switch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"organizationId": "org-456"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.organizationId").value("org-456"))
+            .andExpect(jsonPath("$.roles[0]").value("MEMBER"))
+            .andExpect(jsonPath("$.accessToken").value("new-token"))
+    }
+
+    @Test
+    fun `POST organizations switch should return 400 for unauthorized org`() {
+        val user =
+            User(
+                uuid = "user-123",
+                username = "testuser",
+                email = "test@example.com",
+                firstName = "Test",
+                lastName = "User",
+                passwordHash = "encoded",
+                organizationId = "org-123",
+                roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+            )
+        val session =
+            SessionToken(
+                token = "test-token",
+                userId = user.uuid,
+                organizationId = "org-123",
+                expiryAt = LocalDateTime.now().plusHours(24),
+            )
+        setupAuth(user, session)
+
+        `when`(authService.switchOrganization(any(), any(), anyOrNull(), anyOrNull()))
+            .thenThrow(IllegalArgumentException("You do not have access to this organization"))
+
+        mockMvc
+            .perform(
+                post("/auth/organizations/switch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"organizationId": "org-999"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("You do not have access to this organization"))
+    }
+
+    private fun setupAuth(
+        user: User,
+        session: SessionToken,
+    ) {
+        val authorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
+        authentication.details = session
+        SecurityContextHolder.getContext().authentication = authentication
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -33,6 +33,7 @@ import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -673,6 +674,137 @@ class AuthServiceTest {
             orgLegalName = "Test Organization LLC",
             orgTradeName = "Test Org",
         )
+
+    @Test
+    fun `switchOrganization should return new token pair scoped to target org`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("OWNER", "org-123"),
+                        RoleAssignment("MEMBER", "org-456"),
+                    ),
+            )
+        val targetOrg = createMockOrganization().copy(uuid = "org-456")
+
+        `when`(organizationRepository.findById("org-456")).thenReturn(Optional.of(targetOrg))
+        `when`(sessionTokenRepository.save(any<SessionToken>())).thenAnswer { it.arguments[0] }
+        `when`(refreshTokenRepository.save(any<RefreshToken>())).thenAnswer { it.arguments[0] }
+
+        val result = authService.switchOrganization(user, "org-456")
+
+        assertEquals("org-456", result.organizationId)
+        assertEquals(listOf("MEMBER"), result.roles)
+        assertNotNull(result.accessToken)
+        assertNotNull(result.refreshToken)
+
+        val sessionCaptor = argumentCaptor<SessionToken>()
+        verify(sessionTokenRepository).save(sessionCaptor.capture())
+        assertEquals("org-456", sessionCaptor.firstValue.organizationId)
+    }
+
+    @Test
+    fun `switchOrganization should throw when user has no role in target org`() {
+        val user = createMockUser()
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                authService.switchOrganization(user, "org-999")
+            }
+        assertEquals("You do not have access to this organization", exception.message)
+    }
+
+    @Test
+    fun `switchOrganization should throw when org not found`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("MEMBER", "org-123"),
+                        RoleAssignment("MEMBER", "org-missing"),
+                    ),
+            )
+
+        `when`(organizationRepository.findById("org-missing")).thenReturn(Optional.empty())
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                authService.switchOrganization(user, "org-missing")
+            }
+        assertEquals("Organization not found", exception.message)
+    }
+
+    @Test
+    fun `switchOrganization should throw when org is inactive`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("MEMBER", "org-123"),
+                        RoleAssignment("MEMBER", "org-inactive"),
+                    ),
+            )
+        val inactiveOrg = createMockOrganization().copy(uuid = "org-inactive", isActive = false)
+
+        `when`(organizationRepository.findById("org-inactive")).thenReturn(Optional.of(inactiveOrg))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                authService.switchOrganization(user, "org-inactive")
+            }
+        assertEquals("Organization is not active", exception.message)
+    }
+
+    @Test
+    fun `listUserOrganizations should return orgs with current indicator`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("OWNER", "org-123"),
+                        RoleAssignment("MEMBER", "org-456"),
+                    ),
+            )
+        val org1 = createMockOrganization().copy(uuid = "org-123", name = "Org One", orgSlug = "org-one")
+        val org2 = createMockOrganization().copy(uuid = "org-456", name = "Org Two", orgSlug = "org-two")
+
+        `when`(organizationRepository.findAllById(listOf("org-123", "org-456"))).thenReturn(listOf(org1, org2))
+
+        val result = authService.listUserOrganizations(user, "org-123")
+
+        assertEquals(2, result.size)
+        val current = result.first { it.isCurrent }
+        assertEquals("org-123", current.organizationId)
+        assertEquals(listOf("OWNER"), current.roles)
+
+        val other = result.first { !it.isCurrent }
+        assertEquals("org-456", other.organizationId)
+        assertEquals(listOf("MEMBER"), other.roles)
+    }
+
+    @Test
+    fun `listUserOrganizations should include inactive orgs with isActive false`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("OWNER", "org-123"),
+                        RoleAssignment("MEMBER", "org-inactive"),
+                    ),
+            )
+        val activeOrg = createMockOrganization().copy(uuid = "org-123")
+        val inactiveOrg = createMockOrganization().copy(uuid = "org-inactive", isActive = false)
+
+        `when`(organizationRepository.findAllById(listOf("org-123", "org-inactive"))).thenReturn(listOf(activeOrg, inactiveOrg))
+
+        val result = authService.listUserOrganizations(user, "org-123")
+
+        assertEquals(2, result.size)
+        val active = result.first { it.organizationId == "org-123" }
+        assertTrue(active.isActive)
+        val inactive = result.first { it.organizationId == "org-inactive" }
+        assertFalse(inactive.isActive)
+    }
 
     private fun createMockOrganization() =
         Organizations(

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -8,7 +8,7 @@ import com.froilan.synectix.model.RefreshToken
 import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
-import com.froilan.synectix.model.effectiveRoleNames
+import com.froilan.synectix.model.orgRoleNames
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
@@ -229,7 +229,8 @@ class AuthServiceTest {
 
         assertNotNull(result)
         assertEquals(user.username, result.username)
-        assertEquals(user.effectiveRoleNames(), result.roles)
+        assertEquals(user.orgRoleNames(user.organizationId), result.roles)
+        assertEquals(user.organizationId, result.organizationId)
         assertNotNull(result.accessToken)
         assertNotNull(result.expiresAt)
 


### PR DESCRIPTION
## Summary
- Add `organizationId` to `SessionToken` for org-scoped sessions (nullable for legacy compat)
- Add `organizationId` to `AuthResponse` so clients know the active org
- Login and refresh now scope roles/permissions to the active org + system roles only
- `TokenAuthenticationFilter` filters authorities by session's org context, stores session in `authentication.details`
- New endpoints:
  - `GET /api/auth/organizations` — list all orgs the user belongs to with active indicator
  - `POST /api/auth/organizations/switch` — switch active org, returns new token pair
- Switching validates user has a role assignment for the target org and that the org is active
- Old sessions remain valid with their original org context (no revocation on switch)
- Add `SwitchOrganizationRequest` and `UserOrganizationResponse` DTOs

## Test plan
- [x] 117/118 tests pass (1 pre-existing context-load failure)
- [x] ktlint passes
- [x] Login returns org-scoped roles and organizationId
- [x] Refresh carries forward org context from old session
- [x] Existing AuthController and AuthService tests updated

Closes #18