### PR TITLE
Staging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,10 @@ tasks.named<Jar>("jar") {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+    systemProperty("junit.jupiter.execution.parallel.enabled", "true")
+    systemProperty("junit.jupiter.execution.parallel.mode.default", "same_thread")
+    systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
 }
 
 ktlint {

--- a/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
@@ -4,14 +4,23 @@ import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
 import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.IndexOptions
+import com.mongodb.client.model.Indexes
+import org.bson.Document
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.data.mongodb.MongoDatabaseFactory
 import org.springframework.data.mongodb.MongoTransactionManager
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration
 import org.springframework.data.mongodb.config.EnableMongoAuditing
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.stereotype.Component
 
 @Configuration
 @EnableMongoAuditing
@@ -20,6 +29,8 @@ class MongoConfig : AbstractMongoClientConfiguration() {
 
     @Value("\${spring.data.mongodb.uri}")
     private lateinit var mongoUri: String
+
+    override fun autoIndexCreation(): Boolean = true
 
     override fun getDatabaseName(): String {
         val connectionString = ConnectionString(mongoUri)
@@ -50,5 +61,28 @@ class MongoConfig : AbstractMongoClientConfiguration() {
         )
 
         return MongoClients.create(settings)
+    }
+}
+
+@Component
+@Order(0)
+class MongoIndexInitializer(
+    private val mongoTemplate: MongoTemplate,
+) : ApplicationRunner {
+    private val log = LoggerFactory.getLogger(MongoIndexInitializer::class.java)
+
+    override fun run(args: ApplicationArguments) {
+        val collection = mongoTemplate.getCollection("invitations")
+        collection.createIndex(
+            Indexes.compoundIndex(
+                Document("email", 1),
+                Document("organizationId", 1),
+            ),
+            IndexOptions()
+                .unique(true)
+                .partialFilterExpression(Filters.eq("status", "PENDING"))
+                .name("unique_pending_invitation_per_email_org"),
+        )
+        log.info("Ensured partial unique index on invitations(email, organizationId) where status=PENDING")
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -42,6 +42,8 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_READ,
                             Permissions.ORGANIZATION_WRITE,
                             Permissions.ORGANIZATION_DELETE,
+                            Permissions.INVITATION_READ,
+                            Permissions.INVITATION_WRITE,
                         ),
                 ),
                 Role(
@@ -56,6 +58,8 @@ class RoleSeeder(
                             Permissions.USER_WRITE,
                             Permissions.ORGANIZATION_READ,
                             Permissions.ORGANIZATION_WRITE,
+                            Permissions.INVITATION_READ,
+                            Permissions.INVITATION_WRITE,
                         ),
                 ),
                 Role(
@@ -68,6 +72,7 @@ class RoleSeeder(
                             Permissions.SESSION_DELETE,
                             Permissions.USER_READ,
                             Permissions.ORGANIZATION_READ,
+                            Permissions.INVITATION_READ,
                         ),
                 ),
                 Role(

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -49,6 +49,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/auth/invitations").authenticated()
                 it.requestMatchers(HttpMethod.GET, "/auth/invitations").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/auth/invitations/*").authenticated()
+                it.requestMatchers("/auth/organizations", "/auth/organizations/**").authenticated()
                 it.requestMatchers("/auth/**").permitAll()
                 it.requestMatchers("/health/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.froilan.synectix.security.SynectixPermissionEvaluator
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -45,6 +46,9 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 it.requestMatchers("/auth/change-password").authenticated()
                 it.requestMatchers("/auth/sessions", "/auth/sessions/**").authenticated()
+                it.requestMatchers(HttpMethod.POST, "/auth/invitations").authenticated()
+                it.requestMatchers(HttpMethod.GET, "/auth/invitations").authenticated()
+                it.requestMatchers(HttpMethod.DELETE, "/auth/invitations/*").authenticated()
                 it.requestMatchers("/auth/**").permitAll()
                 it.requestMatchers("/health/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -3,6 +3,7 @@ package com.froilan.synectix.config
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -36,14 +37,28 @@ class TokenAuthenticationFilter(
                     val userOpt = userRepository.findById(sessionToken.userId)
                     if (userOpt.isPresent && userOpt.get().isActive) {
                         val user = userOpt.get()
-                        val roleAuthorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+                        val activeOrgId = sessionToken.organizationId ?: user.organizationId
+                        val activeRoleAssignments =
+                            user.roleAssignments.filter {
+                                it.organizationId == activeOrgId || it.organizationId == null
+                            }
+                        val roleAuthorities =
+                            activeRoleAssignments
+                                .map { it.role }
+                                .distinct()
+                                .map { SimpleGrantedAuthority("ROLE_$it") }
                         val permissionAuthorities =
-                            user.roleAssignments
+                            activeRoleAssignments
                                 .flatMap { rolePermissionCache.getPermissions(it.role) }
                                 .distinct()
                                 .map { SimpleGrantedAuthority(it) }
                         val authorities = roleAuthorities + permissionAuthorities
                         val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
+                        authentication.details =
+                            SessionContext(
+                                sessionId = sessionToken.id,
+                                organizationId = activeOrgId,
+                            )
                         SecurityContextHolder.getContext().authentication = authentication
                     }
                 } else {

--- a/src/main/kotlin/com/froilan/synectix/controller/AuthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AuthController.kt
@@ -8,7 +8,9 @@ import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RefreshRequest
 import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.dto.ResetPasswordRequest
+import com.froilan.synectix.dto.SwitchOrganizationRequest
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.AuthService
 import com.github.benmanes.caffeine.cache.Caffeine
 import jakarta.servlet.http.HttpServletRequest
@@ -17,6 +19,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -171,6 +174,50 @@ class AuthController(
         } catch (e: IllegalArgumentException) {
             ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Password reset failed")))
         }
+
+    @GetMapping("/organizations")
+    fun listOrganizations(): ResponseEntity<Any> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val user =
+            authentication?.principal as? User
+                ?: return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(mapOf("error" to "Authentication required"))
+        val sessionContext =
+            authentication.details as? SessionContext
+                ?: return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(mapOf("error" to "Authentication required"))
+
+        val orgs = authService.listUserOrganizations(user, sessionContext.organizationId)
+        return ResponseEntity.ok(orgs)
+    }
+
+    @PostMapping("/organizations/switch")
+    fun switchOrganization(
+        @Valid @RequestBody request: SwitchOrganizationRequest,
+        httpRequest: HttpServletRequest,
+    ): ResponseEntity<Any> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val user =
+            authentication?.principal as? User
+                ?: return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(mapOf("error" to "Authentication required"))
+
+        return try {
+            val response =
+                authService.switchOrganization(
+                    user = user,
+                    targetOrgId = request.organizationId,
+                    ipAddress = httpRequest.remoteAddr?.take(MAX_IP_LENGTH),
+                    userAgent = httpRequest.getHeader("User-Agent")?.take(MAX_USER_AGENT_LENGTH),
+                )
+            ResponseEntity.ok(response)
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Organization switch failed")))
+        }
+    }
 
     @PostMapping("/logout")
     fun logout(

--- a/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
@@ -7,6 +7,7 @@ import com.froilan.synectix.dto.CreateInvitationRequest
 import com.froilan.synectix.dto.InvitationResponse
 import com.froilan.synectix.dto.ValidateInvitationRequest
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.InvitationService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -32,10 +33,10 @@ class InvitationController(
     fun createInvitation(
         @Valid @RequestBody request: CreateInvitationRequest,
     ): ResponseEntity<Any> {
-        val user = extractUser() ?: return unauthorized()
+        val (user, sessionContext) = extractUserAndContext() ?: return unauthorized()
 
         return try {
-            val token = invitationService.invite(request, user)
+            val token = invitationService.invite(request, user, sessionContext.organizationId)
             ResponseEntity.status(HttpStatus.CREATED).body(
                 mapOf("message" to "Invitation created", "token" to token),
             )
@@ -47,10 +48,10 @@ class InvitationController(
     @GetMapping
     @PreAuthorize("hasAuthority('invitation:read')")
     fun listInvitations(): ResponseEntity<Any> {
-        val user = extractUser() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
 
         val invitations =
-            invitationService.listInvitations(user.organizationId).map { invitation ->
+            invitationService.listInvitations(sessionContext.organizationId).map { invitation ->
                 InvitationResponse(
                     id = invitation.id,
                     email = invitation.email,
@@ -91,19 +92,21 @@ class InvitationController(
     fun revokeInvitation(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val user = extractUser() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
 
         return try {
-            invitationService.revokeInvitation(id, user)
+            invitationService.revokeInvitation(id, sessionContext.organizationId)
             ResponseEntity.ok(mapOf("message" to "Invitation revoked"))
         } catch (e: IllegalArgumentException) {
             ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation operation")))
         }
     }
 
-    private fun extractUser(): User? {
+    private fun extractUserAndContext(): Pair<User, SessionContext>? {
         val authentication = SecurityContextHolder.getContext().authentication
-        return authentication?.principal as? User
+        val user = authentication?.principal as? User ?: return null
+        val sessionContext = authentication.details as? SessionContext ?: return null
+        return user to sessionContext
     }
 
     private fun unauthorized(): ResponseEntity<Any> =

--- a/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
@@ -1,0 +1,113 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.AcceptInvitationRequest
+import com.froilan.synectix.dto.CreateInvitationRequest
+import com.froilan.synectix.dto.InvitationResponse
+import com.froilan.synectix.dto.ValidateInvitationRequest
+import com.froilan.synectix.model.User
+import com.froilan.synectix.service.InvitationService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth/invitations")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class InvitationController(
+    private val invitationService: InvitationService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('invitation:write')")
+    fun createInvitation(
+        @Valid @RequestBody request: CreateInvitationRequest,
+    ): ResponseEntity<Any> {
+        val user = extractUser() ?: return unauthorized()
+
+        return try {
+            val token = invitationService.invite(request, user)
+            ResponseEntity.status(HttpStatus.CREATED).body(
+                mapOf("message" to "Invitation created", "token" to token),
+            )
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation request")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('invitation:read')")
+    fun listInvitations(): ResponseEntity<Any> {
+        val user = extractUser() ?: return unauthorized()
+
+        val invitations =
+            invitationService.listInvitations(user.organizationId).map { invitation ->
+                InvitationResponse(
+                    id = invitation.id,
+                    email = invitation.email,
+                    role = invitation.role,
+                    status = invitation.status.name,
+                    invitedBy = invitation.invitedBy,
+                    expiresAt = invitation.expiryAt.toString(),
+                    createdAt = invitation.createdAt?.toString(),
+                )
+            }
+        return ResponseEntity.ok(invitations)
+    }
+
+    @PostMapping("/validate")
+    fun validateInvitation(
+        @Valid @RequestBody request: ValidateInvitationRequest,
+    ): ResponseEntity<Any> =
+        try {
+            val result = invitationService.validateInvitation(request.token)
+            ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation token")))
+        }
+
+    @PostMapping("/accept")
+    fun acceptInvitation(
+        @Valid @RequestBody request: AcceptInvitationRequest,
+    ): ResponseEntity<Any> =
+        try {
+            invitationService.acceptInvitation(request)
+            ResponseEntity.ok(mapOf("message" to "Invitation accepted successfully"))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation token")))
+        }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('invitation:write')")
+    fun revokeInvitation(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val user = extractUser() ?: return unauthorized()
+
+        return try {
+            invitationService.revokeInvitation(id, user)
+            ResponseEntity.ok(mapOf("message" to "Invitation revoked"))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation operation")))
+        }
+    }
+
+    private fun extractUser(): User? {
+        val authentication = SecurityContextHolder.getContext().authentication
+        return authentication?.principal as? User
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/AuthDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/AuthDtos.kt
@@ -83,6 +83,21 @@ data class AuthResponse(
     val refreshToken: String,
     val username: String,
     val roles: List<String>,
+    val organizationId: String,
     val expiresAt: String,
     val refreshTokenExpiresAt: String,
+)
+
+data class SwitchOrganizationRequest(
+    @field:NotBlank(message = "Organization ID is required")
+    val organizationId: String,
+)
+
+data class UserOrganizationResponse(
+    val organizationId: String,
+    val name: String,
+    val orgSlug: String,
+    val roles: List<String>,
+    val isCurrent: Boolean,
+    val isActive: Boolean,
 )

--- a/src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt
@@ -1,0 +1,46 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateInvitationRequest(
+    @field:NotBlank(message = "Email is required")
+    @field:Email(message = "Email must be valid")
+    val email: String,
+    @field:NotBlank(message = "Role is required")
+    val role: String,
+)
+
+data class AcceptInvitationRequest(
+    @field:NotBlank(message = "Invitation token is required")
+    val token: String,
+    @field:Size(min = 3, max = 50, message = "Username must be between 3 and 50 characters")
+    val username: String? = null,
+    @field:Size(min = 8, message = "Password must be at least 8 characters")
+    val password: String? = null,
+    val firstName: String? = null,
+    val lastName: String? = null,
+)
+
+data class ValidateInvitationRequest(
+    @field:NotBlank(message = "Invitation token is required")
+    val token: String,
+)
+
+data class ValidateInvitationResponse(
+    val email: String,
+    val role: String,
+    val organizationId: String,
+    val existingUser: Boolean,
+)
+
+data class InvitationResponse(
+    val id: String,
+    val email: String,
+    val role: String,
+    val status: String,
+    val invitedBy: String,
+    val expiresAt: String,
+    val createdAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Invitation.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Invitation.kt
@@ -1,0 +1,33 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class InvitationStatus {
+    PENDING,
+    ACCEPTED,
+    EXPIRED,
+    REVOKED,
+}
+
+@Document(collection = "invitations")
+data class Invitation(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    @Indexed
+    val email: String,
+    val organizationId: String,
+    val role: String,
+    @Indexed(unique = true)
+    val tokenHash: String,
+    val invitedBy: String,
+    val status: InvitationStatus = InvitationStatus.PENDING,
+    @Indexed(expireAfterSeconds = 0)
+    val expiryAt: LocalDateTime,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/SessionToken.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/SessionToken.kt
@@ -13,6 +13,7 @@ data class SessionToken(
     @Indexed(unique = true)
     val token: String,
     val userId: String,
+    val organizationId: String? = null,
     @Indexed(expireAfterSeconds = 0)
     val expiryAt: LocalDateTime,
     val ipAddress: String? = null,

--- a/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt
@@ -1,0 +1,32 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Invitation
+import com.froilan.synectix.model.InvitationStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.util.Optional
+
+@Repository
+interface InvitationRepository : MongoRepository<Invitation, String> {
+    fun findByTokenHash(tokenHash: String): Optional<Invitation>
+
+    fun findByOrganizationIdAndStatusAndExpiryAtAfter(
+        organizationId: String,
+        status: InvitationStatus,
+        expiryAt: LocalDateTime,
+    ): List<Invitation>
+
+    fun findByEmailAndOrganizationIdAndStatusAndExpiryAtAfter(
+        email: String,
+        organizationId: String,
+        status: InvitationStatus,
+        expiryAt: LocalDateTime,
+    ): Optional<Invitation>
+
+    fun findByEmailAndOrganizationIdAndStatus(
+        email: String,
+        organizationId: String,
+        status: InvitationStatus,
+    ): Optional<Invitation>
+}

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -13,4 +13,7 @@ object Permissions {
     const val ORGANIZATION_DELETE = "organization:delete"
 
     const val ENVIRONMENT_READ = "environment:read"
+
+    const val INVITATION_READ = "invitation:read"
+    const val INVITATION_WRITE = "invitation:write"
 }

--- a/src/main/kotlin/com/froilan/synectix/security/SessionContext.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/SessionContext.kt
@@ -1,0 +1,6 @@
+package com.froilan.synectix.security
+
+data class SessionContext(
+    val sessionId: String,
+    val organizationId: String,
+)

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -24,10 +24,8 @@ import org.springframework.data.mongodb.core.query.Query
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.security.SecureRandom
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
-import java.util.Base64
 import java.util.Locale
 
 @Service
@@ -47,8 +45,6 @@ class AuthService(
     @Value("\${security.password-reset.expiration-minutes:60}")
     private val resetTokenExpiryMinutes: Long,
 ) {
-    private val secureRandom = SecureRandom()
-
     @Transactional
     fun register(request: RegisterRequest): User {
         try {
@@ -340,9 +336,5 @@ class AuthService(
         }
     }
 
-    private fun generateToken(): String {
-        val bytes = ByteArray(32)
-        secureRandom.nextBytes(bytes)
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
-    }
+    private fun generateToken(): String = tokenHasher.generate()
 }

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -89,7 +89,7 @@ class AuthService(
                 errorMessage.contains("name", ignoreCase = true) ->
                     throw IllegalArgumentException("Organization name already exists")
                 else ->
-                    throw IllegalArgumentException("Duplicate entry: ${e.message}")
+                    throw IllegalArgumentException("Registration failed due to a conflict")
             }
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -3,13 +3,15 @@ package com.froilan.synectix.service
 import com.froilan.synectix.dto.AuthResponse
 import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RegisterRequest
+import com.froilan.synectix.dto.UserOrganizationResponse
 import com.froilan.synectix.model.Organizations
 import com.froilan.synectix.model.PasswordResetToken
 import com.froilan.synectix.model.RefreshToken
 import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
-import com.froilan.synectix.model.effectiveRoleNames
+import com.froilan.synectix.model.orgRoleNames
+import com.froilan.synectix.model.systemRoleNames
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
@@ -114,11 +116,13 @@ class AuthService(
         val accessTokenStr = generateToken()
         val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
 
+        val orgId = user.organizationId
         val sessionToken =
             SessionToken(
                 token = accessTokenStr,
                 expiryAt = expiryAt,
                 userId = user.uuid,
+                organizationId = orgId,
                 ipAddress = ipAddress,
                 userAgent = userAgent,
             )
@@ -136,11 +140,13 @@ class AuthService(
             )
         refreshTokenRepository.save(refreshToken)
 
+        val roles = (user.orgRoleNames(orgId) + user.systemRoleNames()).distinct()
         return AuthResponse(
             accessToken = accessTokenStr,
             refreshToken = refreshTokenStr,
             username = user.username,
-            roles = user.effectiveRoleNames(),
+            roles = roles,
+            organizationId = orgId,
             expiresAt = expiryAt.toString(),
             refreshTokenExpiresAt = refreshExpiryAt.toString(),
         )
@@ -167,6 +173,9 @@ class AuthService(
             throw IllegalArgumentException("User account is inactive")
         }
 
+        val oldSession = sessionTokenRepository.findById(existing.sessionTokenId).orElse(null)
+        val orgId = oldSession?.organizationId ?: user.organizationId
+
         val accessTokenStr = generateToken()
         val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
 
@@ -175,6 +184,7 @@ class AuthService(
                 token = accessTokenStr,
                 expiryAt = expiryAt,
                 userId = user.uuid,
+                organizationId = orgId,
             )
         val savedSession = sessionTokenRepository.save(sessionToken)
 
@@ -204,11 +214,13 @@ class AuthService(
 
         sessionTokenRepository.deleteById(existing.sessionTokenId)
 
+        val roles = (user.orgRoleNames(orgId) + user.systemRoleNames()).distinct()
         return AuthResponse(
             accessToken = accessTokenStr,
             refreshToken = refreshTokenStr,
             username = user.username,
-            roles = user.effectiveRoleNames(),
+            roles = roles,
+            organizationId = orgId,
             expiresAt = expiryAt.toString(),
             refreshTokenExpiresAt = refreshExpiryAt.toString(),
         )
@@ -325,6 +337,91 @@ class AuthService(
         val sessionIds = otherSessions.map { it.id }
         refreshTokenRepository.deleteBySessionTokenIdIn(sessionIds)
         sessionTokenRepository.deleteAllById(sessionIds)
+    }
+
+    @Transactional
+    fun switchOrganization(
+        user: User,
+        targetOrgId: String,
+        ipAddress: String? = null,
+        userAgent: String? = null,
+    ): AuthResponse {
+        val orgRoles = user.orgRoleNames(targetOrgId)
+        if (orgRoles.isEmpty()) {
+            throw IllegalArgumentException("You do not have access to this organization")
+        }
+
+        val org =
+            organizationRepository.findById(targetOrgId).orElseThrow {
+                IllegalArgumentException("Organization not found")
+            }
+        if (!org.isActive) {
+            throw IllegalArgumentException("Organization is not active")
+        }
+
+        val accessTokenStr = generateToken()
+        val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
+
+        val sessionToken =
+            SessionToken(
+                token = accessTokenStr,
+                expiryAt = expiryAt,
+                userId = user.uuid,
+                organizationId = targetOrgId,
+                ipAddress = ipAddress,
+                userAgent = userAgent,
+            )
+        val savedSession = sessionTokenRepository.save(sessionToken)
+
+        val refreshTokenStr = generateToken()
+        val refreshExpiryAt = LocalDateTime.now().plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+
+        val refreshToken =
+            RefreshToken(
+                tokenHash = tokenHasher.hash(refreshTokenStr),
+                userId = user.uuid,
+                sessionTokenId = savedSession.id,
+                expiryAt = refreshExpiryAt,
+            )
+        refreshTokenRepository.save(refreshToken)
+
+        val roles = (orgRoles + user.systemRoleNames()).distinct()
+        return AuthResponse(
+            accessToken = accessTokenStr,
+            refreshToken = refreshTokenStr,
+            username = user.username,
+            roles = roles,
+            organizationId = targetOrgId,
+            expiresAt = expiryAt.toString(),
+            refreshTokenExpiresAt = refreshExpiryAt.toString(),
+        )
+    }
+
+    fun listUserOrganizations(
+        user: User,
+        currentOrgId: String,
+    ): List<UserOrganizationResponse> {
+        val orgIds =
+            user.roleAssignments
+                .mapNotNull { it.organizationId }
+                .distinct()
+
+        val orgsById =
+            organizationRepository
+                .findAllById(orgIds)
+                .associateBy { it.uuid }
+
+        return orgIds.map { orgId ->
+            val org = orgsById[orgId]
+            UserOrganizationResponse(
+                organizationId = orgId,
+                name = org?.name ?: "Unknown",
+                orgSlug = org?.orgSlug ?: "unknown",
+                roles = user.orgRoleNames(orgId).distinct(),
+                isCurrent = orgId == currentOrgId,
+                isActive = org?.isActive ?: false,
+            )
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -40,6 +40,7 @@ class InvitationService(
     fun invite(
         request: CreateInvitationRequest,
         inviter: User,
+        activeOrgId: String,
     ): String {
         val normalizedEmail = request.email.lowercase(Locale.ROOT)
 
@@ -54,7 +55,7 @@ class InvitationService(
         val existing =
             invitationRepository.findByEmailAndOrganizationIdAndStatus(
                 normalizedEmail,
-                inviter.organizationId,
+                activeOrgId,
                 InvitationStatus.PENDING,
             )
         if (existing.isPresent) {
@@ -69,7 +70,7 @@ class InvitationService(
         val invitation =
             Invitation(
                 email = normalizedEmail,
-                organizationId = inviter.organizationId,
+                organizationId = activeOrgId,
                 role = role.name,
                 tokenHash = tokenHasher.hash(rawToken),
                 invitedBy = inviter.uuid,
@@ -178,7 +179,7 @@ class InvitationService(
                 errorMessage.contains("email", ignoreCase = true) ->
                     throw IllegalArgumentException("Email already exists")
                 else ->
-                    throw IllegalArgumentException("Duplicate entry: ${e.message}")
+                    throw IllegalArgumentException("Account could not be created")
             }
         }
     }
@@ -186,13 +187,13 @@ class InvitationService(
     @Transactional
     fun revokeInvitation(
         invitationId: String,
-        user: User,
+        activeOrgId: String,
     ) {
         val invitation =
             invitationRepository.findById(invitationId).orElseThrow {
                 IllegalArgumentException("Invitation not found")
             }
-        if (invitation.organizationId != user.organizationId) {
+        if (invitation.organizationId != activeOrgId) {
             throw IllegalArgumentException("Invitation not found")
         }
         if (invitation.status != InvitationStatus.PENDING) {

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -1,0 +1,210 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AcceptInvitationRequest
+import com.froilan.synectix.dto.CreateInvitationRequest
+import com.froilan.synectix.dto.ValidateInvitationResponse
+import com.froilan.synectix.model.Invitation
+import com.froilan.synectix.model.InvitationStatus
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.RoleRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.util.TokenHasher
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.data.mongodb.core.FindAndModifyOptions
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.Locale
+
+@Service
+class InvitationService(
+    private val invitationRepository: InvitationRepository,
+    private val userRepository: UserRepository,
+    private val roleRepository: RoleRepository,
+    private val mongoTemplate: MongoTemplate,
+    private val tokenHasher: TokenHasher,
+    private val passwordEncoder: PasswordEncoder,
+    @Value("\${security.invitation.expiration-hours:72}")
+    private val invitationExpiryHours: Long,
+) {
+    @Transactional
+    fun invite(
+        request: CreateInvitationRequest,
+        inviter: User,
+    ): String {
+        val normalizedEmail = request.email.lowercase(Locale.ROOT)
+
+        val role =
+            roleRepository.findByName(request.role).orElseThrow {
+                IllegalArgumentException("Role '${request.role}' does not exist")
+            }
+        if (role.level != RoleLevel.ORGANIZATION) {
+            throw IllegalArgumentException("Cannot invite with system-level role")
+        }
+
+        val existing =
+            invitationRepository.findByEmailAndOrganizationIdAndStatus(
+                normalizedEmail,
+                inviter.organizationId,
+                InvitationStatus.PENDING,
+            )
+        if (existing.isPresent) {
+            val pendingInvitation = existing.get()
+            if (pendingInvitation.expiryAt.isAfter(LocalDateTime.now())) {
+                throw IllegalArgumentException("An invitation has already been sent to this email")
+            }
+            invitationRepository.save(pendingInvitation.copy(status = InvitationStatus.EXPIRED))
+        }
+
+        val rawToken = tokenHasher.generate()
+        val invitation =
+            Invitation(
+                email = normalizedEmail,
+                organizationId = inviter.organizationId,
+                role = role.name,
+                tokenHash = tokenHasher.hash(rawToken),
+                invitedBy = inviter.uuid,
+                expiryAt = LocalDateTime.now().plusHours(invitationExpiryHours),
+            )
+        try {
+            invitationRepository.save(invitation)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException("An invitation has already been sent to this email")
+        }
+
+        return rawToken
+    }
+
+    fun validateInvitation(token: String): ValidateInvitationResponse {
+        val tokenHash = tokenHasher.hash(token)
+        val invitation =
+            invitationRepository.findByTokenHash(tokenHash).orElseThrow {
+                IllegalArgumentException("Invalid or expired invitation token")
+            }
+        if (invitation.status != InvitationStatus.PENDING || !invitation.expiryAt.isAfter(LocalDateTime.now())) {
+            throw IllegalArgumentException("Invalid or expired invitation token")
+        }
+        val existingUser = userRepository.findByEmail(invitation.email).isPresent
+        return ValidateInvitationResponse(
+            email = invitation.email,
+            role = invitation.role,
+            organizationId = invitation.organizationId,
+            existingUser = existingUser,
+        )
+    }
+
+    @Transactional
+    fun acceptInvitation(request: AcceptInvitationRequest): User {
+        val tokenHash = tokenHasher.hash(request.token)
+
+        val accepted =
+            mongoTemplate.findAndModify(
+                Query.query(
+                    Criteria
+                        .where("tokenHash")
+                        .`is`(tokenHash)
+                        .and("status")
+                        .`is`(InvitationStatus.PENDING)
+                        .and("expiryAt")
+                        .gt(LocalDateTime.now()),
+                ),
+                Update.update("status", InvitationStatus.ACCEPTED),
+                FindAndModifyOptions.options().returnNew(true),
+                Invitation::class.java,
+            ) ?: throw IllegalArgumentException("Invalid or expired invitation token")
+
+        val existingUser = userRepository.findByEmail(accepted.email)
+        if (existingUser.isPresent) {
+            val user = existingUser.get()
+            val alreadyHasRole =
+                user.roleAssignments.any {
+                    it.role == accepted.role && it.organizationId == accepted.organizationId
+                }
+            if (alreadyHasRole) {
+                return user
+            }
+            val updatedUser =
+                user.copy(
+                    roleAssignments =
+                        user.roleAssignments +
+                            RoleAssignment(
+                                role = accepted.role,
+                                organizationId = accepted.organizationId,
+                            ),
+                )
+            return userRepository.save(updatedUser)
+        }
+
+        if (request.username.isNullOrBlank() ||
+            request.password.isNullOrBlank() ||
+            request.firstName.isNullOrBlank() ||
+            request.lastName.isNullOrBlank()
+        ) {
+            throw IllegalArgumentException("Username, password, first name, and last name are required for new users")
+        }
+
+        val newUser =
+            User(
+                username = request.username,
+                email = accepted.email,
+                firstName = request.firstName,
+                lastName = request.lastName,
+                passwordHash = passwordEncoder.encode(request.password) as String,
+                organizationId = accepted.organizationId,
+                roleAssignments =
+                    listOf(
+                        RoleAssignment(
+                            role = accepted.role,
+                            organizationId = accepted.organizationId,
+                        ),
+                    ),
+            )
+        return try {
+            userRepository.save(newUser)
+        } catch (e: DuplicateKeyException) {
+            val errorMessage = e.message ?: ""
+            when {
+                errorMessage.contains("username", ignoreCase = true) ->
+                    throw IllegalArgumentException("Username already exists")
+                errorMessage.contains("email", ignoreCase = true) ->
+                    throw IllegalArgumentException("Email already exists")
+                else ->
+                    throw IllegalArgumentException("Duplicate entry: ${e.message}")
+            }
+        }
+    }
+
+    @Transactional
+    fun revokeInvitation(
+        invitationId: String,
+        user: User,
+    ) {
+        val invitation =
+            invitationRepository.findById(invitationId).orElseThrow {
+                IllegalArgumentException("Invitation not found")
+            }
+        if (invitation.organizationId != user.organizationId) {
+            throw IllegalArgumentException("Invitation not found")
+        }
+        if (invitation.status != InvitationStatus.PENDING) {
+            throw IllegalArgumentException("Invitation is not pending")
+        }
+        invitationRepository.save(invitation.copy(status = InvitationStatus.REVOKED))
+    }
+
+    fun listInvitations(organizationId: String): List<Invitation> =
+        invitationRepository.findByOrganizationIdAndStatusAndExpiryAtAfter(
+            organizationId,
+            InvitationStatus.PENDING,
+            LocalDateTime.now(),
+        )
+}

--- a/src/main/kotlin/com/froilan/synectix/util/TokenHasher.kt
+++ b/src/main/kotlin/com/froilan/synectix/util/TokenHasher.kt
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
+import java.security.SecureRandom
+import java.util.Base64
 import java.util.HexFormat
 
 @Component
@@ -23,6 +25,14 @@ class TokenHasher(
                 e,
             )
         }
+    }
+
+    private val secureRandom = SecureRandom()
+
+    fun generate(byteLength: Int = 32): String {
+        val bytes = ByteArray(byteLength)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
     }
 
     fun hash(token: String): String {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,8 @@ management.info.env.enabled=true
 security.jwt.secret=${JWT_SECRET}
 security.jwt.expiration=${JWT_EXPIRATION:86400000}
 security.jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION:2592000000}
+security.invitation.expiration-hours=${INVITATION_EXPIRATION_HOURS:72}
+security.password-reset.expiration-minutes=${PASSWORD_RESET_EXPIRATION_MINUTES:60}
 
 # Proxy / forwarded headers (set to "framework" when behind a reverse proxy)
 server.forward-headers-strategy=${FORWARD_HEADERS_STRATEGY:none}

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -63,6 +63,8 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
+                        Permissions.INVITATION_READ,
+                        Permissions.INVITATION_WRITE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -117,6 +119,8 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
+                        Permissions.INVITATION_READ,
+                        Permissions.INVITATION_WRITE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -198,6 +202,8 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.ORGANIZATION_DELETE,
+                        Permissions.INVITATION_READ,
+                        Permissions.INVITATION_WRITE,
                     ),
             )
         val admin =
@@ -213,6 +219,8 @@ class RoleSeederTest {
                         Permissions.USER_WRITE,
                         Permissions.ORGANIZATION_READ,
                         Permissions.ORGANIZATION_WRITE,
+                        Permissions.INVITATION_READ,
+                        Permissions.INVITATION_WRITE,
                     ),
             )
         val member =
@@ -226,6 +234,7 @@ class RoleSeederTest {
                         Permissions.SESSION_DELETE,
                         Permissions.USER_READ,
                         Permissions.ORGANIZATION_READ,
+                        Permissions.INVITATION_READ,
                     ),
             )
         val viewer =

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -5,6 +5,8 @@ import com.froilan.synectix.config.TestSecurityConfig
 import com.froilan.synectix.dto.AuthResponse
 import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RegisterRequest
+import com.froilan.synectix.dto.UserOrganizationResponse
+import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.User
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
@@ -12,6 +14,7 @@ import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
@@ -25,10 +28,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -276,6 +283,7 @@ class AuthControllerTest {
                 refreshToken = "generated-refresh-token-123",
                 username = "testuser",
                 roles = listOf("OWNER"),
+                organizationId = "org-123",
                 expiresAt = LocalDateTime.now().plusHours(24).toString(),
                 refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
             )
@@ -389,6 +397,7 @@ class AuthControllerTest {
                 refreshToken = "new-refresh-token-789",
                 username = "testuser",
                 roles = listOf("OWNER"),
+                organizationId = "org-123",
                 expiresAt = LocalDateTime.now().plusHours(24).toString(),
                 refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
             )
@@ -620,5 +629,124 @@ class AuthControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestJson),
             ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET organizations should return org list for authenticated user`() {
+        val user =
+            User(
+                uuid = "user-123",
+                username = "testuser",
+                email = "test@example.com",
+                firstName = "Test",
+                lastName = "User",
+                passwordHash = "encoded",
+                organizationId = "org-123",
+                roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+            )
+        val session = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        setupAuth(user, session)
+
+        val orgs =
+            listOf(
+                UserOrganizationResponse(
+                    organizationId = "org-123",
+                    name = "Test Org",
+                    orgSlug = "test-org",
+                    roles = listOf("OWNER"),
+                    isCurrent = true,
+                    isActive = true,
+                ),
+            )
+        `when`(authService.listUserOrganizations(any(), any())).thenReturn(orgs)
+
+        mockMvc
+            .perform(get("/auth/organizations"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].organizationId").value("org-123"))
+            .andExpect(jsonPath("$[0].current").value(true))
+            .andExpect(jsonPath("$[0].active").value(true))
+    }
+
+    @Test
+    fun `POST organizations switch should return new token pair`() {
+        val user =
+            User(
+                uuid = "user-123",
+                username = "testuser",
+                email = "test@example.com",
+                firstName = "Test",
+                lastName = "User",
+                passwordHash = "encoded",
+                organizationId = "org-123",
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("OWNER", "org-123"),
+                        RoleAssignment("MEMBER", "org-456"),
+                    ),
+            )
+        val session = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        setupAuth(user, session)
+
+        val switchResponse =
+            AuthResponse(
+                accessToken = "new-token",
+                refreshToken = "new-refresh",
+                username = "testuser",
+                roles = listOf("MEMBER"),
+                organizationId = "org-456",
+                expiresAt = LocalDateTime.now().plusHours(24).toString(),
+                refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
+            )
+        `when`(authService.switchOrganization(any(), any(), anyOrNull(), anyOrNull())).thenReturn(switchResponse)
+
+        mockMvc
+            .perform(
+                post("/auth/organizations/switch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"organizationId": "org-456"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.organizationId").value("org-456"))
+            .andExpect(jsonPath("$.roles[0]").value("MEMBER"))
+            .andExpect(jsonPath("$.accessToken").value("new-token"))
+    }
+
+    @Test
+    fun `POST organizations switch should return 400 for unauthorized org`() {
+        val user =
+            User(
+                uuid = "user-123",
+                username = "testuser",
+                email = "test@example.com",
+                firstName = "Test",
+                lastName = "User",
+                passwordHash = "encoded",
+                organizationId = "org-123",
+                roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+            )
+        val session = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        setupAuth(user, session)
+
+        `when`(authService.switchOrganization(any(), any(), anyOrNull(), anyOrNull()))
+            .thenThrow(IllegalArgumentException("You do not have access to this organization"))
+
+        mockMvc
+            .perform(
+                post("/auth/organizations/switch")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"organizationId": "org-999"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("You do not have access to this organization"))
+    }
+
+    private fun setupAuth(
+        user: User,
+        session: SessionContext,
+    ) {
+        val authorities = user.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val authentication = UsernamePasswordAuthenticationToken(user, null, authorities)
+        authentication.details = session
+        SecurityContextHolder.getContext().authentication = authentication
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -1,0 +1,293 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.dto.ValidateInvitationResponse
+import com.froilan.synectix.model.Invitation
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.InvitationService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+@WebMvcTest(controllers = [InvitationController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class InvitationControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var invitationService: InvitationService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("invitation:read", "invitation:write")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    @Test
+    fun `POST invitations should return 201 when invitation is created`() {
+        `when`(invitationService.invite(any(), any())).thenReturn("raw-token-123")
+
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "newuser@example.com", "role": "MEMBER"}"""),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.message").value("Invitation created"))
+            .andExpect(jsonPath("$.token").value("raw-token-123"))
+    }
+
+    @Test
+    fun `POST invitations should return 400 when email is invalid`() {
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "not-an-email", "role": "MEMBER"}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST invitations should return 400 when role is blank`() {
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "user@example.com", "role": ""}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST invitations should return 400 when duplicate invitation exists`() {
+        `when`(invitationService.invite(any(), any()))
+            .thenThrow(IllegalArgumentException("An invitation has already been sent to this email"))
+
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "existing@example.com", "role": "MEMBER"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("An invitation has already been sent to this email"))
+    }
+
+    @Test
+    fun `GET invitations should return 200 with invitation list`() {
+        val invitations =
+            listOf(
+                Invitation(
+                    id = "inv-1",
+                    email = "user1@example.com",
+                    organizationId = "org-123",
+                    role = "MEMBER",
+                    tokenHash = "hash1",
+                    invitedBy = "user-123",
+                    expiryAt = LocalDateTime.now().plusHours(72),
+                ),
+            )
+        `when`(invitationService.listInvitations("org-123")).thenReturn(invitations)
+
+        mockMvc
+            .perform(get("/auth/invitations"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].email").value("user1@example.com"))
+            .andExpect(jsonPath("$[0].role").value("MEMBER"))
+            .andExpect(jsonPath("$[0].status").value("PENDING"))
+    }
+
+    @Test
+    fun `POST invitations validate should return invitation details`() {
+        val response =
+            ValidateInvitationResponse(
+                email = "invited@example.com",
+                role = "MEMBER",
+                organizationId = "org-123",
+                existingUser = false,
+            )
+        `when`(invitationService.validateInvitation(any())).thenReturn(response)
+
+        mockMvc
+            .perform(
+                post("/auth/invitations/validate")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"token": "valid-token"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.email").value("invited@example.com"))
+            .andExpect(jsonPath("$.role").value("MEMBER"))
+            .andExpect(jsonPath("$.existingUser").value(false))
+    }
+
+    @Test
+    fun `POST invitations validate should return 400 for invalid token`() {
+        `when`(invitationService.validateInvitation(any()))
+            .thenThrow(IllegalArgumentException("Invalid or expired invitation token"))
+
+        mockMvc
+            .perform(
+                post("/auth/invitations/validate")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"token": "bad-token"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invalid or expired invitation token"))
+    }
+
+    @Test
+    fun `POST invitations accept should return 200 when accepted`() {
+        `when`(invitationService.acceptInvitation(any())).thenReturn(testUser)
+
+        mockMvc
+            .perform(
+                post("/auth/invitations/accept")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "token": "valid-token",
+                            "username": "newuser",
+                            "password": "SecurePass123!",
+                            "firstName": "New",
+                            "lastName": "User"
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("Invitation accepted successfully"))
+    }
+
+    @Test
+    fun `POST invitations accept should return 400 with invalid token`() {
+        `when`(invitationService.acceptInvitation(any()))
+            .thenThrow(IllegalArgumentException("Invalid or expired invitation token"))
+
+        mockMvc
+            .perform(
+                post("/auth/invitations/accept")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "token": "invalid",
+                            "username": "newuser",
+                            "password": "SecurePass123!",
+                            "firstName": "New",
+                            "lastName": "User"
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invalid or expired invitation token"))
+    }
+
+    @Test
+    fun `DELETE invitation should return 200 when revoked`() {
+        mockMvc
+            .perform(delete("/auth/invitations/inv-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("Invitation revoked"))
+    }
+
+    @Test
+    fun `DELETE invitation should return 400 when not pending`() {
+        `when`(invitationService.revokeInvitation(any(), any()))
+            .thenThrow(IllegalArgumentException("Invitation is not pending"))
+
+        mockMvc
+            .perform(delete("/auth/invitations/inv-123"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invitation is not pending"))
+    }
+
+    @Test
+    fun `POST invitations should return 403 without invitation write permission`() {
+        setupAuthWithPermissions("invitation:read")
+
+        mockMvc
+            .perform(
+                post("/auth/invitations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"email": "user@example.com", "role": "MEMBER"}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GET invitations should return 403 without invitation read permission`() {
+        setupAuthWithPermissions()
+
+        mockMvc
+            .perform(get("/auth/invitations"))
+            .andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -13,6 +13,7 @@ import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.InvitationService
 import com.froilan.synectix.util.TokenHasher
@@ -92,12 +93,13 @@ class InvitationControllerTest {
         val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
         val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
         val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
         SecurityContextHolder.getContext().authentication = authentication
     }
 
     @Test
     fun `POST invitations should return 201 when invitation is created`() {
-        `when`(invitationService.invite(any(), any())).thenReturn("raw-token-123")
+        `when`(invitationService.invite(any(), any(), any())).thenReturn("raw-token-123")
 
         mockMvc
             .perform(
@@ -131,7 +133,7 @@ class InvitationControllerTest {
 
     @Test
     fun `POST invitations should return 400 when duplicate invitation exists`() {
-        `when`(invitationService.invite(any(), any()))
+        `when`(invitationService.invite(any(), any(), any()))
             .thenThrow(IllegalArgumentException("An invitation has already been sent to this email"))
 
         mockMvc

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -31,6 +31,7 @@ import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
+import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
@@ -59,6 +60,7 @@ class AuthServiceTest {
         passwordEncoder = mock(PasswordEncoder::class.java)
 
         `when`(tokenHasher.hash(any())).thenAnswer { "hashed-${it.arguments[0]}" }
+        `when`(tokenHasher.generate(any())).thenAnswer { UUID.randomUUID().toString() }
 
         authService =
             AuthService(

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -8,7 +8,7 @@ import com.froilan.synectix.model.RefreshToken
 import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
-import com.froilan.synectix.model.effectiveRoleNames
+import com.froilan.synectix.model.orgRoleNames
 import com.froilan.synectix.repository.OrganizationRepository
 import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
@@ -33,6 +33,7 @@ import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -229,7 +230,8 @@ class AuthServiceTest {
 
         assertNotNull(result)
         assertEquals(user.username, result.username)
-        assertEquals(user.effectiveRoleNames(), result.roles)
+        assertEquals(user.orgRoleNames(user.organizationId), result.roles)
+        assertEquals(user.organizationId, result.organizationId)
         assertNotNull(result.accessToken)
         assertNotNull(result.expiresAt)
 
@@ -672,6 +674,137 @@ class AuthServiceTest {
             orgLegalName = "Test Organization LLC",
             orgTradeName = "Test Org",
         )
+
+    @Test
+    fun `switchOrganization should return new token pair scoped to target org`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("OWNER", "org-123"),
+                        RoleAssignment("MEMBER", "org-456"),
+                    ),
+            )
+        val targetOrg = createMockOrganization().copy(uuid = "org-456")
+
+        `when`(organizationRepository.findById("org-456")).thenReturn(Optional.of(targetOrg))
+        `when`(sessionTokenRepository.save(any<SessionToken>())).thenAnswer { it.arguments[0] }
+        `when`(refreshTokenRepository.save(any<RefreshToken>())).thenAnswer { it.arguments[0] }
+
+        val result = authService.switchOrganization(user, "org-456")
+
+        assertEquals("org-456", result.organizationId)
+        assertEquals(listOf("MEMBER"), result.roles)
+        assertNotNull(result.accessToken)
+        assertNotNull(result.refreshToken)
+
+        val sessionCaptor = argumentCaptor<SessionToken>()
+        verify(sessionTokenRepository).save(sessionCaptor.capture())
+        assertEquals("org-456", sessionCaptor.firstValue.organizationId)
+    }
+
+    @Test
+    fun `switchOrganization should throw when user has no role in target org`() {
+        val user = createMockUser()
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                authService.switchOrganization(user, "org-999")
+            }
+        assertEquals("You do not have access to this organization", exception.message)
+    }
+
+    @Test
+    fun `switchOrganization should throw when org not found`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("MEMBER", "org-123"),
+                        RoleAssignment("MEMBER", "org-missing"),
+                    ),
+            )
+
+        `when`(organizationRepository.findById("org-missing")).thenReturn(Optional.empty())
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                authService.switchOrganization(user, "org-missing")
+            }
+        assertEquals("Organization not found", exception.message)
+    }
+
+    @Test
+    fun `switchOrganization should throw when org is inactive`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("MEMBER", "org-123"),
+                        RoleAssignment("MEMBER", "org-inactive"),
+                    ),
+            )
+        val inactiveOrg = createMockOrganization().copy(uuid = "org-inactive", isActive = false)
+
+        `when`(organizationRepository.findById("org-inactive")).thenReturn(Optional.of(inactiveOrg))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                authService.switchOrganization(user, "org-inactive")
+            }
+        assertEquals("Organization is not active", exception.message)
+    }
+
+    @Test
+    fun `listUserOrganizations should return orgs with current indicator`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("OWNER", "org-123"),
+                        RoleAssignment("MEMBER", "org-456"),
+                    ),
+            )
+        val org1 = createMockOrganization().copy(uuid = "org-123", name = "Org One", orgSlug = "org-one")
+        val org2 = createMockOrganization().copy(uuid = "org-456", name = "Org Two", orgSlug = "org-two")
+
+        `when`(organizationRepository.findAllById(listOf("org-123", "org-456"))).thenReturn(listOf(org1, org2))
+
+        val result = authService.listUserOrganizations(user, "org-123")
+
+        assertEquals(2, result.size)
+        val current = result.first { it.isCurrent }
+        assertEquals("org-123", current.organizationId)
+        assertEquals(listOf("OWNER"), current.roles)
+
+        val other = result.first { !it.isCurrent }
+        assertEquals("org-456", other.organizationId)
+        assertEquals(listOf("MEMBER"), other.roles)
+    }
+
+    @Test
+    fun `listUserOrganizations should include inactive orgs with isActive false`() {
+        val user =
+            createMockUser().copy(
+                roleAssignments =
+                    listOf(
+                        RoleAssignment("OWNER", "org-123"),
+                        RoleAssignment("MEMBER", "org-inactive"),
+                    ),
+            )
+        val activeOrg = createMockOrganization().copy(uuid = "org-123")
+        val inactiveOrg = createMockOrganization().copy(uuid = "org-inactive", isActive = false)
+
+        `when`(organizationRepository.findAllById(listOf("org-123", "org-inactive"))).thenReturn(listOf(activeOrg, inactiveOrg))
+
+        val result = authService.listUserOrganizations(user, "org-123")
+
+        assertEquals(2, result.size)
+        val active = result.first { it.organizationId == "org-123" }
+        assertTrue(active.isActive)
+        val inactive = result.first { it.organizationId == "org-inactive" }
+        assertFalse(inactive.isActive)
+    }
 
     private fun createMockOrganization() =
         Organizations(

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -77,7 +77,7 @@ class InvitationServiceTest {
             .thenReturn(Optional.empty())
         `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
 
-        val token = invitationService.invite(request, inviter)
+        val token = invitationService.invite(request, inviter, inviter.organizationId)
 
         assertNotNull(token)
         assertTrue(token.isNotEmpty())
@@ -98,7 +98,7 @@ class InvitationServiceTest {
 
         `when`(roleRepository.findByName("NONEXISTENT")).thenReturn(Optional.empty())
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
         assertEquals("Role 'NONEXISTENT' does not exist", exception.message)
     }
 
@@ -110,7 +110,7 @@ class InvitationServiceTest {
 
         `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(systemRole))
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
         assertEquals("Cannot invite with system-level role", exception.message)
     }
 
@@ -130,7 +130,7 @@ class InvitationServiceTest {
             ),
         ).thenReturn(Optional.of(existingInvitation))
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
         assertEquals("An invitation has already been sent to this email", exception.message)
     }
 
@@ -155,7 +155,7 @@ class InvitationServiceTest {
         ).thenReturn(Optional.of(expiredInvitation))
         `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
 
-        val token = invitationService.invite(request, inviter)
+        val token = invitationService.invite(request, inviter, inviter.organizationId)
 
         assertNotNull(token)
         val captor = argumentCaptor<Invitation>()
@@ -322,13 +322,12 @@ class InvitationServiceTest {
 
     @Test
     fun `revokeInvitation should update status to REVOKED`() {
-        val user = createMockUser()
         val invitation = createMockInvitation()
 
         `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
         `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
 
-        invitationService.revokeInvitation(invitation.id, user)
+        invitationService.revokeInvitation(invitation.id, "org-123")
 
         val captor = argumentCaptor<Invitation>()
         verify(invitationRepository).save(captor.capture())
@@ -337,28 +336,26 @@ class InvitationServiceTest {
 
     @Test
     fun `revokeInvitation should throw when invitation not in same org`() {
-        val user = createMockUser()
         val invitation = createMockInvitation(organizationId = "other-org")
 
         `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
 
         val exception =
             assertThrows<IllegalArgumentException> {
-                invitationService.revokeInvitation(invitation.id, user)
+                invitationService.revokeInvitation(invitation.id, "org-123")
             }
         assertEquals("Invitation not found", exception.message)
     }
 
     @Test
     fun `revokeInvitation should throw when invitation is not pending`() {
-        val user = createMockUser()
         val invitation = createMockInvitation(status = InvitationStatus.ACCEPTED)
 
         `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
 
         val exception =
             assertThrows<IllegalArgumentException> {
-                invitationService.revokeInvitation(invitation.id, user)
+                invitationService.revokeInvitation(invitation.id, "org-123")
             }
         assertEquals("Invitation is not pending", exception.message)
     }

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -1,0 +1,406 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AcceptInvitationRequest
+import com.froilan.synectix.dto.CreateInvitationRequest
+import com.froilan.synectix.model.Invitation
+import com.froilan.synectix.model.InvitationStatus
+import com.froilan.synectix.model.Role
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.RoleLevel
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.RoleRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.data.mongodb.core.FindAndModifyOptions
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.LocalDateTime
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class InvitationServiceTest {
+    private lateinit var invitationService: InvitationService
+    private lateinit var invitationRepository: InvitationRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var roleRepository: RoleRepository
+    private lateinit var mongoTemplate: MongoTemplate
+    private lateinit var tokenHasher: TokenHasher
+    private lateinit var passwordEncoder: PasswordEncoder
+
+    @BeforeEach
+    fun setup() {
+        invitationRepository = mock(InvitationRepository::class.java)
+        userRepository = mock(UserRepository::class.java)
+        roleRepository = mock(RoleRepository::class.java)
+        mongoTemplate = mock(MongoTemplate::class.java)
+        tokenHasher = mock(TokenHasher::class.java)
+        passwordEncoder = mock(PasswordEncoder::class.java)
+
+        `when`(tokenHasher.hash(any())).thenAnswer { "hashed-${it.arguments[0]}" }
+        `when`(tokenHasher.generate(any())).thenReturn("generated-test-token")
+
+        invitationService =
+            InvitationService(
+                invitationRepository = invitationRepository,
+                userRepository = userRepository,
+                roleRepository = roleRepository,
+                mongoTemplate = mongoTemplate,
+                tokenHasher = tokenHasher,
+                passwordEncoder = passwordEncoder,
+                invitationExpiryHours = 72L,
+            )
+    }
+
+    @Test
+    fun `invite should create invitation and return raw token`() {
+        val request = CreateInvitationRequest(email = "newuser@example.com", role = "MEMBER")
+        val inviter = createMockUser()
+        val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
+
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
+        `when`(invitationRepository.findByEmailAndOrganizationIdAndStatus(any(), any(), any()))
+            .thenReturn(Optional.empty())
+        `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
+
+        val token = invitationService.invite(request, inviter)
+
+        assertNotNull(token)
+        assertTrue(token.isNotEmpty())
+
+        val captor = argumentCaptor<Invitation>()
+        verify(invitationRepository).save(captor.capture())
+        assertEquals("newuser@example.com", captor.firstValue.email)
+        assertEquals("MEMBER", captor.firstValue.role)
+        assertEquals(inviter.organizationId, captor.firstValue.organizationId)
+        assertEquals(inviter.uuid, captor.firstValue.invitedBy)
+        assertEquals(InvitationStatus.PENDING, captor.firstValue.status)
+    }
+
+    @Test
+    fun `invite should throw when role does not exist`() {
+        val request = CreateInvitationRequest(email = "newuser@example.com", role = "NONEXISTENT")
+        val inviter = createMockUser()
+
+        `when`(roleRepository.findByName("NONEXISTENT")).thenReturn(Optional.empty())
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        assertEquals("Role 'NONEXISTENT' does not exist", exception.message)
+    }
+
+    @Test
+    fun `invite should throw when role is system level`() {
+        val request = CreateInvitationRequest(email = "newuser@example.com", role = "SUPER_ADMIN")
+        val inviter = createMockUser()
+        val systemRole = Role(name = "SUPER_ADMIN", description = "System admin", level = RoleLevel.SYSTEM)
+
+        `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(systemRole))
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        assertEquals("Cannot invite with system-level role", exception.message)
+    }
+
+    @Test
+    fun `invite should throw when active pending invitation already exists`() {
+        val request = CreateInvitationRequest(email = "existing@example.com", role = "MEMBER")
+        val inviter = createMockUser()
+        val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
+        val existingInvitation = createMockInvitation(email = "existing@example.com")
+
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
+        `when`(
+            invitationRepository.findByEmailAndOrganizationIdAndStatus(
+                eq("existing@example.com"),
+                eq(inviter.organizationId),
+                eq(InvitationStatus.PENDING),
+            ),
+        ).thenReturn(Optional.of(existingInvitation))
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter) }
+        assertEquals("An invitation has already been sent to this email", exception.message)
+    }
+
+    @Test
+    fun `invite should expire old invitation and create new one when previous expired`() {
+        val request = CreateInvitationRequest(email = "reinvite@example.com", role = "MEMBER")
+        val inviter = createMockUser()
+        val memberRole = Role(name = "MEMBER", description = "Member", level = RoleLevel.ORGANIZATION)
+        val expiredInvitation =
+            createMockInvitation(
+                email = "reinvite@example.com",
+                expiryAt = LocalDateTime.now().minusHours(1),
+            )
+
+        `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
+        `when`(
+            invitationRepository.findByEmailAndOrganizationIdAndStatus(
+                eq("reinvite@example.com"),
+                eq(inviter.organizationId),
+                eq(InvitationStatus.PENDING),
+            ),
+        ).thenReturn(Optional.of(expiredInvitation))
+        `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
+
+        val token = invitationService.invite(request, inviter)
+
+        assertNotNull(token)
+        val captor = argumentCaptor<Invitation>()
+        verify(invitationRepository, times(2)).save(captor.capture())
+
+        val expired = captor.allValues.first { it.status == InvitationStatus.EXPIRED }
+        assertEquals(expiredInvitation.id, expired.id)
+
+        val newInvite = captor.allValues.first { it.status == InvitationStatus.PENDING }
+        assertEquals("reinvite@example.com", newInvite.email)
+    }
+
+    @Test
+    fun `validateInvitation should return invitation details with existingUser false`() {
+        val invitation = createMockInvitation()
+
+        `when`(invitationRepository.findByTokenHash("hashed-valid-token")).thenReturn(Optional.of(invitation))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
+
+        val result = invitationService.validateInvitation("valid-token")
+
+        assertEquals(invitation.email, result.email)
+        assertEquals(invitation.role, result.role)
+        assertEquals(invitation.organizationId, result.organizationId)
+        assertEquals(false, result.existingUser)
+    }
+
+    @Test
+    fun `validateInvitation should return existingUser true when email registered`() {
+        val invitation = createMockInvitation()
+        val existingUser = createMockUser().copy(email = invitation.email)
+
+        `when`(invitationRepository.findByTokenHash("hashed-valid-token")).thenReturn(Optional.of(invitation))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.of(existingUser))
+
+        val result = invitationService.validateInvitation("valid-token")
+
+        assertEquals(true, result.existingUser)
+    }
+
+    @Test
+    fun `validateInvitation should throw for invalid token`() {
+        `when`(invitationRepository.findByTokenHash("hashed-bad-token")).thenReturn(Optional.empty())
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.validateInvitation("bad-token") }
+        assertEquals("Invalid or expired invitation token", exception.message)
+    }
+
+    @Test
+    fun `acceptInvitation should create new user when email not registered`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "raw-token",
+                username = "newuser",
+                password = "SecurePass123!",
+                firstName = "New",
+                lastName = "User",
+            )
+        val invitation = createMockInvitation()
+        val accepted = invitation.copy(status = InvitationStatus.ACCEPTED)
+
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(accepted)
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
+        `when`(passwordEncoder.encode("SecurePass123!")).thenReturn("encodedPassword")
+        `when`(userRepository.save(any<User>())).thenAnswer { it.arguments[0] }
+
+        val result = invitationService.acceptInvitation(request)
+
+        assertNotNull(result)
+        assertEquals("newuser", result.username)
+        assertEquals(invitation.email, result.email)
+        assertEquals(invitation.organizationId, result.organizationId)
+
+        val userCaptor = argumentCaptor<User>()
+        verify(userRepository).save(userCaptor.capture())
+        assertEquals("MEMBER", userCaptor.firstValue.roleAssignments[0].role)
+        assertEquals(invitation.organizationId, userCaptor.firstValue.roleAssignments[0].organizationId)
+    }
+
+    @Test
+    fun `acceptInvitation should add role to existing user with only token`() {
+        val request = AcceptInvitationRequest(token = "raw-token")
+        val invitation = createMockInvitation(role = "ADMIN")
+        val accepted = invitation.copy(status = InvitationStatus.ACCEPTED)
+        val existingUser =
+            User(
+                uuid = "existing-user",
+                username = "existinguser",
+                email = invitation.email,
+                firstName = "Existing",
+                lastName = "User",
+                passwordHash = "existingHash",
+                organizationId = "other-org",
+                roleAssignments = listOf(RoleAssignment("MEMBER", "other-org")),
+            )
+
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(accepted)
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.of(existingUser))
+        `when`(userRepository.save(any<User>())).thenAnswer { it.arguments[0] }
+
+        val result = invitationService.acceptInvitation(request)
+
+        assertEquals(2, result.roleAssignments.size)
+        assertTrue(result.roleAssignments.any { it.role == "ADMIN" && it.organizationId == invitation.organizationId })
+
+        verify(passwordEncoder, never()).encode(any())
+    }
+
+    @Test
+    fun `acceptInvitation should throw for invalid or expired token`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "invalid",
+                username = "user",
+                password = "password123",
+                firstName = "F",
+                lastName = "L",
+            )
+
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(null)
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        assertEquals("Invalid or expired invitation token", exception.message)
+    }
+
+    @Test
+    fun `acceptInvitation should throw when new user missing required fields`() {
+        val request = AcceptInvitationRequest(token = "raw-token")
+        val invitation = createMockInvitation()
+
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        assertEquals("Username, password, first name, and last name are required for new users", exception.message)
+    }
+
+    @Test
+    fun `acceptInvitation should throw when username already exists`() {
+        val request =
+            AcceptInvitationRequest(
+                token = "raw-token",
+                username = "taken",
+                password = "SecurePass123!",
+                firstName = "New",
+                lastName = "User",
+            )
+        val invitation = createMockInvitation()
+
+        `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
+            .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
+        `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
+        `when`(passwordEncoder.encode("SecurePass123!")).thenReturn("encodedPassword")
+        `when`(userRepository.save(any<User>()))
+            .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.users index: username"))
+
+        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        assertEquals("Username already exists", exception.message)
+    }
+
+    @Test
+    fun `revokeInvitation should update status to REVOKED`() {
+        val user = createMockUser()
+        val invitation = createMockInvitation()
+
+        `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
+        `when`(invitationRepository.save(any<Invitation>())).thenAnswer { it.arguments[0] }
+
+        invitationService.revokeInvitation(invitation.id, user)
+
+        val captor = argumentCaptor<Invitation>()
+        verify(invitationRepository).save(captor.capture())
+        assertEquals(InvitationStatus.REVOKED, captor.firstValue.status)
+    }
+
+    @Test
+    fun `revokeInvitation should throw when invitation not in same org`() {
+        val user = createMockUser()
+        val invitation = createMockInvitation(organizationId = "other-org")
+
+        `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invitationService.revokeInvitation(invitation.id, user)
+            }
+        assertEquals("Invitation not found", exception.message)
+    }
+
+    @Test
+    fun `revokeInvitation should throw when invitation is not pending`() {
+        val user = createMockUser()
+        val invitation = createMockInvitation(status = InvitationStatus.ACCEPTED)
+
+        `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invitationService.revokeInvitation(invitation.id, user)
+            }
+        assertEquals("Invitation is not pending", exception.message)
+    }
+
+    @Test
+    fun `listInvitations should return pending invitations for org`() {
+        val invitations = listOf(createMockInvitation(), createMockInvitation(email = "other@example.com"))
+
+        `when`(invitationRepository.findByOrganizationIdAndStatusAndExpiryAtAfter(eq("org-123"), eq(InvitationStatus.PENDING), any()))
+            .thenReturn(invitations)
+
+        val result = invitationService.listInvitations("org-123")
+
+        assertEquals(2, result.size)
+    }
+
+    private fun createMockUser() =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encodedPassword",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    private fun createMockInvitation(
+        email: String = "invited@example.com",
+        role: String = "MEMBER",
+        organizationId: String = "org-123",
+        status: InvitationStatus = InvitationStatus.PENDING,
+        expiryAt: LocalDateTime = LocalDateTime.now().plusHours(72),
+    ) = Invitation(
+        id = "inv-123",
+        email = email,
+        organizationId = organizationId,
+        role = role,
+        tokenHash = "hashed-token",
+        invitedBy = "user-123",
+        status = status,
+        expiryAt = expiryAt,
+    )
+}


### PR DESCRIPTION
This pull request introduces a comprehensive invitation system for organization management, adds support for switching organizations within a user session, and enhances security and permissions handling. The changes include new endpoints, models, permissions, and MongoDB index management. Below are the most important changes grouped by theme:

**Invitation System Implementation**
* Added `InvitationController` with endpoints to create, list, validate, accept, and revoke invitations (`src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt`).
* Introduced invitation-related DTOs for request and response handling (`src/main/kotlin/com/froilan/synectix/dto/InvitationDtos.kt`).
* Created the `Invitation` model and `InvitationStatus` enum to represent invitation documents in MongoDB (`src/main/kotlin/com/froilan/synectix/model/Invitation.kt`).
* Implemented `InvitationRepository` for MongoDB operations on invitations (`src/main/kotlin/com/froilan/synectix/repository/InvitationRepository.kt`).
* Added a partial unique index on invitations (`email`, `organizationId`) where status is `PENDING` for data integrity (`MongoConfig.kt`).

**Organization Switching and User Session Enhancements**
* Added endpoints to list user organizations and switch the active organization in `AuthController`, with supporting DTOs (`SwitchOrganizationRequest`, `UserOrganizationResponse`) and updated `AuthResponse` to include `organizationId` (`src/main/kotlin/com/froilan/synectix/controller/AuthController.kt`, `src/main/kotlin/com/froilan/synectix/dto/AuthDtos.kt`). [[1]](diffhunk://#diff-83939a27d4ba8d153697e702b966242f6abe6a68d5d7be095b8dfa12852680fcR178-R221) [[2]](diffhunk://#diff-4b60457c004d6b1fcba24289bda4100b845de829fe18b3c4de475d7cc7a3a68fR86-R103)
* Updated `SessionToken` to include an optional `organizationId` field (`src/main/kotlin/com/froilan/synectix/model/SessionToken.kt`).
* Modified `TokenAuthenticationFilter` to set active organization context and filter role assignments accordingly (`src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt`).

**Security and Permissions**
* Updated `SecurityConfig` to require authentication for invitation and organization endpoints, and added HTTP method-specific rules (`src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt`).
* Assigned new `INVITATION_READ` and `INVITATION_WRITE` permissions to appropriate roles in `RoleSeeder` (`src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt`). [[1]](diffhunk://#diff-442acc6b29ab3765fd9d2176f8eec18a39edbf23dd2162635338570e97ecd3d9R45-R46) [[2]](diffhunk://#diff-442acc6b29ab3765fd9d2176f8eec18a39edbf23dd2162635338570e97ecd3d9R61-R62) [[3]](diffhunk://#diff-442acc6b29ab3765fd9d2176f8eec18a39edbf23dd2162635338570e97ecd3d9R75)

**MongoDB Configuration**
* Enabled automatic index creation and added necessary imports to support the new invitation index (`src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt`). [[1]](diffhunk://#diff-eb9078a0dbc8f859f00562bd6de56956505736b9121a4f69a1a0be857d90284dR7-R23) [[2]](diffhunk://#diff-eb9078a0dbc8f859f00562bd6de56956505736b9121a4f69a1a0be857d90284dR33-R34)

These changes collectively enable secure, permissioned invitation flows and multi-organization support for users.