### PR TITLE
Add API key management for service integrations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
-        allWarningsAsErrors.set(true)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
+        allWarningsAsErrors.set(true)
     }
 }
 

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -44,6 +44,7 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_DELETE,
                             Permissions.INVITATION_READ,
                             Permissions.INVITATION_WRITE,
+                            Permissions.API_KEY_MANAGE,
                         ),
                 ),
                 Role(
@@ -60,6 +61,7 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_WRITE,
                             Permissions.INVITATION_READ,
                             Permissions.INVITATION_WRITE,
+                            Permissions.API_KEY_MANAGE,
                         ),
                 ),
                 Role(

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.GET, "/auth/invitations").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/auth/invitations/*").authenticated()
                 it.requestMatchers("/auth/organizations", "/auth/organizations/**").authenticated()
+                it.requestMatchers("/auth/api-keys", "/auth/api-keys/**").authenticated()
                 it.requestMatchers("/auth/**").permitAll()
                 it.requestMatchers("/health/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -2,8 +2,11 @@ package com.froilan.synectix.config
 
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.ApiKeyPrincipal
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.ApiKeyService
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -19,6 +22,7 @@ class TokenAuthenticationFilter(
     private val sessionTokenRepository: SessionTokenRepository,
     private val userRepository: UserRepository,
     private val rolePermissionCache: RolePermissionCache,
+    private val apiKeyService: ApiKeyService,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -30,6 +34,8 @@ class TokenAuthenticationFilter(
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             val token = authHeader.substring(7)
             val sessionTokenOpt = sessionTokenRepository.findByToken(token)
+
+            val requestPath = request.requestURI
 
             if (sessionTokenOpt.isPresent) {
                 val sessionToken = sessionTokenOpt.get()
@@ -63,6 +69,16 @@ class TokenAuthenticationFilter(
                     }
                 } else {
                     sessionTokenRepository.delete(sessionToken)
+                }
+            } else if (!requestPath.contains("/auth/")) {
+                // API key fallback — blocked from auth endpoints
+                val apiKey = apiKeyService.authenticateByApiKey(token)
+                if (apiKey != null) {
+                    val authorities = apiKey.permissions.map { SimpleGrantedAuthority(it) }
+                    val principal = ApiKeyPrincipal(apiKey.id, apiKey.name, apiKey.organizationId)
+                    val authentication = UsernamePasswordAuthenticationToken(principal, null, authorities)
+                    authentication.details = ApiKeyContext(apiKey.id, apiKey.organizationId)
+                    SecurityContextHolder.getContext().authentication = authentication
                 }
             }
         }

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -7,6 +7,7 @@ import com.froilan.synectix.security.ApiKeyPrincipal
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.ApiKeyService
+import com.github.benmanes.caffeine.cache.Caffeine
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -16,6 +17,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 
 @Component
 class TokenAuthenticationFilter(
@@ -24,6 +26,24 @@ class TokenAuthenticationFilter(
     private val rolePermissionCache: RolePermissionCache,
     private val apiKeyService: ApiKeyService,
 ) : OncePerRequestFilter() {
+    private val apiKeyAttemptCounts =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(15, TimeUnit.MINUTES)
+            .maximumSize(10_000)
+            .build<String, Int>()
+
+    private val apiKeyBlockedIps =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(15, TimeUnit.MINUTES)
+            .maximumSize(10_000)
+            .build<String, Boolean>()
+
+    companion object {
+        private const val MAX_API_KEY_ATTEMPTS = 10
+    }
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -71,7 +91,11 @@ class TokenAuthenticationFilter(
                     sessionTokenRepository.delete(sessionToken)
                 }
             } else if (!path.startsWith("/auth")) {
-                // API key fallback — blocked from auth endpoints
+                val clientIp = request.remoteAddr ?: "unknown"
+                if (apiKeyBlockedIps.getIfPresent(clientIp) != null) {
+                    filterChain.doFilter(request, response)
+                    return
+                }
                 val apiKey = apiKeyService.authenticateByApiKey(token)
                 if (apiKey != null) {
                     val authorities = apiKey.permissions.map { SimpleGrantedAuthority(it) }
@@ -79,6 +103,12 @@ class TokenAuthenticationFilter(
                     val authentication = UsernamePasswordAuthenticationToken(principal, null, authorities)
                     authentication.details = ApiKeyContext(apiKey.id, apiKey.organizationId)
                     SecurityContextHolder.getContext().authentication = authentication
+                } else {
+                    val count = apiKeyAttemptCounts.asMap().merge(clientIp, 1, Int::plus) ?: 1
+                    if (count >= MAX_API_KEY_ATTEMPTS) {
+                        apiKeyBlockedIps.put(clientIp, true)
+                        apiKeyAttemptCounts.invalidate(clientIp)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -35,7 +35,7 @@ class TokenAuthenticationFilter(
             val token = authHeader.substring(7)
             val sessionTokenOpt = sessionTokenRepository.findByToken(token)
 
-            val requestPath = request.requestURI
+            val path = request.requestURI.removePrefix(request.contextPath)
 
             if (sessionTokenOpt.isPresent) {
                 val sessionToken = sessionTokenOpt.get()
@@ -70,7 +70,7 @@ class TokenAuthenticationFilter(
                 } else {
                     sessionTokenRepository.delete(sessionToken)
                 }
-            } else if (!requestPath.contains("/auth/")) {
+            } else if (!path.startsWith("/auth")) {
                 // API key fallback — blocked from auth endpoints
                 val apiKey = apiKeyService.authenticateByApiKey(token)
                 if (apiKey != null) {

--- a/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
@@ -1,0 +1,111 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.ApiKeyCreatedResponse
+import com.froilan.synectix.dto.ApiKeyResponse
+import com.froilan.synectix.dto.CreateApiKeyRequest
+import com.froilan.synectix.model.User
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.ApiKeyService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth/api-keys")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ApiKeyController(
+    private val apiKeyService: ApiKeyService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('apikey:manage')")
+    fun createApiKey(
+        @Valid @RequestBody request: CreateApiKeyRequest,
+    ): ResponseEntity<Any> {
+        val (user, sessionContext) = extractUserAndContext() ?: return unauthorized()
+
+        return try {
+            val (apiKey, rawKey) =
+                apiKeyService.createApiKey(
+                    name = request.name,
+                    permissions = request.permissions,
+                    organizationId = sessionContext.organizationId,
+                    createdBy = user.uuid,
+                    expiresAt = request.expiresAt,
+                )
+            ResponseEntity.status(HttpStatus.CREATED).body(
+                ApiKeyCreatedResponse(
+                    id = apiKey.id,
+                    name = apiKey.name,
+                    rawKey = rawKey,
+                    keyPrefix = apiKey.keyPrefix,
+                    permissions = apiKey.permissions,
+                    organizationId = apiKey.organizationId,
+                    expiresAt = apiKey.expiresAt?.toString(),
+                    createdAt = apiKey.createdAt?.toString(),
+                ),
+            )
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create API key")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('apikey:manage')")
+    fun listApiKeys(): ResponseEntity<Any> {
+        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+
+        val keys =
+            apiKeyService.listApiKeys(sessionContext.organizationId).map { key ->
+                ApiKeyResponse(
+                    id = key.id,
+                    name = key.name,
+                    keyPrefix = key.keyPrefix,
+                    permissions = key.permissions,
+                    organizationId = key.organizationId,
+                    isActive = key.isActive,
+                    lastUsedAt = key.lastUsedAt?.toString(),
+                    expiresAt = key.expiresAt?.toString(),
+                    createdAt = key.createdAt?.toString(),
+                )
+            }
+        return ResponseEntity.ok(keys)
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('apikey:manage')")
+    fun revokeApiKey(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+
+        return try {
+            apiKeyService.revokeApiKey(id, sessionContext.organizationId)
+            ResponseEntity.ok(mapOf("message" to "API key revoked"))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to revoke API key")))
+        }
+    }
+
+    private fun extractUserAndContext(): Pair<User, SessionContext>? {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val user = authentication?.principal as? User ?: return null
+        val sessionContext = authentication.details as? SessionContext ?: return null
+        return user to sessionContext
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
@@ -33,6 +33,8 @@ class ApiKeyController(
         @Valid @RequestBody request: CreateApiKeyRequest,
     ): ResponseEntity<Any> {
         val (user, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val authentication = SecurityContextHolder.getContext().authentication ?: return unauthorized()
+        val creatorPermissions = authentication.authorities.mapNotNull { it.authority }.toSet()
 
         return try {
             val (apiKey, rawKey) =
@@ -41,6 +43,7 @@ class ApiKeyController(
                     permissions = request.permissions,
                     organizationId = sessionContext.organizationId,
                     createdBy = user.uuid,
+                    creatorPermissions = creatorPermissions,
                     expiresAt = request.expiresAt,
                 )
             ResponseEntity.status(HttpStatus.CREATED).body(

--- a/src/main/kotlin/com/froilan/synectix/dto/ApiKeyDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/ApiKeyDtos.kt
@@ -1,12 +1,17 @@
 package com.froilan.synectix.dto
 
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
 import java.time.LocalDateTime
 
 data class CreateApiKeyRequest(
     @field:NotBlank(message = "API key name is required")
     val name: String,
-    val permissions: List<String>,
+    @field:NotEmpty(message = "At least one permission is required")
+    val permissions: List<
+        @NotBlank(message = "Permission must not be blank")
+        String,
+    >,
     val expiresAt: LocalDateTime? = null,
 )
 

--- a/src/main/kotlin/com/froilan/synectix/dto/ApiKeyDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/ApiKeyDtos.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDateTime
+
+data class CreateApiKeyRequest(
+    @field:NotBlank(message = "API key name is required")
+    val name: String,
+    val permissions: List<String>,
+    val expiresAt: LocalDateTime? = null,
+)
+
+data class ApiKeyResponse(
+    val id: String,
+    val name: String,
+    val keyPrefix: String,
+    val permissions: List<String>,
+    val organizationId: String,
+    val isActive: Boolean,
+    val lastUsedAt: String?,
+    val expiresAt: String?,
+    val createdAt: String?,
+)
+
+data class ApiKeyCreatedResponse(
+    val id: String,
+    val name: String,
+    val rawKey: String,
+    val keyPrefix: String,
+    val permissions: List<String>,
+    val organizationId: String,
+    val expiresAt: String?,
+    val createdAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/ApiKey.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/ApiKey.kt
@@ -1,0 +1,27 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "api_keys")
+data class ApiKey(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    @Indexed(unique = true)
+    val keyHash: String,
+    val keyPrefix: String,
+    @Indexed
+    val organizationId: String,
+    val permissions: List<String>,
+    val createdBy: String,
+    val isActive: Boolean = true,
+    val lastUsedAt: LocalDateTime? = null,
+    val expiresAt: LocalDateTime? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/ApiKeyRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/ApiKeyRepository.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.ApiKey
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface ApiKeyRepository : MongoRepository<ApiKey, String> {
+    fun findByKeyHash(keyHash: String): Optional<ApiKey>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<ApiKey>
+}

--- a/src/main/kotlin/com/froilan/synectix/security/ApiKeyContext.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/ApiKeyContext.kt
@@ -1,0 +1,6 @@
+package com.froilan.synectix.security
+
+data class ApiKeyContext(
+    val apiKeyId: String,
+    val organizationId: String,
+)

--- a/src/main/kotlin/com/froilan/synectix/security/ApiKeyPrincipal.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/ApiKeyPrincipal.kt
@@ -1,0 +1,7 @@
+package com.froilan.synectix.security
+
+data class ApiKeyPrincipal(
+    val apiKeyId: String,
+    val apiKeyName: String,
+    val organizationId: String,
+)

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -16,4 +16,22 @@ object Permissions {
 
     const val INVITATION_READ = "invitation:read"
     const val INVITATION_WRITE = "invitation:write"
+
+    const val API_KEY_MANAGE = "apikey:manage"
+
+    val ALL_PERMISSIONS =
+        listOf(
+            SESSION_READ,
+            SESSION_DELETE,
+            USER_READ,
+            USER_WRITE,
+            USER_DELETE,
+            ORGANIZATION_READ,
+            ORGANIZATION_WRITE,
+            ORGANIZATION_DELETE,
+            ENVIRONMENT_READ,
+            INVITATION_READ,
+            INVITATION_WRITE,
+            API_KEY_MANAGE,
+        )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -4,7 +4,6 @@ import com.froilan.synectix.model.ApiKey
 import com.froilan.synectix.repository.ApiKeyRepository
 import com.froilan.synectix.security.Permissions
 import com.froilan.synectix.util.TokenHasher
-import org.slf4j.LoggerFactory
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
@@ -19,8 +18,6 @@ class ApiKeyService(
     private val mongoTemplate: MongoTemplate,
     private val tokenHasher: TokenHasher,
 ) {
-    private val log = LoggerFactory.getLogger(ApiKeyService::class.java)
-
     @Transactional
     fun createApiKey(
         name: String,

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -1,0 +1,91 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.ApiKey
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.security.Permissions
+import com.froilan.synectix.util.TokenHasher
+import org.slf4j.LoggerFactory
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class ApiKeyService(
+    private val apiKeyRepository: ApiKeyRepository,
+    private val mongoTemplate: MongoTemplate,
+    private val tokenHasher: TokenHasher,
+) {
+    private val log = LoggerFactory.getLogger(ApiKeyService::class.java)
+
+    @Transactional
+    fun createApiKey(
+        name: String,
+        permissions: List<String>,
+        organizationId: String,
+        createdBy: String,
+        expiresAt: LocalDateTime? = null,
+    ): Pair<ApiKey, String> {
+        val invalidPermissions = permissions.filter { it !in Permissions.ALL_PERMISSIONS }
+        if (invalidPermissions.isNotEmpty()) {
+            throw IllegalArgumentException("Invalid permissions: ${invalidPermissions.joinToString()}")
+        }
+        if (permissions.isEmpty()) {
+            throw IllegalArgumentException("At least one permission is required")
+        }
+
+        val rawKey = tokenHasher.generate()
+        val apiKey =
+            ApiKey(
+                name = name,
+                keyHash = tokenHasher.hash(rawKey),
+                keyPrefix = rawKey.take(8),
+                organizationId = organizationId,
+                permissions = permissions.distinct(),
+                createdBy = createdBy,
+                expiresAt = expiresAt,
+            )
+        val saved = apiKeyRepository.save(apiKey)
+        return saved to rawKey
+    }
+
+    fun listApiKeys(organizationId: String): List<ApiKey> =
+        apiKeyRepository.findByOrganizationIdAndIsActive(organizationId, true)
+
+    @Transactional
+    fun revokeApiKey(
+        keyId: String,
+        organizationId: String,
+    ) {
+        val apiKey =
+            apiKeyRepository.findById(keyId).orElseThrow {
+                IllegalArgumentException("API key not found")
+            }
+        if (apiKey.organizationId != organizationId) {
+            throw IllegalArgumentException("API key not found")
+        }
+        if (!apiKey.isActive) {
+            throw IllegalArgumentException("API key is already revoked")
+        }
+        apiKeyRepository.save(apiKey.copy(isActive = false))
+    }
+
+    fun authenticateByApiKey(rawKey: String): ApiKey? {
+        val keyHash = tokenHasher.hash(rawKey)
+        val apiKey = apiKeyRepository.findByKeyHash(keyHash).orElse(null) ?: return null
+
+        if (!apiKey.isActive) return null
+        if (apiKey.expiresAt != null && !apiKey.expiresAt.isAfter(LocalDateTime.now())) return null
+
+        mongoTemplate.updateFirst(
+            Query.query(Criteria.where("_id").`is`(apiKey.id)),
+            Update.update("lastUsedAt", LocalDateTime.now()),
+            ApiKey::class.java,
+        )
+
+        return apiKey
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -52,8 +52,7 @@ class ApiKeyService(
         return saved to rawKey
     }
 
-    fun listApiKeys(organizationId: String): List<ApiKey> =
-        apiKeyRepository.findByOrganizationIdAndIsActive(organizationId, true)
+    fun listApiKeys(organizationId: String): List<ApiKey> = apiKeyRepository.findByOrganizationIdAndIsActive(organizationId, true)
 
     @Transactional
     fun revokeApiKey(

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -24,6 +24,7 @@ class ApiKeyService(
         permissions: List<String>,
         organizationId: String,
         createdBy: String,
+        creatorPermissions: Set<String>,
         expiresAt: LocalDateTime? = null,
     ): Pair<ApiKey, String> {
         val invalidPermissions = permissions.filter { it !in Permissions.ALL_PERMISSIONS }
@@ -32,6 +33,12 @@ class ApiKeyService(
         }
         if (permissions.isEmpty()) {
             throw IllegalArgumentException("At least one permission is required")
+        }
+        val escalatedPermissions = permissions.filter { it !in creatorPermissions }
+        if (escalatedPermissions.isNotEmpty()) {
+            throw IllegalArgumentException(
+                "Cannot grant permissions you do not have: ${escalatedPermissions.joinToString()}",
+            )
         }
 
         val rawKey = tokenHasher.generate()

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -65,6 +65,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_DELETE,
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
+                        Permissions.API_KEY_MANAGE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -121,6 +122,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_DELETE,
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
+                        Permissions.API_KEY_MANAGE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -204,6 +206,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_DELETE,
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
+                        Permissions.API_KEY_MANAGE,
                     ),
             )
         val admin =
@@ -221,6 +224,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
+                        Permissions.API_KEY_MANAGE,
                     ),
             )
         val member =

--- a/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
@@ -1,0 +1,203 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.model.ApiKey
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [ApiKeyController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class ApiKeyControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var apiKeyRepository: ApiKeyRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("apikey:manage")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    @Test
+    fun `POST api-keys should return 201 with raw key`() {
+        val apiKey =
+            ApiKey(
+                id = "key-123",
+                name = "Test Key",
+                keyHash = "hashed",
+                keyPrefix = "abc12345",
+                organizationId = "org-123",
+                permissions = listOf("session:read"),
+                createdBy = "user-123",
+            )
+        `when`(apiKeyService.createApiKey(any(), any(), any(), any(), anyOrNull()))
+            .thenReturn(apiKey to "raw-key-value")
+
+        mockMvc
+            .perform(
+                post("/auth/api-keys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Test Key", "permissions": ["session:read"]}"""),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.rawKey").value("raw-key-value"))
+            .andExpect(jsonPath("$.name").value("Test Key"))
+            .andExpect(jsonPath("$.keyPrefix").value("abc12345"))
+    }
+
+    @Test
+    fun `POST api-keys should return 400 when name is blank`() {
+        mockMvc
+            .perform(
+                post("/auth/api-keys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "", "permissions": ["session:read"]}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST api-keys should return 400 with invalid permissions`() {
+        `when`(apiKeyService.createApiKey(any(), any(), any(), any(), anyOrNull()))
+            .thenThrow(IllegalArgumentException("Invalid permissions: bad:perm"))
+
+        mockMvc
+            .perform(
+                post("/auth/api-keys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Bad Key", "permissions": ["bad:perm"]}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invalid permissions: bad:perm"))
+    }
+
+    @Test
+    fun `GET api-keys should return 200 with key list`() {
+        val keys =
+            listOf(
+                ApiKey(
+                    id = "key-1",
+                    name = "Key One",
+                    keyHash = "h1",
+                    keyPrefix = "prefix01",
+                    organizationId = "org-123",
+                    permissions = listOf("session:read"),
+                    createdBy = "user-123",
+                ),
+            )
+        `when`(apiKeyService.listApiKeys("org-123")).thenReturn(keys)
+
+        mockMvc
+            .perform(get("/auth/api-keys"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].name").value("Key One"))
+            .andExpect(jsonPath("$[0].keyPrefix").value("prefix01"))
+    }
+
+    @Test
+    fun `DELETE api-keys should return 200 when revoked`() {
+        mockMvc
+            .perform(delete("/auth/api-keys/key-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("API key revoked"))
+    }
+
+    @Test
+    fun `DELETE api-keys should return 400 when already revoked`() {
+        `when`(apiKeyService.revokeApiKey(any(), any()))
+            .thenThrow(IllegalArgumentException("API key is already revoked"))
+
+        mockMvc
+            .perform(delete("/auth/api-keys/key-123"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("API key is already revoked"))
+    }
+
+    @Test
+    fun `POST api-keys should return 403 without apikey manage permission`() {
+        setupAuthWithPermissions()
+
+        mockMvc
+            .perform(
+                post("/auth/api-keys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Key", "permissions": ["session:read"]}"""),
+            ).andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
@@ -108,7 +108,7 @@ class ApiKeyControllerTest {
                 permissions = listOf("session:read"),
                 createdBy = "user-123",
             )
-        `when`(apiKeyService.createApiKey(any(), any(), any(), any(), anyOrNull()))
+        `when`(apiKeyService.createApiKey(any(), any(), any(), any(), any(), anyOrNull()))
             .thenReturn(apiKey to "raw-key-value")
 
         mockMvc
@@ -134,7 +134,7 @@ class ApiKeyControllerTest {
 
     @Test
     fun `POST api-keys should return 400 with invalid permissions`() {
-        `when`(apiKeyService.createApiKey(any(), any(), any(), any(), anyOrNull()))
+        `when`(apiKeyService.createApiKey(any(), any(), any(), any(), any(), anyOrNull()))
             .thenThrow(IllegalArgumentException("Invalid permissions: bad:perm"))
 
         mockMvc

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -16,6 +16,7 @@ import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.Test
@@ -74,6 +75,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
 
     @Test
     fun `POST signup should return 201 when registration is successful`() {

--- a/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
@@ -6,6 +6,7 @@ import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
 import com.mongodb.client.MongoDatabase
 import org.bson.Document
 import org.junit.jupiter.api.Test
@@ -44,6 +45,9 @@ class HealthControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
 
     @Test
     fun `should return health status UP when database is healthy`() {

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -15,6 +15,7 @@ import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.InvitationService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.BeforeEach
@@ -71,6 +72,9 @@ class InvitationControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.BeforeEach
@@ -67,6 +68,9 @@ class SessionControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -52,6 +52,7 @@ class ApiKeyServiceTest {
                 permissions = listOf("session:read", "organization:read"),
                 organizationId = "org-123",
                 createdBy = "user-123",
+                creatorPermissions = setOf("session:read", "session:delete", "organization:read"),
             )
 
         assertEquals("Test Key", apiKey.name)
@@ -75,6 +76,7 @@ class ApiKeyServiceTest {
                     permissions = listOf("session:read", "nonexistent:permission"),
                     organizationId = "org-123",
                     createdBy = "user-123",
+                    creatorPermissions = setOf("session:read"),
                 )
             }
         assertTrue(exception.message!!.contains("nonexistent:permission"))
@@ -89,9 +91,25 @@ class ApiKeyServiceTest {
                     permissions = emptyList(),
                     organizationId = "org-123",
                     createdBy = "user-123",
+                    creatorPermissions = setOf("session:read"),
                 )
             }
         assertEquals("At least one permission is required", exception.message)
+    }
+
+    @Test
+    fun `createApiKey should throw when requesting permissions creator does not have`() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.createApiKey(
+                    name = "Escalated Key",
+                    permissions = listOf("session:read", "user:delete"),
+                    organizationId = "org-123",
+                    createdBy = "user-123",
+                    creatorPermissions = setOf("session:read", "organization:read"),
+                )
+            }
+        assertTrue(exception.message!!.contains("user:delete"))
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -1,0 +1,200 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.ApiKey
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.springframework.data.mongodb.core.MongoTemplate
+import java.time.LocalDateTime
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ApiKeyServiceTest {
+    private lateinit var apiKeyService: ApiKeyService
+    private lateinit var apiKeyRepository: ApiKeyRepository
+    private lateinit var mongoTemplate: MongoTemplate
+    private lateinit var tokenHasher: TokenHasher
+
+    @BeforeEach
+    fun setup() {
+        apiKeyRepository = mock(ApiKeyRepository::class.java)
+        mongoTemplate = mock(MongoTemplate::class.java)
+        tokenHasher = mock(TokenHasher::class.java)
+
+        `when`(tokenHasher.hash(any())).thenAnswer { "hashed-${it.arguments[0]}" }
+        `when`(tokenHasher.generate(any())).thenReturn("generated-api-key-token")
+
+        apiKeyService =
+            ApiKeyService(
+                apiKeyRepository = apiKeyRepository,
+                mongoTemplate = mongoTemplate,
+                tokenHasher = tokenHasher,
+            )
+    }
+
+    @Test
+    fun `createApiKey should create key and return raw key`() {
+        `when`(apiKeyRepository.save(any<ApiKey>())).thenAnswer { it.arguments[0] }
+
+        val (apiKey, rawKey) =
+            apiKeyService.createApiKey(
+                name = "Test Key",
+                permissions = listOf("session:read", "organization:read"),
+                organizationId = "org-123",
+                createdBy = "user-123",
+            )
+
+        assertEquals("Test Key", apiKey.name)
+        assertEquals("org-123", apiKey.organizationId)
+        assertEquals("user-123", apiKey.createdBy)
+        assertEquals(listOf("session:read", "organization:read"), apiKey.permissions)
+        assertEquals("generate", apiKey.keyPrefix.take(8))
+        assertNotNull(rawKey)
+
+        val captor = argumentCaptor<ApiKey>()
+        verify(apiKeyRepository).save(captor.capture())
+        assertTrue(captor.firstValue.isActive)
+    }
+
+    @Test
+    fun `createApiKey should throw when permissions are invalid`() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.createApiKey(
+                    name = "Bad Key",
+                    permissions = listOf("session:read", "nonexistent:permission"),
+                    organizationId = "org-123",
+                    createdBy = "user-123",
+                )
+            }
+        assertTrue(exception.message!!.contains("nonexistent:permission"))
+    }
+
+    @Test
+    fun `createApiKey should throw when permissions are empty`() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.createApiKey(
+                    name = "Empty Key",
+                    permissions = emptyList(),
+                    organizationId = "org-123",
+                    createdBy = "user-123",
+                )
+            }
+        assertEquals("At least one permission is required", exception.message)
+    }
+
+    @Test
+    fun `authenticateByApiKey should return api key for valid key`() {
+        val apiKey = createMockApiKey()
+        `when`(apiKeyRepository.findByKeyHash("hashed-valid-key")).thenReturn(Optional.of(apiKey))
+
+        val result = apiKeyService.authenticateByApiKey("valid-key")
+
+        assertNotNull(result)
+        assertEquals(apiKey.id, result.id)
+    }
+
+    @Test
+    fun `authenticateByApiKey should return null for inactive key`() {
+        val apiKey = createMockApiKey(isActive = false)
+        `when`(apiKeyRepository.findByKeyHash("hashed-inactive-key")).thenReturn(Optional.of(apiKey))
+
+        val result = apiKeyService.authenticateByApiKey("inactive-key")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `authenticateByApiKey should return null for expired key`() {
+        val apiKey = createMockApiKey(expiresAt = LocalDateTime.now().minusHours(1))
+        `when`(apiKeyRepository.findByKeyHash("hashed-expired-key")).thenReturn(Optional.of(apiKey))
+
+        val result = apiKeyService.authenticateByApiKey("expired-key")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `authenticateByApiKey should return null for unknown key`() {
+        `when`(apiKeyRepository.findByKeyHash("hashed-unknown")).thenReturn(Optional.empty())
+
+        val result = apiKeyService.authenticateByApiKey("unknown")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `listApiKeys should return active keys for org`() {
+        val keys = listOf(createMockApiKey(), createMockApiKey(name = "Key 2"))
+        `when`(apiKeyRepository.findByOrganizationIdAndIsActive("org-123", true)).thenReturn(keys)
+
+        val result = apiKeyService.listApiKeys("org-123")
+
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `revokeApiKey should set isActive to false`() {
+        val apiKey = createMockApiKey()
+        `when`(apiKeyRepository.findById(apiKey.id)).thenReturn(Optional.of(apiKey))
+        `when`(apiKeyRepository.save(any<ApiKey>())).thenAnswer { it.arguments[0] }
+
+        apiKeyService.revokeApiKey(apiKey.id, "org-123")
+
+        val captor = argumentCaptor<ApiKey>()
+        verify(apiKeyRepository).save(captor.capture())
+        assertEquals(false, captor.firstValue.isActive)
+    }
+
+    @Test
+    fun `revokeApiKey should throw when key not in same org`() {
+        val apiKey = createMockApiKey(organizationId = "other-org")
+        `when`(apiKeyRepository.findById(apiKey.id)).thenReturn(Optional.of(apiKey))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.revokeApiKey(apiKey.id, "org-123")
+            }
+        assertEquals("API key not found", exception.message)
+    }
+
+    @Test
+    fun `revokeApiKey should throw when key already revoked`() {
+        val apiKey = createMockApiKey(isActive = false)
+        `when`(apiKeyRepository.findById(apiKey.id)).thenReturn(Optional.of(apiKey))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.revokeApiKey(apiKey.id, "org-123")
+            }
+        assertEquals("API key is already revoked", exception.message)
+    }
+
+    private fun createMockApiKey(
+        name: String = "Test Key",
+        organizationId: String = "org-123",
+        isActive: Boolean = true,
+        expiresAt: LocalDateTime? = null,
+    ) = ApiKey(
+        id = "key-123",
+        name = name,
+        keyHash = "hashed-key",
+        keyPrefix = "generat",
+        organizationId = organizationId,
+        permissions = listOf("session:read", "organization:read"),
+        createdBy = "user-123",
+        isActive = isActive,
+        expiresAt = expiresAt,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -190,7 +190,7 @@ class ApiKeyServiceTest {
         id = "key-123",
         name = name,
         keyHash = "hashed-key",
-        keyPrefix = "generat",
+        keyPrefix = "generate",
         organizationId = organizationId,
         permissions = listOf("session:read", "organization:read"),
         createdBy = "user-123",


### PR DESCRIPTION
## Summary
- Add `ApiKey` model with hashed key storage, key prefix for display, org-scoped permissions, optional expiry
- Add `ApiKeyService` with create, list, revoke, and authenticate operations
- Extend `TokenAuthenticationFilter` with API key fallback — tries session token first, falls back to API key hash lookup
- API keys blocked from `/auth/` endpoints to prevent escalation
- Add `ApiKeyPrincipal` and `ApiKeyContext` for distinguishing API key auth from user auth
- New endpoints:
  - `POST /api/auth/api-keys` — create key, returns raw key once (requires `apikey:manage`)
  - `GET /api/auth/api-keys` — list keys with prefix, no raw keys (requires `apikey:manage`)
  - `DELETE /api/auth/api-keys/{id}` — revoke key (requires `apikey:manage`)
- Add `API_KEY_MANAGE` permission to OWNER and ADMIN roles
- Add `Permissions.ALL_PERMISSIONS` list for validation
- 18 new tests (11 service + 7 controller)

## Test plan
- [x] 144/145 tests pass (1 pre-existing context-load failure)
- [x] ktlint passes
- [x] Service: create success, invalid/empty permissions, authenticate valid/inactive/expired/unknown, list, revoke success/wrong org/already revoked
- [x] Controller: POST 201 with raw key, POST 400 validation, GET 200 list, DELETE 200 revoke, DELETE 400 already revoked, 403 permission denial

Closes #19