### PR TITLE
Modernize testing stack: mockito-kotlin 6.3.0 and AssertJ migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.boot:spring-boot-starter-security-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:6.3.0")
     testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring4x:4.22.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -5,6 +5,7 @@ import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.repository.RoleRepository
 import com.froilan.synectix.security.Permissions
 import com.froilan.synectix.security.RolePermissionCache
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -16,7 +17,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.springframework.boot.ApplicationArguments
 import java.util.Optional
-import org.assertj.core.api.Assertions.assertThat
 
 class RoleSeederTest {
     private lateinit var roleRepository: RoleRepository

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -16,8 +16,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.springframework.boot.ApplicationArguments
 import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 
 class RoleSeederTest {
     private lateinit var roleRepository: RoleRepository
@@ -42,7 +41,7 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val seededNames = captor.allValues.map { it.name }.toSet()
-        assertEquals(setOf("SUPER_ADMIN", "OWNER", "ADMIN", "MEMBER", "VIEWER"), seededNames)
+        assertThat(seededNames).isEqualTo(setOf("SUPER_ADMIN", "OWNER", "ADMIN", "MEMBER", "VIEWER"))
     }
 
     @Test
@@ -76,7 +75,7 @@ class RoleSeederTest {
 
         val captor = argumentCaptor<Role>()
         verify(roleRepository, times(4)).save(captor.capture())
-        assertTrue(captor.allValues.none { it.name == "OWNER" })
+        assertThat(captor.allValues).noneMatch { it.name == "OWNER" }
     }
 
     @Test
@@ -98,8 +97,8 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val updatedMember = captor.allValues.first { it.name == "MEMBER" }
-        assertTrue(updatedMember.permissions.contains(Permissions.SESSION_READ))
-        assertTrue(updatedMember.permissions.contains(Permissions.ORGANIZATION_READ))
+        assertThat(updatedMember.permissions).contains(Permissions.SESSION_READ)
+        assertThat(updatedMember.permissions).contains(Permissions.ORGANIZATION_READ)
     }
 
     @Test
@@ -135,9 +134,9 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val updatedOwner = captor.allValues.first { it.name == "OWNER" }
-        assertEquals("Organization owner with full org-level access", updatedOwner.description)
-        assertEquals(RoleLevel.ORGANIZATION, updatedOwner.level)
-        assertTrue(updatedOwner.isDefault)
+        assertThat(updatedOwner.description).isEqualTo("Organization owner with full org-level access")
+        assertThat(updatedOwner.level).isEqualTo(RoleLevel.ORGANIZATION)
+        assertThat(updatedOwner.isDefault).isTrue()
     }
 
     @Test
@@ -151,8 +150,8 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val superAdmin = captor.allValues.first { it.name == "SUPER_ADMIN" }
-        assertEquals(RoleLevel.SYSTEM, superAdmin.level)
-        assertTrue(superAdmin.permissions.isEmpty())
+        assertThat(superAdmin.level).isEqualTo(RoleLevel.SYSTEM)
+        assertThat(superAdmin.permissions).isEmpty()
     }
 
     @Test
@@ -166,7 +165,7 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val orgRoles = captor.allValues.filter { it.name in setOf("OWNER", "ADMIN", "MEMBER", "VIEWER") }
-        assertTrue(orgRoles.all { it.level == RoleLevel.ORGANIZATION })
+        assertThat(orgRoles).allMatch { it.level == RoleLevel.ORGANIZATION }
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
@@ -1,10 +1,10 @@
 package com.froilan.synectix.security
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.assertj.core.api.Assertions.assertThat
 
 class PermissionEvaluatorTest {
     private lateinit var evaluator: SynectixPermissionEvaluator

--- a/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
@@ -4,8 +4,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 
 class PermissionEvaluatorTest {
     private lateinit var evaluator: SynectixPermissionEvaluator
@@ -19,45 +18,45 @@ class PermissionEvaluatorTest {
     fun `SUPER_ADMIN should bypass any permission check`() {
         val auth = authWith("ROLE_SUPER_ADMIN")
 
-        assertTrue(evaluator.hasPermission(auth, Unit, "session:read"))
-        assertTrue(evaluator.hasPermission(auth, Unit, "anything:whatever"))
+        assertThat(evaluator.hasPermission(auth, Unit, "session:read")).isTrue()
+        assertThat(evaluator.hasPermission(auth, Unit, "anything:whatever")).isTrue()
     }
 
     @Test
     fun `user with matching authority should pass`() {
         val auth = authWith("ROLE_MEMBER", "session:read", "organization:read")
 
-        assertTrue(evaluator.hasPermission(auth, Unit, "session:read"))
-        assertTrue(evaluator.hasPermission(auth, Unit, "organization:read"))
+        assertThat(evaluator.hasPermission(auth, Unit, "session:read")).isTrue()
+        assertThat(evaluator.hasPermission(auth, Unit, "organization:read")).isTrue()
     }
 
     @Test
     fun `user without matching authority should fail`() {
         val auth = authWith("ROLE_MEMBER", "session:read")
 
-        assertFalse(evaluator.hasPermission(auth, Unit, "session:delete"))
-        assertFalse(evaluator.hasPermission(auth, Unit, "user:write"))
+        assertThat(evaluator.hasPermission(auth, Unit, "session:delete")).isFalse()
+        assertThat(evaluator.hasPermission(auth, Unit, "user:write")).isFalse()
     }
 
     @Test
     fun `user with no authorities should fail`() {
         val auth = authWith()
 
-        assertFalse(evaluator.hasPermission(auth, Unit, "session:read"))
+        assertThat(evaluator.hasPermission(auth, Unit, "session:read")).isFalse()
     }
 
     @Test
     fun `non-string permission should return false`() {
         val auth = authWith("ROLE_ADMIN", "session:read")
 
-        assertFalse(evaluator.hasPermission(auth, Unit, 123))
+        assertThat(evaluator.hasPermission(auth, Unit, 123)).isFalse()
     }
 
     @Test
     fun `targetId overload should delegate to primary`() {
         val auth = authWith("ROLE_SUPER_ADMIN")
 
-        assertTrue(evaluator.hasPermission(auth, "id-1", "Session", "session:read"))
+        assertThat(evaluator.hasPermission(auth, "id-1", "Session", "session:read")).isTrue()
     }
 
     private fun authWith(vararg authorities: String) =

--- a/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
@@ -3,12 +3,12 @@ package com.froilan.synectix.security
 import com.froilan.synectix.model.Role
 import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.repository.RoleRepository
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import java.util.Optional
-import org.assertj.core.api.Assertions.assertThat
 
 class RolePermissionCacheTest {
     private lateinit var roleRepository: RoleRepository

--- a/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 
 class RolePermissionCacheTest {
     private lateinit var roleRepository: RoleRepository
@@ -47,13 +46,13 @@ class RolePermissionCacheTest {
     @Test
     fun `should return permissions for known role`() {
         val permissions = cache.getPermissions("OWNER")
-        assertEquals(setOf("session:read", "session:delete", "user:read"), permissions)
+        assertThat(permissions).isEqualTo(setOf("session:read", "session:delete", "user:read"))
     }
 
     @Test
     fun `should return empty set for unknown role`() {
         val permissions = cache.getPermissions("UNKNOWN")
-        assertTrue(permissions.isEmpty())
+        assertThat(permissions).isEmpty()
     }
 
     @Test
@@ -69,6 +68,6 @@ class RolePermissionCacheTest {
 
         cache.refresh()
 
-        assertEquals(setOf("session:read", "organization:read"), cache.getPermissions("VIEWER"))
+        assertThat(cache.getPermissions("VIEWER")).isEqualTo(setOf("session:read", "organization:read"))
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -3,6 +3,7 @@ package com.froilan.synectix.service
 import com.froilan.synectix.model.ApiKey
 import com.froilan.synectix.repository.ApiKeyRepository
 import com.froilan.synectix.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -14,7 +15,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.springframework.data.mongodb.core.MongoTemplate
 import java.time.LocalDateTime
 import java.util.Optional
-import org.assertj.core.api.Assertions.assertThat
 
 class ApiKeyServiceTest {
     private lateinit var apiKeyService: ApiKeyService

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -117,7 +117,7 @@ class ApiKeyServiceTest {
         val result = apiKeyService.authenticateByApiKey("valid-key")
 
         assertThat(result).isNotNull()
-        assertThat(result!!.id).isEqualTo(apiKey.id)
+        assertThat(result?.id).isEqualTo(apiKey.id)
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -14,10 +14,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.springframework.data.mongodb.core.MongoTemplate
 import java.time.LocalDateTime
 import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 
 class ApiKeyServiceTest {
     private lateinit var apiKeyService: ApiKeyService
@@ -55,16 +52,16 @@ class ApiKeyServiceTest {
                 creatorPermissions = setOf("session:read", "session:delete", "organization:read"),
             )
 
-        assertEquals("Test Key", apiKey.name)
-        assertEquals("org-123", apiKey.organizationId)
-        assertEquals("user-123", apiKey.createdBy)
-        assertEquals(listOf("session:read", "organization:read"), apiKey.permissions)
-        assertEquals("generate", apiKey.keyPrefix.take(8))
-        assertNotNull(rawKey)
+        assertThat(apiKey.name).isEqualTo("Test Key")
+        assertThat(apiKey.organizationId).isEqualTo("org-123")
+        assertThat(apiKey.createdBy).isEqualTo("user-123")
+        assertThat(apiKey.permissions).isEqualTo(listOf("session:read", "organization:read"))
+        assertThat(apiKey.keyPrefix.take(8)).isEqualTo("generate")
+        assertThat(rawKey).isNotNull()
 
         val captor = argumentCaptor<ApiKey>()
         verify(apiKeyRepository).save(captor.capture())
-        assertTrue(captor.firstValue.isActive)
+        assertThat(captor.firstValue.isActive).isTrue()
     }
 
     @Test
@@ -79,7 +76,7 @@ class ApiKeyServiceTest {
                     creatorPermissions = setOf("session:read"),
                 )
             }
-        assertTrue(exception.message!!.contains("nonexistent:permission"))
+        assertThat(exception.message).contains("nonexistent:permission")
     }
 
     @Test
@@ -94,7 +91,7 @@ class ApiKeyServiceTest {
                     creatorPermissions = setOf("session:read"),
                 )
             }
-        assertEquals("At least one permission is required", exception.message)
+        assertThat(exception.message).isEqualTo("At least one permission is required")
     }
 
     @Test
@@ -109,7 +106,7 @@ class ApiKeyServiceTest {
                     creatorPermissions = setOf("session:read", "organization:read"),
                 )
             }
-        assertTrue(exception.message!!.contains("user:delete"))
+        assertThat(exception.message).contains("user:delete")
     }
 
     @Test
@@ -119,8 +116,8 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.authenticateByApiKey("valid-key")
 
-        assertNotNull(result)
-        assertEquals(apiKey.id, result.id)
+        assertThat(result).isNotNull()
+        assertThat(result!!.id).isEqualTo(apiKey.id)
     }
 
     @Test
@@ -130,7 +127,7 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.authenticateByApiKey("inactive-key")
 
-        assertNull(result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -140,7 +137,7 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.authenticateByApiKey("expired-key")
 
-        assertNull(result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -149,7 +146,7 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.authenticateByApiKey("unknown")
 
-        assertNull(result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -159,7 +156,7 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.listApiKeys("org-123")
 
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
     }
 
     @Test
@@ -172,7 +169,7 @@ class ApiKeyServiceTest {
 
         val captor = argumentCaptor<ApiKey>()
         verify(apiKeyRepository).save(captor.capture())
-        assertEquals(false, captor.firstValue.isActive)
+        assertThat(captor.firstValue.isActive).isEqualTo(false)
     }
 
     @Test
@@ -184,7 +181,7 @@ class ApiKeyServiceTest {
             assertThrows<IllegalArgumentException> {
                 apiKeyService.revokeApiKey(apiKey.id, "org-123")
             }
-        assertEquals("API key not found", exception.message)
+        assertThat(exception.message).isEqualTo("API key not found")
     }
 
     @Test
@@ -196,7 +193,7 @@ class ApiKeyServiceTest {
             assertThrows<IllegalArgumentException> {
                 apiKeyService.revokeApiKey(apiKey.id, "org-123")
             }
-        assertEquals("API key is already revoked", exception.message)
+        assertThat(exception.message).isEqualTo("API key is already revoked")
     }
 
     private fun createMockApiKey(

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -15,6 +15,7 @@ import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -32,11 +33,6 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class AuthServiceTest {
     private lateinit var authService: AuthService
@@ -112,18 +108,18 @@ class AuthServiceTest {
 
         val result = authService.register(request)
 
-        assertNotNull(result)
-        assertEquals(request.username, result.username)
-        assertEquals(request.email, result.email)
-        assertEquals(savedOrg.uuid, result.organizationId)
+        assertThat(result).isNotNull()
+        assertThat(result.username).isEqualTo(request.username)
+        assertThat(result.email).isEqualTo(request.email)
+        assertThat(result.organizationId).isEqualTo(savedOrg.uuid)
 
         verify(organizationRepository, times(1)).save(any<Organizations>())
 
         val userCaptor = argumentCaptor<User>()
         verify(userRepository, times(1)).save(userCaptor.capture())
-        assertEquals(encodedPassword, userCaptor.firstValue.passwordHash)
-        assertEquals(savedOrg.uuid, userCaptor.firstValue.organizationId)
-        assertEquals(listOf(RoleAssignment("OWNER", savedOrg.uuid)), userCaptor.firstValue.roleAssignments)
+        assertThat(userCaptor.firstValue.passwordHash).isEqualTo(encodedPassword)
+        assertThat(userCaptor.firstValue.organizationId).isEqualTo(savedOrg.uuid)
+        assertThat(userCaptor.firstValue.roleAssignments).isEqualTo(listOf(RoleAssignment("OWNER", savedOrg.uuid)))
     }
 
     @Test
@@ -139,7 +135,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.register(request)
             }
-        assertEquals("Username already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Username already exists")
     }
 
     @Test
@@ -155,7 +151,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.register(request)
             }
-        assertEquals("Email already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Email already exists")
     }
 
     @Test
@@ -168,7 +164,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.register(request)
             }
-        assertEquals("Organization slug already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Organization slug already exists")
     }
 
     @Test
@@ -181,7 +177,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.register(request)
             }
-        assertEquals("Organization name already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Organization name already exists")
     }
 
     @Test
@@ -198,7 +194,7 @@ class AuthServiceTest {
         verify(passwordEncoder, times(1)).encode(request.password)
         val userCaptor = argumentCaptor<User>()
         verify(userRepository).save(userCaptor.capture())
-        assertEquals(encodedPassword, userCaptor.firstValue.passwordHash)
+        assertThat(userCaptor.firstValue.passwordHash).isEqualTo(encodedPassword)
     }
 
     @Test
@@ -228,12 +224,12 @@ class AuthServiceTest {
 
         val result = authService.login(request)
 
-        assertNotNull(result)
-        assertEquals(user.username, result.username)
-        assertEquals(user.orgRoleNames(user.organizationId), result.roles)
-        assertEquals(user.organizationId, result.organizationId)
-        assertNotNull(result.accessToken)
-        assertNotNull(result.expiresAt)
+        assertThat(result).isNotNull()
+        assertThat(result.username).isEqualTo(user.username)
+        assertThat(result.roles).isEqualTo(user.orgRoleNames(user.organizationId))
+        assertThat(result.organizationId).isEqualTo(user.organizationId)
+        assertThat(result.accessToken).isNotNull()
+        assertThat(result.expiresAt).isNotNull()
 
         verify(sessionTokenRepository, times(1)).save(any<SessionToken>())
     }
@@ -251,15 +247,13 @@ class AuthServiceTest {
 
         val result = authService.login(request)
 
-        assertNotNull(result.accessToken)
-        assertTrue(result.accessToken.isNotEmpty())
-        assertNotNull(result.refreshToken)
-        assertTrue(result.refreshToken.isNotEmpty())
+        assertThat(result.accessToken).isNotNull().isNotEmpty()
+        assertThat(result.refreshToken).isNotNull().isNotEmpty()
 
         val expectedRefreshExpiry = LocalDateTime.now().plusDays(30)
         val actualRefreshExpiry = LocalDateTime.parse(result.refreshTokenExpiresAt)
-        assertTrue(actualRefreshExpiry.isAfter(expectedRefreshExpiry.minusMinutes(1)))
-        assertTrue(actualRefreshExpiry.isBefore(expectedRefreshExpiry.plusMinutes(1)))
+        assertThat(actualRefreshExpiry).isAfter(expectedRefreshExpiry.minusMinutes(1))
+        assertThat(actualRefreshExpiry).isBefore(expectedRefreshExpiry.plusMinutes(1))
     }
 
     @Test
@@ -271,7 +265,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.login(request)
             }
-        assertEquals("Invalid username or password", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid username or password")
     }
 
     @Test
@@ -286,7 +280,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.login(request)
             }
-        assertEquals("Invalid username or password", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid username or password")
     }
 
     @Test
@@ -305,12 +299,12 @@ class AuthServiceTest {
         verify(sessionTokenRepository).save(tokenCaptor.capture())
 
         val capturedToken = tokenCaptor.firstValue
-        assertEquals(user.uuid, capturedToken.userId)
+        assertThat(capturedToken.userId).isEqualTo(user.uuid)
 
         val expectedExpiry = LocalDateTime.now().plusHours(24)
         val actualExpiry = capturedToken.expiryAt
-        assertTrue(actualExpiry.isAfter(expectedExpiry.minusMinutes(1)))
-        assertTrue(actualExpiry.isBefore(expectedExpiry.plusMinutes(1)))
+        assertThat(actualExpiry).isAfter(expectedExpiry.minusMinutes(1))
+        assertThat(actualExpiry).isBefore(expectedExpiry.plusMinutes(1))
     }
 
     @Test
@@ -326,8 +320,8 @@ class AuthServiceTest {
         val result1 = authService.login(request)
         val result2 = authService.login(request)
 
-        assertNotEquals(result1.accessToken, result2.accessToken)
-        assertTrue(result1.accessToken.matches(Regex("^[A-Za-z0-9_-]+$")))
+        assertThat(result2.accessToken).isNotEqualTo(result1.accessToken)
+        assertThat(result1.accessToken).matches("^[A-Za-z0-9_-]+$")
     }
 
     @Test
@@ -341,7 +335,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.login(request)
             }
-        assertEquals("User account is inactive", exception.message)
+        assertThat(exception.message).isEqualTo("User account is inactive")
     }
 
     @Test
@@ -367,10 +361,10 @@ class AuthServiceTest {
 
         val result = authService.refresh(oldRefreshTokenStr)
 
-        assertNotNull(result.accessToken)
-        assertNotNull(result.refreshToken)
-        assertNotEquals(oldSessionToken.token, result.accessToken)
-        assertNotEquals(oldRefreshTokenStr, result.refreshToken)
+        assertThat(result.accessToken).isNotNull()
+        assertThat(result.refreshToken).isNotNull()
+        assertThat(result.accessToken).isNotEqualTo(oldSessionToken.token)
+        assertThat(result.refreshToken).isNotEqualTo(oldRefreshTokenStr)
 
         verify(sessionTokenRepository).deleteById(oldSessionToken.id)
     }
@@ -393,7 +387,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.refresh(expiredTokenStr)
             }
-        assertEquals("Invalid or expired refresh token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired refresh token")
     }
 
     @Test
@@ -407,7 +401,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.refresh(invalidTokenStr)
             }
-        assertEquals("Invalid or expired refresh token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired refresh token")
     }
 
     @Test
@@ -430,7 +424,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.refresh(refreshTokenStr)
             }
-        assertEquals("User account is inactive", exception.message)
+        assertThat(exception.message).isEqualTo("User account is inactive")
     }
 
     @Test
@@ -467,8 +461,8 @@ class AuthServiceTest {
 
         val result = authService.listSessions(userId)
 
-        assertEquals(1, result.size)
-        assertEquals("s1", result[0].id)
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].id).isEqualTo("s1")
     }
 
     @Test
@@ -494,7 +488,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.revokeSession("user-123", "s1", "other-token")
             }
-        assertEquals("Session not found", exception.message)
+        assertThat(exception.message).isEqualTo("Session not found")
     }
 
     @Test
@@ -509,7 +503,7 @@ class AuthServiceTest {
             assertThrows<IllegalStateException> {
                 authService.revokeSession(userId, "s1", currentToken)
             }
-        assertEquals("Cannot revoke the current session", exception.message)
+        assertThat(exception.message).isEqualTo("Cannot revoke the current session")
     }
 
     @Test
@@ -539,7 +533,7 @@ class AuthServiceTest {
 
         val userCaptor = argumentCaptor<User>()
         verify(userRepository).save(userCaptor.capture())
-        assertEquals("newEncodedPassword", userCaptor.firstValue.passwordHash)
+        assertThat(userCaptor.firstValue.passwordHash).isEqualTo("newEncodedPassword")
         verify(sessionTokenRepository).deleteByUserId(user.uuid)
         verify(refreshTokenRepository).deleteByUserId(user.uuid)
     }
@@ -553,7 +547,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.changePassword(user, "wrongPass", "NewSecurePass123!")
             }
-        assertEquals("Current password is incorrect", exception.message)
+        assertThat(exception.message).isEqualTo("Current password is incorrect")
     }
 
     @Test
@@ -565,7 +559,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.changePassword(user, "samePass", "samePass")
             }
-        assertEquals("New password must be different from current password", exception.message)
+        assertThat(exception.message).isEqualTo("New password must be different from current password")
     }
 
     @Test
@@ -576,8 +570,7 @@ class AuthServiceTest {
 
         val result = authService.forgotPassword(user.email)
 
-        val token = assertNotNull(result)
-        assertTrue(token.isNotEmpty())
+        assertThat(result).isNotNull().isNotEmpty()
         verify(passwordResetTokenRepository).deleteByUserId(user.uuid)
         verify(passwordResetTokenRepository).save(any<PasswordResetToken>())
     }
@@ -588,7 +581,7 @@ class AuthServiceTest {
 
         val result = authService.forgotPassword("unknown@example.com")
 
-        assertEquals(null, result)
+        assertThat(result).isNull()
         verify(passwordResetTokenRepository, never()).save(any())
     }
 
@@ -599,7 +592,7 @@ class AuthServiceTest {
 
         val result = authService.forgotPassword(inactiveUser.email)
 
-        assertEquals(null, result)
+        assertThat(result).isNull()
         verify(passwordResetTokenRepository, never()).save(any())
     }
 
@@ -634,7 +627,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.resetPassword("invalid-token", "NewPassword123!")
             }
-        assertEquals("Invalid or expired reset token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired reset token")
     }
 
     @Test
@@ -653,7 +646,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.resetPassword("expired-token", "NewPassword123!")
             }
-        assertEquals("Invalid or expired reset token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired reset token")
         verify(passwordResetTokenRepository).deleteById(expiredToken.id)
         verify(mongoTemplate, never()).findAndRemove(any(), eq(PasswordResetToken::class.java))
     }
@@ -693,14 +686,14 @@ class AuthServiceTest {
 
         val result = authService.switchOrganization(user, "org-456")
 
-        assertEquals("org-456", result.organizationId)
-        assertEquals(listOf("MEMBER"), result.roles)
-        assertNotNull(result.accessToken)
-        assertNotNull(result.refreshToken)
+        assertThat(result.organizationId).isEqualTo("org-456")
+        assertThat(result.roles).isEqualTo(listOf("MEMBER"))
+        assertThat(result.accessToken).isNotNull()
+        assertThat(result.refreshToken).isNotNull()
 
         val sessionCaptor = argumentCaptor<SessionToken>()
         verify(sessionTokenRepository).save(sessionCaptor.capture())
-        assertEquals("org-456", sessionCaptor.firstValue.organizationId)
+        assertThat(sessionCaptor.firstValue.organizationId).isEqualTo("org-456")
     }
 
     @Test
@@ -711,7 +704,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.switchOrganization(user, "org-999")
             }
-        assertEquals("You do not have access to this organization", exception.message)
+        assertThat(exception.message).isEqualTo("You do not have access to this organization")
     }
 
     @Test
@@ -731,7 +724,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.switchOrganization(user, "org-missing")
             }
-        assertEquals("Organization not found", exception.message)
+        assertThat(exception.message).isEqualTo("Organization not found")
     }
 
     @Test
@@ -752,7 +745,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.switchOrganization(user, "org-inactive")
             }
-        assertEquals("Organization is not active", exception.message)
+        assertThat(exception.message).isEqualTo("Organization is not active")
     }
 
     @Test
@@ -772,14 +765,14 @@ class AuthServiceTest {
 
         val result = authService.listUserOrganizations(user, "org-123")
 
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
         val current = result.first { it.isCurrent }
-        assertEquals("org-123", current.organizationId)
-        assertEquals(listOf("OWNER"), current.roles)
+        assertThat(current.organizationId).isEqualTo("org-123")
+        assertThat(current.roles).isEqualTo(listOf("OWNER"))
 
         val other = result.first { !it.isCurrent }
-        assertEquals("org-456", other.organizationId)
-        assertEquals(listOf("MEMBER"), other.roles)
+        assertThat(other.organizationId).isEqualTo("org-456")
+        assertThat(other.roles).isEqualTo(listOf("MEMBER"))
     }
 
     @Test
@@ -799,11 +792,11 @@ class AuthServiceTest {
 
         val result = authService.listUserOrganizations(user, "org-123")
 
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
         val active = result.first { it.organizationId == "org-123" }
-        assertTrue(active.isActive)
+        assertThat(active.isActive).isTrue()
         val inactive = result.first { it.organizationId == "org-inactive" }
-        assertFalse(inactive.isActive)
+        assertThat(inactive.isActive).isFalse()
     }
 
     private fun createMockOrganization() =

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.InvitationRepository
 import com.froilan.synectix.repository.RoleRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -29,7 +30,6 @@ import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
-import org.assertj.core.api.Assertions.assertThat
 
 class InvitationServiceTest {
     private lateinit var invitationService: InvitationService

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -77,8 +77,7 @@ class InvitationServiceTest {
 
         val token = invitationService.invite(request, inviter, inviter.organizationId)
 
-        assertThat(token).isNotNull()
-        assertThat(token.isNotEmpty()).isTrue()
+        assertThat(token).isNotNull().isNotEmpty()
 
         val captor = argumentCaptor<Invitation>()
         verify(invitationRepository).save(captor.capture())

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -29,9 +29,7 @@ import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 
 class InvitationServiceTest {
     private lateinit var invitationService: InvitationService
@@ -79,16 +77,16 @@ class InvitationServiceTest {
 
         val token = invitationService.invite(request, inviter, inviter.organizationId)
 
-        assertNotNull(token)
-        assertTrue(token.isNotEmpty())
+        assertThat(token).isNotNull()
+        assertThat(token.isNotEmpty()).isTrue()
 
         val captor = argumentCaptor<Invitation>()
         verify(invitationRepository).save(captor.capture())
-        assertEquals("newuser@example.com", captor.firstValue.email)
-        assertEquals("MEMBER", captor.firstValue.role)
-        assertEquals(inviter.organizationId, captor.firstValue.organizationId)
-        assertEquals(inviter.uuid, captor.firstValue.invitedBy)
-        assertEquals(InvitationStatus.PENDING, captor.firstValue.status)
+        assertThat(captor.firstValue.email).isEqualTo("newuser@example.com")
+        assertThat(captor.firstValue.role).isEqualTo("MEMBER")
+        assertThat(captor.firstValue.organizationId).isEqualTo(inviter.organizationId)
+        assertThat(captor.firstValue.invitedBy).isEqualTo(inviter.uuid)
+        assertThat(captor.firstValue.status).isEqualTo(InvitationStatus.PENDING)
     }
 
     @Test
@@ -99,7 +97,7 @@ class InvitationServiceTest {
         `when`(roleRepository.findByName("NONEXISTENT")).thenReturn(Optional.empty())
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
-        assertEquals("Role 'NONEXISTENT' does not exist", exception.message)
+        assertThat(exception.message).isEqualTo("Role 'NONEXISTENT' does not exist")
     }
 
     @Test
@@ -111,7 +109,7 @@ class InvitationServiceTest {
         `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(systemRole))
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
-        assertEquals("Cannot invite with system-level role", exception.message)
+        assertThat(exception.message).isEqualTo("Cannot invite with system-level role")
     }
 
     @Test
@@ -131,7 +129,7 @@ class InvitationServiceTest {
         ).thenReturn(Optional.of(existingInvitation))
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
-        assertEquals("An invitation has already been sent to this email", exception.message)
+        assertThat(exception.message).isEqualTo("An invitation has already been sent to this email")
     }
 
     @Test
@@ -157,15 +155,15 @@ class InvitationServiceTest {
 
         val token = invitationService.invite(request, inviter, inviter.organizationId)
 
-        assertNotNull(token)
+        assertThat(token).isNotNull()
         val captor = argumentCaptor<Invitation>()
         verify(invitationRepository, times(2)).save(captor.capture())
 
         val expired = captor.allValues.first { it.status == InvitationStatus.EXPIRED }
-        assertEquals(expiredInvitation.id, expired.id)
+        assertThat(expired.id).isEqualTo(expiredInvitation.id)
 
         val newInvite = captor.allValues.first { it.status == InvitationStatus.PENDING }
-        assertEquals("reinvite@example.com", newInvite.email)
+        assertThat(newInvite.email).isEqualTo("reinvite@example.com")
     }
 
     @Test
@@ -177,10 +175,10 @@ class InvitationServiceTest {
 
         val result = invitationService.validateInvitation("valid-token")
 
-        assertEquals(invitation.email, result.email)
-        assertEquals(invitation.role, result.role)
-        assertEquals(invitation.organizationId, result.organizationId)
-        assertEquals(false, result.existingUser)
+        assertThat(result.email).isEqualTo(invitation.email)
+        assertThat(result.role).isEqualTo(invitation.role)
+        assertThat(result.organizationId).isEqualTo(invitation.organizationId)
+        assertThat(result.existingUser).isEqualTo(false)
     }
 
     @Test
@@ -193,7 +191,7 @@ class InvitationServiceTest {
 
         val result = invitationService.validateInvitation("valid-token")
 
-        assertEquals(true, result.existingUser)
+        assertThat(result.existingUser).isEqualTo(true)
     }
 
     @Test
@@ -201,7 +199,7 @@ class InvitationServiceTest {
         `when`(invitationRepository.findByTokenHash("hashed-bad-token")).thenReturn(Optional.empty())
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.validateInvitation("bad-token") }
-        assertEquals("Invalid or expired invitation token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired invitation token")
     }
 
     @Test
@@ -225,15 +223,15 @@ class InvitationServiceTest {
 
         val result = invitationService.acceptInvitation(request)
 
-        assertNotNull(result)
-        assertEquals("newuser", result.username)
-        assertEquals(invitation.email, result.email)
-        assertEquals(invitation.organizationId, result.organizationId)
+        assertThat(result).isNotNull()
+        assertThat(result.username).isEqualTo("newuser")
+        assertThat(result.email).isEqualTo(invitation.email)
+        assertThat(result.organizationId).isEqualTo(invitation.organizationId)
 
         val userCaptor = argumentCaptor<User>()
         verify(userRepository).save(userCaptor.capture())
-        assertEquals("MEMBER", userCaptor.firstValue.roleAssignments[0].role)
-        assertEquals(invitation.organizationId, userCaptor.firstValue.roleAssignments[0].organizationId)
+        assertThat(userCaptor.firstValue.roleAssignments[0].role).isEqualTo("MEMBER")
+        assertThat(userCaptor.firstValue.roleAssignments[0].organizationId).isEqualTo(invitation.organizationId)
     }
 
     @Test
@@ -260,8 +258,8 @@ class InvitationServiceTest {
 
         val result = invitationService.acceptInvitation(request)
 
-        assertEquals(2, result.roleAssignments.size)
-        assertTrue(result.roleAssignments.any { it.role == "ADMIN" && it.organizationId == invitation.organizationId })
+        assertThat(result.roleAssignments.size).isEqualTo(2)
+        assertThat(result.roleAssignments.any { it.role == "ADMIN" && it.organizationId == invitation.organizationId }).isTrue()
 
         verify(passwordEncoder, never()).encode(any())
     }
@@ -281,7 +279,7 @@ class InvitationServiceTest {
             .thenReturn(null)
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
-        assertEquals("Invalid or expired invitation token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired invitation token")
     }
 
     @Test
@@ -294,7 +292,7 @@ class InvitationServiceTest {
         `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
-        assertEquals("Username, password, first name, and last name are required for new users", exception.message)
+        assertThat(exception.message).isEqualTo("Username, password, first name, and last name are required for new users")
     }
 
     @Test
@@ -317,7 +315,7 @@ class InvitationServiceTest {
             .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.users index: username"))
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
-        assertEquals("Username already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Username already exists")
     }
 
     @Test
@@ -331,7 +329,7 @@ class InvitationServiceTest {
 
         val captor = argumentCaptor<Invitation>()
         verify(invitationRepository).save(captor.capture())
-        assertEquals(InvitationStatus.REVOKED, captor.firstValue.status)
+        assertThat(captor.firstValue.status).isEqualTo(InvitationStatus.REVOKED)
     }
 
     @Test
@@ -344,7 +342,7 @@ class InvitationServiceTest {
             assertThrows<IllegalArgumentException> {
                 invitationService.revokeInvitation(invitation.id, "org-123")
             }
-        assertEquals("Invitation not found", exception.message)
+        assertThat(exception.message).isEqualTo("Invitation not found")
     }
 
     @Test
@@ -357,7 +355,7 @@ class InvitationServiceTest {
             assertThrows<IllegalArgumentException> {
                 invitationService.revokeInvitation(invitation.id, "org-123")
             }
-        assertEquals("Invitation is not pending", exception.message)
+        assertThat(exception.message).isEqualTo("Invitation is not pending")
     }
 
     @Test
@@ -369,7 +367,7 @@ class InvitationServiceTest {
 
         val result = invitationService.listInvitations("org-123")
 
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
     }
 
     private fun createMockUser() =


### PR DESCRIPTION
## Summary
- Update mockito-kotlin from 5.1.0 to 6.3.0 (drop-in, adds Kotlin 2.x improvements)
- Migrate ALL test assertions from `kotlin.test` to AssertJ across 6 test files:
  - `AuthServiceTest.kt` (73 assertions)
  - `InvitationServiceTest.kt` (26 assertions)
  - `ApiKeyServiceTest.kt` (18 assertions)
  - `RoleSeederTest.kt` (12 assertions)
  - `PermissionEvaluatorTest.kt` (9 assertions)
  - `RolePermissionCacheTest.kt` (3 assertions)
- Zero `kotlin.test` imports remaining in the codebase
- Controller tests unchanged (use MockMvc assertions, not kotlin.test)

## Why AssertJ
- Single `assertThat` import vs 5+ individual kotlin.test imports
- Fluent builder pattern: `assertThat(x).isNotNull().isNotEmpty()`
- Rich matchers: `contains()`, `allMatch()`, `noneMatch()`, `isAfter()`, `isBefore()`
- Better failure messages with actual/expected values
- Already bundled in spring-boot-starter-test

## Test plan
- [x] 145/146 tests pass (1 pre-existing context-load failure)
- [x] ktlint passes
- [x] No kotlin.test imports remain

Closes #92