### PR TITLE
Release: API key management, testing modernization, and auth-iam completion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.boot:spring-boot-starter-security-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:6.3.0")
     testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring4x:4.22.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -44,6 +44,7 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_DELETE,
                             Permissions.INVITATION_READ,
                             Permissions.INVITATION_WRITE,
+                            Permissions.API_KEY_MANAGE,
                         ),
                 ),
                 Role(
@@ -60,6 +61,7 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_WRITE,
                             Permissions.INVITATION_READ,
                             Permissions.INVITATION_WRITE,
+                            Permissions.API_KEY_MANAGE,
                         ),
                 ),
                 Role(

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.GET, "/auth/invitations").authenticated()
                 it.requestMatchers(HttpMethod.DELETE, "/auth/invitations/*").authenticated()
                 it.requestMatchers("/auth/organizations", "/auth/organizations/**").authenticated()
+                it.requestMatchers("/auth/api-keys", "/auth/api-keys/**").authenticated()
                 it.requestMatchers("/auth/**").permitAll()
                 it.requestMatchers("/health/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -2,8 +2,12 @@ package com.froilan.synectix.config
 
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.ApiKeyPrincipal
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.ApiKeyService
+import com.github.benmanes.caffeine.cache.Caffeine
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -13,13 +17,33 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 
 @Component
 class TokenAuthenticationFilter(
     private val sessionTokenRepository: SessionTokenRepository,
     private val userRepository: UserRepository,
     private val rolePermissionCache: RolePermissionCache,
+    private val apiKeyService: ApiKeyService,
 ) : OncePerRequestFilter() {
+    private val apiKeyAttemptCounts =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(15, TimeUnit.MINUTES)
+            .maximumSize(10_000)
+            .build<String, Int>()
+
+    private val apiKeyBlockedIps =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(15, TimeUnit.MINUTES)
+            .maximumSize(10_000)
+            .build<String, Boolean>()
+
+    companion object {
+        private const val MAX_API_KEY_ATTEMPTS = 10
+    }
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -30,6 +54,8 @@ class TokenAuthenticationFilter(
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             val token = authHeader.substring(7)
             val sessionTokenOpt = sessionTokenRepository.findByToken(token)
+
+            val path = request.requestURI.removePrefix(request.contextPath)
 
             if (sessionTokenOpt.isPresent) {
                 val sessionToken = sessionTokenOpt.get()
@@ -63,6 +89,26 @@ class TokenAuthenticationFilter(
                     }
                 } else {
                     sessionTokenRepository.delete(sessionToken)
+                }
+            } else if (!path.startsWith("/auth")) {
+                val clientIp = request.remoteAddr ?: "unknown"
+                if (apiKeyBlockedIps.getIfPresent(clientIp) != null) {
+                    filterChain.doFilter(request, response)
+                    return
+                }
+                val apiKey = apiKeyService.authenticateByApiKey(token)
+                if (apiKey != null) {
+                    val authorities = apiKey.permissions.map { SimpleGrantedAuthority(it) }
+                    val principal = ApiKeyPrincipal(apiKey.id, apiKey.name, apiKey.organizationId)
+                    val authentication = UsernamePasswordAuthenticationToken(principal, null, authorities)
+                    authentication.details = ApiKeyContext(apiKey.id, apiKey.organizationId)
+                    SecurityContextHolder.getContext().authentication = authentication
+                } else {
+                    val count = apiKeyAttemptCounts.asMap().merge(clientIp, 1, Int::plus) ?: 1
+                    if (count >= MAX_API_KEY_ATTEMPTS) {
+                        apiKeyBlockedIps.put(clientIp, true)
+                        apiKeyAttemptCounts.invalidate(clientIp)
+                    }
                 }
             }
         }

--- a/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
@@ -1,0 +1,114 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.ApiKeyCreatedResponse
+import com.froilan.synectix.dto.ApiKeyResponse
+import com.froilan.synectix.dto.CreateApiKeyRequest
+import com.froilan.synectix.model.User
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.ApiKeyService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth/api-keys")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ApiKeyController(
+    private val apiKeyService: ApiKeyService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('apikey:manage')")
+    fun createApiKey(
+        @Valid @RequestBody request: CreateApiKeyRequest,
+    ): ResponseEntity<Any> {
+        val (user, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val authentication = SecurityContextHolder.getContext().authentication ?: return unauthorized()
+        val creatorPermissions = authentication.authorities.mapNotNull { it.authority }.toSet()
+
+        return try {
+            val (apiKey, rawKey) =
+                apiKeyService.createApiKey(
+                    name = request.name,
+                    permissions = request.permissions,
+                    organizationId = sessionContext.organizationId,
+                    createdBy = user.uuid,
+                    creatorPermissions = creatorPermissions,
+                    expiresAt = request.expiresAt,
+                )
+            ResponseEntity.status(HttpStatus.CREATED).body(
+                ApiKeyCreatedResponse(
+                    id = apiKey.id,
+                    name = apiKey.name,
+                    rawKey = rawKey,
+                    keyPrefix = apiKey.keyPrefix,
+                    permissions = apiKey.permissions,
+                    organizationId = apiKey.organizationId,
+                    expiresAt = apiKey.expiresAt?.toString(),
+                    createdAt = apiKey.createdAt?.toString(),
+                ),
+            )
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create API key")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('apikey:manage')")
+    fun listApiKeys(): ResponseEntity<Any> {
+        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+
+        val keys =
+            apiKeyService.listApiKeys(sessionContext.organizationId).map { key ->
+                ApiKeyResponse(
+                    id = key.id,
+                    name = key.name,
+                    keyPrefix = key.keyPrefix,
+                    permissions = key.permissions,
+                    organizationId = key.organizationId,
+                    isActive = key.isActive,
+                    lastUsedAt = key.lastUsedAt?.toString(),
+                    expiresAt = key.expiresAt?.toString(),
+                    createdAt = key.createdAt?.toString(),
+                )
+            }
+        return ResponseEntity.ok(keys)
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('apikey:manage')")
+    fun revokeApiKey(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+
+        return try {
+            apiKeyService.revokeApiKey(id, sessionContext.organizationId)
+            ResponseEntity.ok(mapOf("message" to "API key revoked"))
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to revoke API key")))
+        }
+    }
+
+    private fun extractUserAndContext(): Pair<User, SessionContext>? {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val user = authentication?.principal as? User ?: return null
+        val sessionContext = authentication.details as? SessionContext ?: return null
+        return user to sessionContext
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/ApiKeyDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/ApiKeyDtos.kt
@@ -1,0 +1,39 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import java.time.LocalDateTime
+
+data class CreateApiKeyRequest(
+    @field:NotBlank(message = "API key name is required")
+    val name: String,
+    @field:NotEmpty(message = "At least one permission is required")
+    val permissions: List<
+        @NotBlank(message = "Permission must not be blank")
+        String,
+    >,
+    val expiresAt: LocalDateTime? = null,
+)
+
+data class ApiKeyResponse(
+    val id: String,
+    val name: String,
+    val keyPrefix: String,
+    val permissions: List<String>,
+    val organizationId: String,
+    val isActive: Boolean,
+    val lastUsedAt: String?,
+    val expiresAt: String?,
+    val createdAt: String?,
+)
+
+data class ApiKeyCreatedResponse(
+    val id: String,
+    val name: String,
+    val rawKey: String,
+    val keyPrefix: String,
+    val permissions: List<String>,
+    val organizationId: String,
+    val expiresAt: String?,
+    val createdAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/ApiKey.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/ApiKey.kt
@@ -1,0 +1,27 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "api_keys")
+data class ApiKey(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    @Indexed(unique = true)
+    val keyHash: String,
+    val keyPrefix: String,
+    @Indexed
+    val organizationId: String,
+    val permissions: List<String>,
+    val createdBy: String,
+    val isActive: Boolean = true,
+    val lastUsedAt: LocalDateTime? = null,
+    val expiresAt: LocalDateTime? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/ApiKeyRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/ApiKeyRepository.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.ApiKey
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface ApiKeyRepository : MongoRepository<ApiKey, String> {
+    fun findByKeyHash(keyHash: String): Optional<ApiKey>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<ApiKey>
+}

--- a/src/main/kotlin/com/froilan/synectix/security/ApiKeyContext.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/ApiKeyContext.kt
@@ -1,0 +1,6 @@
+package com.froilan.synectix.security
+
+data class ApiKeyContext(
+    val apiKeyId: String,
+    val organizationId: String,
+)

--- a/src/main/kotlin/com/froilan/synectix/security/ApiKeyPrincipal.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/ApiKeyPrincipal.kt
@@ -1,0 +1,7 @@
+package com.froilan.synectix.security
+
+data class ApiKeyPrincipal(
+    val apiKeyId: String,
+    val apiKeyName: String,
+    val organizationId: String,
+)

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -16,4 +16,22 @@ object Permissions {
 
     const val INVITATION_READ = "invitation:read"
     const val INVITATION_WRITE = "invitation:write"
+
+    const val API_KEY_MANAGE = "apikey:manage"
+
+    val ALL_PERMISSIONS =
+        listOf(
+            SESSION_READ,
+            SESSION_DELETE,
+            USER_READ,
+            USER_WRITE,
+            USER_DELETE,
+            ORGANIZATION_READ,
+            ORGANIZATION_WRITE,
+            ORGANIZATION_DELETE,
+            ENVIRONMENT_READ,
+            INVITATION_READ,
+            INVITATION_WRITE,
+            API_KEY_MANAGE,
+        )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -1,0 +1,94 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.ApiKey
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.security.Permissions
+import com.froilan.synectix.util.TokenHasher
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class ApiKeyService(
+    private val apiKeyRepository: ApiKeyRepository,
+    private val mongoTemplate: MongoTemplate,
+    private val tokenHasher: TokenHasher,
+) {
+    @Transactional
+    fun createApiKey(
+        name: String,
+        permissions: List<String>,
+        organizationId: String,
+        createdBy: String,
+        creatorPermissions: Set<String>,
+        expiresAt: LocalDateTime? = null,
+    ): Pair<ApiKey, String> {
+        val invalidPermissions = permissions.filter { it !in Permissions.ALL_PERMISSIONS }
+        if (invalidPermissions.isNotEmpty()) {
+            throw IllegalArgumentException("Invalid permissions: ${invalidPermissions.joinToString()}")
+        }
+        if (permissions.isEmpty()) {
+            throw IllegalArgumentException("At least one permission is required")
+        }
+        val escalatedPermissions = permissions.filter { it !in creatorPermissions }
+        if (escalatedPermissions.isNotEmpty()) {
+            throw IllegalArgumentException(
+                "Cannot grant permissions you do not have: ${escalatedPermissions.joinToString()}",
+            )
+        }
+
+        val rawKey = tokenHasher.generate()
+        val apiKey =
+            ApiKey(
+                name = name,
+                keyHash = tokenHasher.hash(rawKey),
+                keyPrefix = rawKey.take(8),
+                organizationId = organizationId,
+                permissions = permissions.distinct(),
+                createdBy = createdBy,
+                expiresAt = expiresAt,
+            )
+        val saved = apiKeyRepository.save(apiKey)
+        return saved to rawKey
+    }
+
+    fun listApiKeys(organizationId: String): List<ApiKey> = apiKeyRepository.findByOrganizationIdAndIsActive(organizationId, true)
+
+    @Transactional
+    fun revokeApiKey(
+        keyId: String,
+        organizationId: String,
+    ) {
+        val apiKey =
+            apiKeyRepository.findById(keyId).orElseThrow {
+                IllegalArgumentException("API key not found")
+            }
+        if (apiKey.organizationId != organizationId) {
+            throw IllegalArgumentException("API key not found")
+        }
+        if (!apiKey.isActive) {
+            throw IllegalArgumentException("API key is already revoked")
+        }
+        apiKeyRepository.save(apiKey.copy(isActive = false))
+    }
+
+    fun authenticateByApiKey(rawKey: String): ApiKey? {
+        val keyHash = tokenHasher.hash(rawKey)
+        val apiKey = apiKeyRepository.findByKeyHash(keyHash).orElse(null) ?: return null
+
+        if (!apiKey.isActive) return null
+        if (apiKey.expiresAt != null && !apiKey.expiresAt.isAfter(LocalDateTime.now())) return null
+
+        mongoTemplate.updateFirst(
+            Query.query(Criteria.where("_id").`is`(apiKey.id)),
+            Update.update("lastUsedAt", LocalDateTime.now()),
+            ApiKey::class.java,
+        )
+
+        return apiKey
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -41,7 +41,7 @@ class ApiKeyService(
             )
         }
 
-        val rawKey = tokenHasher.generate()
+        val rawKey = tokenHasher.generate(32)
         val apiKey =
             ApiKey(
                 name = name,

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -433,5 +433,5 @@ class AuthService(
         }
     }
 
-    private fun generateToken(): String = tokenHasher.generate()
+    private fun generateToken(): String = tokenHasher.generate(32)
 }

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -66,7 +66,7 @@ class InvitationService(
             invitationRepository.save(pendingInvitation.copy(status = InvitationStatus.EXPIRED))
         }
 
-        val rawToken = tokenHasher.generate()
+        val rawToken = tokenHasher.generate(32)
         val invitation =
             Invitation(
                 email = normalizedEmail,

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -65,6 +65,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_DELETE,
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
+                        Permissions.API_KEY_MANAGE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -121,6 +122,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_DELETE,
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
+                        Permissions.API_KEY_MANAGE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -204,6 +206,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_DELETE,
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
+                        Permissions.API_KEY_MANAGE,
                     ),
             )
         val admin =
@@ -221,6 +224,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_WRITE,
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
+                        Permissions.API_KEY_MANAGE,
                     ),
             )
         val member =

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -5,6 +5,7 @@ import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.repository.RoleRepository
 import com.froilan.synectix.security.Permissions
 import com.froilan.synectix.security.RolePermissionCache
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -16,8 +17,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.springframework.boot.ApplicationArguments
 import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class RoleSeederTest {
     private lateinit var roleRepository: RoleRepository
@@ -42,7 +41,7 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val seededNames = captor.allValues.map { it.name }.toSet()
-        assertEquals(setOf("SUPER_ADMIN", "OWNER", "ADMIN", "MEMBER", "VIEWER"), seededNames)
+        assertThat(seededNames).isEqualTo(setOf("SUPER_ADMIN", "OWNER", "ADMIN", "MEMBER", "VIEWER"))
     }
 
     @Test
@@ -76,7 +75,7 @@ class RoleSeederTest {
 
         val captor = argumentCaptor<Role>()
         verify(roleRepository, times(4)).save(captor.capture())
-        assertTrue(captor.allValues.none { it.name == "OWNER" })
+        assertThat(captor.allValues).noneMatch { it.name == "OWNER" }
     }
 
     @Test
@@ -98,8 +97,8 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val updatedMember = captor.allValues.first { it.name == "MEMBER" }
-        assertTrue(updatedMember.permissions.contains(Permissions.SESSION_READ))
-        assertTrue(updatedMember.permissions.contains(Permissions.ORGANIZATION_READ))
+        assertThat(updatedMember.permissions).contains(Permissions.SESSION_READ)
+        assertThat(updatedMember.permissions).contains(Permissions.ORGANIZATION_READ)
     }
 
     @Test
@@ -135,9 +134,9 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val updatedOwner = captor.allValues.first { it.name == "OWNER" }
-        assertEquals("Organization owner with full org-level access", updatedOwner.description)
-        assertEquals(RoleLevel.ORGANIZATION, updatedOwner.level)
-        assertTrue(updatedOwner.isDefault)
+        assertThat(updatedOwner.description).isEqualTo("Organization owner with full org-level access")
+        assertThat(updatedOwner.level).isEqualTo(RoleLevel.ORGANIZATION)
+        assertThat(updatedOwner.isDefault).isTrue()
     }
 
     @Test
@@ -151,8 +150,8 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val superAdmin = captor.allValues.first { it.name == "SUPER_ADMIN" }
-        assertEquals(RoleLevel.SYSTEM, superAdmin.level)
-        assertTrue(superAdmin.permissions.isEmpty())
+        assertThat(superAdmin.level).isEqualTo(RoleLevel.SYSTEM)
+        assertThat(superAdmin.permissions).isEmpty()
     }
 
     @Test
@@ -166,7 +165,7 @@ class RoleSeederTest {
         verify(roleRepository, times(5)).save(captor.capture())
 
         val orgRoles = captor.allValues.filter { it.name in setOf("OWNER", "ADMIN", "MEMBER", "VIEWER") }
-        assertTrue(orgRoles.all { it.level == RoleLevel.ORGANIZATION })
+        assertThat(orgRoles).allMatch { it.level == RoleLevel.ORGANIZATION }
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
@@ -1,0 +1,203 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.model.ApiKey
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [ApiKeyController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class ApiKeyControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var apiKeyRepository: ApiKeyRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("apikey:manage")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    @Test
+    fun `POST api-keys should return 201 with raw key`() {
+        val apiKey =
+            ApiKey(
+                id = "key-123",
+                name = "Test Key",
+                keyHash = "hashed",
+                keyPrefix = "abc12345",
+                organizationId = "org-123",
+                permissions = listOf("session:read"),
+                createdBy = "user-123",
+            )
+        `when`(apiKeyService.createApiKey(any(), any(), any(), any(), any(), anyOrNull()))
+            .thenReturn(apiKey to "raw-key-value")
+
+        mockMvc
+            .perform(
+                post("/auth/api-keys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Test Key", "permissions": ["session:read"]}"""),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.rawKey").value("raw-key-value"))
+            .andExpect(jsonPath("$.name").value("Test Key"))
+            .andExpect(jsonPath("$.keyPrefix").value("abc12345"))
+    }
+
+    @Test
+    fun `POST api-keys should return 400 when name is blank`() {
+        mockMvc
+            .perform(
+                post("/auth/api-keys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "", "permissions": ["session:read"]}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST api-keys should return 400 with invalid permissions`() {
+        `when`(apiKeyService.createApiKey(any(), any(), any(), any(), any(), anyOrNull()))
+            .thenThrow(IllegalArgumentException("Invalid permissions: bad:perm"))
+
+        mockMvc
+            .perform(
+                post("/auth/api-keys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Bad Key", "permissions": ["bad:perm"]}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invalid permissions: bad:perm"))
+    }
+
+    @Test
+    fun `GET api-keys should return 200 with key list`() {
+        val keys =
+            listOf(
+                ApiKey(
+                    id = "key-1",
+                    name = "Key One",
+                    keyHash = "h1",
+                    keyPrefix = "prefix01",
+                    organizationId = "org-123",
+                    permissions = listOf("session:read"),
+                    createdBy = "user-123",
+                ),
+            )
+        `when`(apiKeyService.listApiKeys("org-123")).thenReturn(keys)
+
+        mockMvc
+            .perform(get("/auth/api-keys"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].name").value("Key One"))
+            .andExpect(jsonPath("$[0].keyPrefix").value("prefix01"))
+    }
+
+    @Test
+    fun `DELETE api-keys should return 200 when revoked`() {
+        mockMvc
+            .perform(delete("/auth/api-keys/key-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("API key revoked"))
+    }
+
+    @Test
+    fun `DELETE api-keys should return 400 when already revoked`() {
+        `when`(apiKeyService.revokeApiKey(any(), any()))
+            .thenThrow(IllegalArgumentException("API key is already revoked"))
+
+        mockMvc
+            .perform(delete("/auth/api-keys/key-123"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("API key is already revoked"))
+    }
+
+    @Test
+    fun `POST api-keys should return 403 without apikey manage permission`() {
+        setupAuthWithPermissions()
+
+        mockMvc
+            .perform(
+                post("/auth/api-keys")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Key", "permissions": ["session:read"]}"""),
+            ).andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -16,6 +16,7 @@ import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.Test
@@ -74,6 +75,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
 
     @Test
     fun `POST signup should return 201 when registration is successful`() {

--- a/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/HealthControllerTest.kt
@@ -6,6 +6,7 @@ import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
 import com.mongodb.client.MongoDatabase
 import org.bson.Document
 import org.junit.jupiter.api.Test
@@ -44,6 +45,9 @@ class HealthControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
 
     @Test
     fun `should return health status UP when database is healthy`() {

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -15,6 +15,7 @@ import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.InvitationService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.BeforeEach
@@ -71,6 +72,9 @@ class InvitationControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.AuthService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.BeforeEach
@@ -67,6 +68,9 @@ class SessionControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/PermissionEvaluatorTest.kt
@@ -1,11 +1,10 @@
 package com.froilan.synectix.security
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class PermissionEvaluatorTest {
     private lateinit var evaluator: SynectixPermissionEvaluator
@@ -19,45 +18,45 @@ class PermissionEvaluatorTest {
     fun `SUPER_ADMIN should bypass any permission check`() {
         val auth = authWith("ROLE_SUPER_ADMIN")
 
-        assertTrue(evaluator.hasPermission(auth, Unit, "session:read"))
-        assertTrue(evaluator.hasPermission(auth, Unit, "anything:whatever"))
+        assertThat(evaluator.hasPermission(auth, Unit, "session:read")).isTrue()
+        assertThat(evaluator.hasPermission(auth, Unit, "anything:whatever")).isTrue()
     }
 
     @Test
     fun `user with matching authority should pass`() {
         val auth = authWith("ROLE_MEMBER", "session:read", "organization:read")
 
-        assertTrue(evaluator.hasPermission(auth, Unit, "session:read"))
-        assertTrue(evaluator.hasPermission(auth, Unit, "organization:read"))
+        assertThat(evaluator.hasPermission(auth, Unit, "session:read")).isTrue()
+        assertThat(evaluator.hasPermission(auth, Unit, "organization:read")).isTrue()
     }
 
     @Test
     fun `user without matching authority should fail`() {
         val auth = authWith("ROLE_MEMBER", "session:read")
 
-        assertFalse(evaluator.hasPermission(auth, Unit, "session:delete"))
-        assertFalse(evaluator.hasPermission(auth, Unit, "user:write"))
+        assertThat(evaluator.hasPermission(auth, Unit, "session:delete")).isFalse()
+        assertThat(evaluator.hasPermission(auth, Unit, "user:write")).isFalse()
     }
 
     @Test
     fun `user with no authorities should fail`() {
         val auth = authWith()
 
-        assertFalse(evaluator.hasPermission(auth, Unit, "session:read"))
+        assertThat(evaluator.hasPermission(auth, Unit, "session:read")).isFalse()
     }
 
     @Test
     fun `non-string permission should return false`() {
         val auth = authWith("ROLE_ADMIN", "session:read")
 
-        assertFalse(evaluator.hasPermission(auth, Unit, 123))
+        assertThat(evaluator.hasPermission(auth, Unit, 123)).isFalse()
     }
 
     @Test
     fun `targetId overload should delegate to primary`() {
         val auth = authWith("ROLE_SUPER_ADMIN")
 
-        assertTrue(evaluator.hasPermission(auth, "id-1", "Session", "session:read"))
+        assertThat(evaluator.hasPermission(auth, "id-1", "Session", "session:read")).isTrue()
     }
 
     private fun authWith(vararg authorities: String) =

--- a/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/RolePermissionCacheTest.kt
@@ -3,13 +3,12 @@ package com.froilan.synectix.security
 import com.froilan.synectix.model.Role
 import com.froilan.synectix.model.RoleLevel
 import com.froilan.synectix.repository.RoleRepository
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class RolePermissionCacheTest {
     private lateinit var roleRepository: RoleRepository
@@ -47,13 +46,13 @@ class RolePermissionCacheTest {
     @Test
     fun `should return permissions for known role`() {
         val permissions = cache.getPermissions("OWNER")
-        assertEquals(setOf("session:read", "session:delete", "user:read"), permissions)
+        assertThat(permissions).isEqualTo(setOf("session:read", "session:delete", "user:read"))
     }
 
     @Test
     fun `should return empty set for unknown role`() {
         val permissions = cache.getPermissions("UNKNOWN")
-        assertTrue(permissions.isEmpty())
+        assertThat(permissions).isEmpty()
     }
 
     @Test
@@ -69,6 +68,6 @@ class RolePermissionCacheTest {
 
         cache.refresh()
 
-        assertEquals(setOf("session:read", "organization:read"), cache.getPermissions("VIEWER"))
+        assertThat(cache.getPermissions("VIEWER")).isEqualTo(setOf("session:read", "organization:read"))
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -3,6 +3,7 @@ package com.froilan.synectix.service
 import com.froilan.synectix.model.ApiKey
 import com.froilan.synectix.repository.ApiKeyRepository
 import com.froilan.synectix.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -14,10 +15,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.springframework.data.mongodb.core.MongoTemplate
 import java.time.LocalDateTime
 import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class ApiKeyServiceTest {
     private lateinit var apiKeyService: ApiKeyService
@@ -55,16 +52,16 @@ class ApiKeyServiceTest {
                 creatorPermissions = setOf("session:read", "session:delete", "organization:read"),
             )
 
-        assertEquals("Test Key", apiKey.name)
-        assertEquals("org-123", apiKey.organizationId)
-        assertEquals("user-123", apiKey.createdBy)
-        assertEquals(listOf("session:read", "organization:read"), apiKey.permissions)
-        assertEquals("generate", apiKey.keyPrefix.take(8))
-        assertNotNull(rawKey)
+        assertThat(apiKey.name).isEqualTo("Test Key")
+        assertThat(apiKey.organizationId).isEqualTo("org-123")
+        assertThat(apiKey.createdBy).isEqualTo("user-123")
+        assertThat(apiKey.permissions).isEqualTo(listOf("session:read", "organization:read"))
+        assertThat(apiKey.keyPrefix.take(8)).isEqualTo("generate")
+        assertThat(rawKey).isNotNull()
 
         val captor = argumentCaptor<ApiKey>()
         verify(apiKeyRepository).save(captor.capture())
-        assertTrue(captor.firstValue.isActive)
+        assertThat(captor.firstValue.isActive).isTrue()
     }
 
     @Test
@@ -79,7 +76,7 @@ class ApiKeyServiceTest {
                     creatorPermissions = setOf("session:read"),
                 )
             }
-        assertTrue(exception.message!!.contains("nonexistent:permission"))
+        assertThat(exception.message).contains("nonexistent:permission")
     }
 
     @Test
@@ -94,7 +91,7 @@ class ApiKeyServiceTest {
                     creatorPermissions = setOf("session:read"),
                 )
             }
-        assertEquals("At least one permission is required", exception.message)
+        assertThat(exception.message).isEqualTo("At least one permission is required")
     }
 
     @Test
@@ -109,7 +106,7 @@ class ApiKeyServiceTest {
                     creatorPermissions = setOf("session:read", "organization:read"),
                 )
             }
-        assertTrue(exception.message!!.contains("user:delete"))
+        assertThat(exception.message).contains("user:delete")
     }
 
     @Test
@@ -119,8 +116,8 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.authenticateByApiKey("valid-key")
 
-        assertNotNull(result)
-        assertEquals(apiKey.id, result.id)
+        assertThat(result).isNotNull()
+        assertThat(result?.id).isEqualTo(apiKey.id)
     }
 
     @Test
@@ -130,7 +127,7 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.authenticateByApiKey("inactive-key")
 
-        assertNull(result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -140,7 +137,7 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.authenticateByApiKey("expired-key")
 
-        assertNull(result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -149,7 +146,7 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.authenticateByApiKey("unknown")
 
-        assertNull(result)
+        assertThat(result).isNull()
     }
 
     @Test
@@ -159,7 +156,7 @@ class ApiKeyServiceTest {
 
         val result = apiKeyService.listApiKeys("org-123")
 
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
     }
 
     @Test
@@ -172,7 +169,7 @@ class ApiKeyServiceTest {
 
         val captor = argumentCaptor<ApiKey>()
         verify(apiKeyRepository).save(captor.capture())
-        assertEquals(false, captor.firstValue.isActive)
+        assertThat(captor.firstValue.isActive).isEqualTo(false)
     }
 
     @Test
@@ -184,7 +181,7 @@ class ApiKeyServiceTest {
             assertThrows<IllegalArgumentException> {
                 apiKeyService.revokeApiKey(apiKey.id, "org-123")
             }
-        assertEquals("API key not found", exception.message)
+        assertThat(exception.message).isEqualTo("API key not found")
     }
 
     @Test
@@ -196,7 +193,7 @@ class ApiKeyServiceTest {
             assertThrows<IllegalArgumentException> {
                 apiKeyService.revokeApiKey(apiKey.id, "org-123")
             }
-        assertEquals("API key is already revoked", exception.message)
+        assertThat(exception.message).isEqualTo("API key is already revoked")
     }
 
     private fun createMockApiKey(

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -1,0 +1,218 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.ApiKey
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.springframework.data.mongodb.core.MongoTemplate
+import java.time.LocalDateTime
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ApiKeyServiceTest {
+    private lateinit var apiKeyService: ApiKeyService
+    private lateinit var apiKeyRepository: ApiKeyRepository
+    private lateinit var mongoTemplate: MongoTemplate
+    private lateinit var tokenHasher: TokenHasher
+
+    @BeforeEach
+    fun setup() {
+        apiKeyRepository = mock(ApiKeyRepository::class.java)
+        mongoTemplate = mock(MongoTemplate::class.java)
+        tokenHasher = mock(TokenHasher::class.java)
+
+        `when`(tokenHasher.hash(any())).thenAnswer { "hashed-${it.arguments[0]}" }
+        `when`(tokenHasher.generate(any())).thenReturn("generated-api-key-token")
+
+        apiKeyService =
+            ApiKeyService(
+                apiKeyRepository = apiKeyRepository,
+                mongoTemplate = mongoTemplate,
+                tokenHasher = tokenHasher,
+            )
+    }
+
+    @Test
+    fun `createApiKey should create key and return raw key`() {
+        `when`(apiKeyRepository.save(any<ApiKey>())).thenAnswer { it.arguments[0] }
+
+        val (apiKey, rawKey) =
+            apiKeyService.createApiKey(
+                name = "Test Key",
+                permissions = listOf("session:read", "organization:read"),
+                organizationId = "org-123",
+                createdBy = "user-123",
+                creatorPermissions = setOf("session:read", "session:delete", "organization:read"),
+            )
+
+        assertEquals("Test Key", apiKey.name)
+        assertEquals("org-123", apiKey.organizationId)
+        assertEquals("user-123", apiKey.createdBy)
+        assertEquals(listOf("session:read", "organization:read"), apiKey.permissions)
+        assertEquals("generate", apiKey.keyPrefix.take(8))
+        assertNotNull(rawKey)
+
+        val captor = argumentCaptor<ApiKey>()
+        verify(apiKeyRepository).save(captor.capture())
+        assertTrue(captor.firstValue.isActive)
+    }
+
+    @Test
+    fun `createApiKey should throw when permissions are invalid`() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.createApiKey(
+                    name = "Bad Key",
+                    permissions = listOf("session:read", "nonexistent:permission"),
+                    organizationId = "org-123",
+                    createdBy = "user-123",
+                    creatorPermissions = setOf("session:read"),
+                )
+            }
+        assertTrue(exception.message!!.contains("nonexistent:permission"))
+    }
+
+    @Test
+    fun `createApiKey should throw when permissions are empty`() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.createApiKey(
+                    name = "Empty Key",
+                    permissions = emptyList(),
+                    organizationId = "org-123",
+                    createdBy = "user-123",
+                    creatorPermissions = setOf("session:read"),
+                )
+            }
+        assertEquals("At least one permission is required", exception.message)
+    }
+
+    @Test
+    fun `createApiKey should throw when requesting permissions creator does not have`() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.createApiKey(
+                    name = "Escalated Key",
+                    permissions = listOf("session:read", "user:delete"),
+                    organizationId = "org-123",
+                    createdBy = "user-123",
+                    creatorPermissions = setOf("session:read", "organization:read"),
+                )
+            }
+        assertTrue(exception.message!!.contains("user:delete"))
+    }
+
+    @Test
+    fun `authenticateByApiKey should return api key for valid key`() {
+        val apiKey = createMockApiKey()
+        `when`(apiKeyRepository.findByKeyHash("hashed-valid-key")).thenReturn(Optional.of(apiKey))
+
+        val result = apiKeyService.authenticateByApiKey("valid-key")
+
+        assertNotNull(result)
+        assertEquals(apiKey.id, result.id)
+    }
+
+    @Test
+    fun `authenticateByApiKey should return null for inactive key`() {
+        val apiKey = createMockApiKey(isActive = false)
+        `when`(apiKeyRepository.findByKeyHash("hashed-inactive-key")).thenReturn(Optional.of(apiKey))
+
+        val result = apiKeyService.authenticateByApiKey("inactive-key")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `authenticateByApiKey should return null for expired key`() {
+        val apiKey = createMockApiKey(expiresAt = LocalDateTime.now().minusHours(1))
+        `when`(apiKeyRepository.findByKeyHash("hashed-expired-key")).thenReturn(Optional.of(apiKey))
+
+        val result = apiKeyService.authenticateByApiKey("expired-key")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `authenticateByApiKey should return null for unknown key`() {
+        `when`(apiKeyRepository.findByKeyHash("hashed-unknown")).thenReturn(Optional.empty())
+
+        val result = apiKeyService.authenticateByApiKey("unknown")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `listApiKeys should return active keys for org`() {
+        val keys = listOf(createMockApiKey(), createMockApiKey(name = "Key 2"))
+        `when`(apiKeyRepository.findByOrganizationIdAndIsActive("org-123", true)).thenReturn(keys)
+
+        val result = apiKeyService.listApiKeys("org-123")
+
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `revokeApiKey should set isActive to false`() {
+        val apiKey = createMockApiKey()
+        `when`(apiKeyRepository.findById(apiKey.id)).thenReturn(Optional.of(apiKey))
+        `when`(apiKeyRepository.save(any<ApiKey>())).thenAnswer { it.arguments[0] }
+
+        apiKeyService.revokeApiKey(apiKey.id, "org-123")
+
+        val captor = argumentCaptor<ApiKey>()
+        verify(apiKeyRepository).save(captor.capture())
+        assertEquals(false, captor.firstValue.isActive)
+    }
+
+    @Test
+    fun `revokeApiKey should throw when key not in same org`() {
+        val apiKey = createMockApiKey(organizationId = "other-org")
+        `when`(apiKeyRepository.findById(apiKey.id)).thenReturn(Optional.of(apiKey))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.revokeApiKey(apiKey.id, "org-123")
+            }
+        assertEquals("API key not found", exception.message)
+    }
+
+    @Test
+    fun `revokeApiKey should throw when key already revoked`() {
+        val apiKey = createMockApiKey(isActive = false)
+        `when`(apiKeyRepository.findById(apiKey.id)).thenReturn(Optional.of(apiKey))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                apiKeyService.revokeApiKey(apiKey.id, "org-123")
+            }
+        assertEquals("API key is already revoked", exception.message)
+    }
+
+    private fun createMockApiKey(
+        name: String = "Test Key",
+        organizationId: String = "org-123",
+        isActive: Boolean = true,
+        expiresAt: LocalDateTime? = null,
+    ) = ApiKey(
+        id = "key-123",
+        name = name,
+        keyHash = "hashed-key",
+        keyPrefix = "generate",
+        organizationId = organizationId,
+        permissions = listOf("session:read", "organization:read"),
+        createdBy = "user-123",
+        isActive = isActive,
+        expiresAt = expiresAt,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -15,6 +15,7 @@ import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -32,11 +33,6 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class AuthServiceTest {
     private lateinit var authService: AuthService
@@ -112,18 +108,18 @@ class AuthServiceTest {
 
         val result = authService.register(request)
 
-        assertNotNull(result)
-        assertEquals(request.username, result.username)
-        assertEquals(request.email, result.email)
-        assertEquals(savedOrg.uuid, result.organizationId)
+        assertThat(result).isNotNull()
+        assertThat(result.username).isEqualTo(request.username)
+        assertThat(result.email).isEqualTo(request.email)
+        assertThat(result.organizationId).isEqualTo(savedOrg.uuid)
 
         verify(organizationRepository, times(1)).save(any<Organizations>())
 
         val userCaptor = argumentCaptor<User>()
         verify(userRepository, times(1)).save(userCaptor.capture())
-        assertEquals(encodedPassword, userCaptor.firstValue.passwordHash)
-        assertEquals(savedOrg.uuid, userCaptor.firstValue.organizationId)
-        assertEquals(listOf(RoleAssignment("OWNER", savedOrg.uuid)), userCaptor.firstValue.roleAssignments)
+        assertThat(userCaptor.firstValue.passwordHash).isEqualTo(encodedPassword)
+        assertThat(userCaptor.firstValue.organizationId).isEqualTo(savedOrg.uuid)
+        assertThat(userCaptor.firstValue.roleAssignments).isEqualTo(listOf(RoleAssignment("OWNER", savedOrg.uuid)))
     }
 
     @Test
@@ -139,7 +135,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.register(request)
             }
-        assertEquals("Username already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Username already exists")
     }
 
     @Test
@@ -155,7 +151,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.register(request)
             }
-        assertEquals("Email already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Email already exists")
     }
 
     @Test
@@ -168,7 +164,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.register(request)
             }
-        assertEquals("Organization slug already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Organization slug already exists")
     }
 
     @Test
@@ -181,7 +177,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.register(request)
             }
-        assertEquals("Organization name already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Organization name already exists")
     }
 
     @Test
@@ -198,7 +194,7 @@ class AuthServiceTest {
         verify(passwordEncoder, times(1)).encode(request.password)
         val userCaptor = argumentCaptor<User>()
         verify(userRepository).save(userCaptor.capture())
-        assertEquals(encodedPassword, userCaptor.firstValue.passwordHash)
+        assertThat(userCaptor.firstValue.passwordHash).isEqualTo(encodedPassword)
     }
 
     @Test
@@ -228,12 +224,12 @@ class AuthServiceTest {
 
         val result = authService.login(request)
 
-        assertNotNull(result)
-        assertEquals(user.username, result.username)
-        assertEquals(user.orgRoleNames(user.organizationId), result.roles)
-        assertEquals(user.organizationId, result.organizationId)
-        assertNotNull(result.accessToken)
-        assertNotNull(result.expiresAt)
+        assertThat(result).isNotNull()
+        assertThat(result.username).isEqualTo(user.username)
+        assertThat(result.roles).isEqualTo(user.orgRoleNames(user.organizationId))
+        assertThat(result.organizationId).isEqualTo(user.organizationId)
+        assertThat(result.accessToken).isNotNull()
+        assertThat(result.expiresAt).isNotNull()
 
         verify(sessionTokenRepository, times(1)).save(any<SessionToken>())
     }
@@ -251,15 +247,13 @@ class AuthServiceTest {
 
         val result = authService.login(request)
 
-        assertNotNull(result.accessToken)
-        assertTrue(result.accessToken.isNotEmpty())
-        assertNotNull(result.refreshToken)
-        assertTrue(result.refreshToken.isNotEmpty())
+        assertThat(result.accessToken).isNotNull().isNotEmpty()
+        assertThat(result.refreshToken).isNotNull().isNotEmpty()
 
         val expectedRefreshExpiry = LocalDateTime.now().plusDays(30)
         val actualRefreshExpiry = LocalDateTime.parse(result.refreshTokenExpiresAt)
-        assertTrue(actualRefreshExpiry.isAfter(expectedRefreshExpiry.minusMinutes(1)))
-        assertTrue(actualRefreshExpiry.isBefore(expectedRefreshExpiry.plusMinutes(1)))
+        assertThat(actualRefreshExpiry).isAfter(expectedRefreshExpiry.minusMinutes(1))
+        assertThat(actualRefreshExpiry).isBefore(expectedRefreshExpiry.plusMinutes(1))
     }
 
     @Test
@@ -271,7 +265,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.login(request)
             }
-        assertEquals("Invalid username or password", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid username or password")
     }
 
     @Test
@@ -286,7 +280,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.login(request)
             }
-        assertEquals("Invalid username or password", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid username or password")
     }
 
     @Test
@@ -305,12 +299,12 @@ class AuthServiceTest {
         verify(sessionTokenRepository).save(tokenCaptor.capture())
 
         val capturedToken = tokenCaptor.firstValue
-        assertEquals(user.uuid, capturedToken.userId)
+        assertThat(capturedToken.userId).isEqualTo(user.uuid)
 
         val expectedExpiry = LocalDateTime.now().plusHours(24)
         val actualExpiry = capturedToken.expiryAt
-        assertTrue(actualExpiry.isAfter(expectedExpiry.minusMinutes(1)))
-        assertTrue(actualExpiry.isBefore(expectedExpiry.plusMinutes(1)))
+        assertThat(actualExpiry).isAfter(expectedExpiry.minusMinutes(1))
+        assertThat(actualExpiry).isBefore(expectedExpiry.plusMinutes(1))
     }
 
     @Test
@@ -326,8 +320,8 @@ class AuthServiceTest {
         val result1 = authService.login(request)
         val result2 = authService.login(request)
 
-        assertNotEquals(result1.accessToken, result2.accessToken)
-        assertTrue(result1.accessToken.matches(Regex("^[A-Za-z0-9_-]+$")))
+        assertThat(result2.accessToken).isNotEqualTo(result1.accessToken)
+        assertThat(result1.accessToken).matches("^[A-Za-z0-9_-]+$")
     }
 
     @Test
@@ -341,7 +335,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.login(request)
             }
-        assertEquals("User account is inactive", exception.message)
+        assertThat(exception.message).isEqualTo("User account is inactive")
     }
 
     @Test
@@ -367,10 +361,10 @@ class AuthServiceTest {
 
         val result = authService.refresh(oldRefreshTokenStr)
 
-        assertNotNull(result.accessToken)
-        assertNotNull(result.refreshToken)
-        assertNotEquals(oldSessionToken.token, result.accessToken)
-        assertNotEquals(oldRefreshTokenStr, result.refreshToken)
+        assertThat(result.accessToken).isNotNull()
+        assertThat(result.refreshToken).isNotNull()
+        assertThat(result.accessToken).isNotEqualTo(oldSessionToken.token)
+        assertThat(result.refreshToken).isNotEqualTo(oldRefreshTokenStr)
 
         verify(sessionTokenRepository).deleteById(oldSessionToken.id)
     }
@@ -393,7 +387,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.refresh(expiredTokenStr)
             }
-        assertEquals("Invalid or expired refresh token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired refresh token")
     }
 
     @Test
@@ -407,7 +401,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.refresh(invalidTokenStr)
             }
-        assertEquals("Invalid or expired refresh token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired refresh token")
     }
 
     @Test
@@ -430,7 +424,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.refresh(refreshTokenStr)
             }
-        assertEquals("User account is inactive", exception.message)
+        assertThat(exception.message).isEqualTo("User account is inactive")
     }
 
     @Test
@@ -467,8 +461,8 @@ class AuthServiceTest {
 
         val result = authService.listSessions(userId)
 
-        assertEquals(1, result.size)
-        assertEquals("s1", result[0].id)
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].id).isEqualTo("s1")
     }
 
     @Test
@@ -494,7 +488,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.revokeSession("user-123", "s1", "other-token")
             }
-        assertEquals("Session not found", exception.message)
+        assertThat(exception.message).isEqualTo("Session not found")
     }
 
     @Test
@@ -509,7 +503,7 @@ class AuthServiceTest {
             assertThrows<IllegalStateException> {
                 authService.revokeSession(userId, "s1", currentToken)
             }
-        assertEquals("Cannot revoke the current session", exception.message)
+        assertThat(exception.message).isEqualTo("Cannot revoke the current session")
     }
 
     @Test
@@ -539,7 +533,7 @@ class AuthServiceTest {
 
         val userCaptor = argumentCaptor<User>()
         verify(userRepository).save(userCaptor.capture())
-        assertEquals("newEncodedPassword", userCaptor.firstValue.passwordHash)
+        assertThat(userCaptor.firstValue.passwordHash).isEqualTo("newEncodedPassword")
         verify(sessionTokenRepository).deleteByUserId(user.uuid)
         verify(refreshTokenRepository).deleteByUserId(user.uuid)
     }
@@ -553,7 +547,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.changePassword(user, "wrongPass", "NewSecurePass123!")
             }
-        assertEquals("Current password is incorrect", exception.message)
+        assertThat(exception.message).isEqualTo("Current password is incorrect")
     }
 
     @Test
@@ -565,7 +559,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.changePassword(user, "samePass", "samePass")
             }
-        assertEquals("New password must be different from current password", exception.message)
+        assertThat(exception.message).isEqualTo("New password must be different from current password")
     }
 
     @Test
@@ -576,8 +570,7 @@ class AuthServiceTest {
 
         val result = authService.forgotPassword(user.email)
 
-        val token = assertNotNull(result)
-        assertTrue(token.isNotEmpty())
+        assertThat(result).isNotNull().isNotEmpty()
         verify(passwordResetTokenRepository).deleteByUserId(user.uuid)
         verify(passwordResetTokenRepository).save(any<PasswordResetToken>())
     }
@@ -588,7 +581,7 @@ class AuthServiceTest {
 
         val result = authService.forgotPassword("unknown@example.com")
 
-        assertEquals(null, result)
+        assertThat(result).isNull()
         verify(passwordResetTokenRepository, never()).save(any())
     }
 
@@ -599,7 +592,7 @@ class AuthServiceTest {
 
         val result = authService.forgotPassword(inactiveUser.email)
 
-        assertEquals(null, result)
+        assertThat(result).isNull()
         verify(passwordResetTokenRepository, never()).save(any())
     }
 
@@ -634,7 +627,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.resetPassword("invalid-token", "NewPassword123!")
             }
-        assertEquals("Invalid or expired reset token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired reset token")
     }
 
     @Test
@@ -653,7 +646,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.resetPassword("expired-token", "NewPassword123!")
             }
-        assertEquals("Invalid or expired reset token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired reset token")
         verify(passwordResetTokenRepository).deleteById(expiredToken.id)
         verify(mongoTemplate, never()).findAndRemove(any(), eq(PasswordResetToken::class.java))
     }
@@ -693,14 +686,14 @@ class AuthServiceTest {
 
         val result = authService.switchOrganization(user, "org-456")
 
-        assertEquals("org-456", result.organizationId)
-        assertEquals(listOf("MEMBER"), result.roles)
-        assertNotNull(result.accessToken)
-        assertNotNull(result.refreshToken)
+        assertThat(result.organizationId).isEqualTo("org-456")
+        assertThat(result.roles).isEqualTo(listOf("MEMBER"))
+        assertThat(result.accessToken).isNotNull()
+        assertThat(result.refreshToken).isNotNull()
 
         val sessionCaptor = argumentCaptor<SessionToken>()
         verify(sessionTokenRepository).save(sessionCaptor.capture())
-        assertEquals("org-456", sessionCaptor.firstValue.organizationId)
+        assertThat(sessionCaptor.firstValue.organizationId).isEqualTo("org-456")
     }
 
     @Test
@@ -711,7 +704,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.switchOrganization(user, "org-999")
             }
-        assertEquals("You do not have access to this organization", exception.message)
+        assertThat(exception.message).isEqualTo("You do not have access to this organization")
     }
 
     @Test
@@ -731,7 +724,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.switchOrganization(user, "org-missing")
             }
-        assertEquals("Organization not found", exception.message)
+        assertThat(exception.message).isEqualTo("Organization not found")
     }
 
     @Test
@@ -752,7 +745,7 @@ class AuthServiceTest {
             assertThrows<IllegalArgumentException> {
                 authService.switchOrganization(user, "org-inactive")
             }
-        assertEquals("Organization is not active", exception.message)
+        assertThat(exception.message).isEqualTo("Organization is not active")
     }
 
     @Test
@@ -772,14 +765,14 @@ class AuthServiceTest {
 
         val result = authService.listUserOrganizations(user, "org-123")
 
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
         val current = result.first { it.isCurrent }
-        assertEquals("org-123", current.organizationId)
-        assertEquals(listOf("OWNER"), current.roles)
+        assertThat(current.organizationId).isEqualTo("org-123")
+        assertThat(current.roles).isEqualTo(listOf("OWNER"))
 
         val other = result.first { !it.isCurrent }
-        assertEquals("org-456", other.organizationId)
-        assertEquals(listOf("MEMBER"), other.roles)
+        assertThat(other.organizationId).isEqualTo("org-456")
+        assertThat(other.roles).isEqualTo(listOf("MEMBER"))
     }
 
     @Test
@@ -799,11 +792,11 @@ class AuthServiceTest {
 
         val result = authService.listUserOrganizations(user, "org-123")
 
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
         val active = result.first { it.organizationId == "org-123" }
-        assertTrue(active.isActive)
+        assertThat(active.isActive).isTrue()
         val inactive = result.first { it.organizationId == "org-inactive" }
-        assertFalse(inactive.isActive)
+        assertThat(inactive.isActive).isFalse()
     }
 
     private fun createMockOrganization() =

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.InvitationRepository
 import com.froilan.synectix.repository.RoleRepository
 import com.froilan.synectix.repository.UserRepository
 import com.froilan.synectix.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -29,9 +30,6 @@ import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 import java.util.Optional
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class InvitationServiceTest {
     private lateinit var invitationService: InvitationService
@@ -79,16 +77,15 @@ class InvitationServiceTest {
 
         val token = invitationService.invite(request, inviter, inviter.organizationId)
 
-        assertNotNull(token)
-        assertTrue(token.isNotEmpty())
+        assertThat(token).isNotNull().isNotEmpty()
 
         val captor = argumentCaptor<Invitation>()
         verify(invitationRepository).save(captor.capture())
-        assertEquals("newuser@example.com", captor.firstValue.email)
-        assertEquals("MEMBER", captor.firstValue.role)
-        assertEquals(inviter.organizationId, captor.firstValue.organizationId)
-        assertEquals(inviter.uuid, captor.firstValue.invitedBy)
-        assertEquals(InvitationStatus.PENDING, captor.firstValue.status)
+        assertThat(captor.firstValue.email).isEqualTo("newuser@example.com")
+        assertThat(captor.firstValue.role).isEqualTo("MEMBER")
+        assertThat(captor.firstValue.organizationId).isEqualTo(inviter.organizationId)
+        assertThat(captor.firstValue.invitedBy).isEqualTo(inviter.uuid)
+        assertThat(captor.firstValue.status).isEqualTo(InvitationStatus.PENDING)
     }
 
     @Test
@@ -99,7 +96,7 @@ class InvitationServiceTest {
         `when`(roleRepository.findByName("NONEXISTENT")).thenReturn(Optional.empty())
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
-        assertEquals("Role 'NONEXISTENT' does not exist", exception.message)
+        assertThat(exception.message).isEqualTo("Role 'NONEXISTENT' does not exist")
     }
 
     @Test
@@ -111,7 +108,7 @@ class InvitationServiceTest {
         `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(systemRole))
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
-        assertEquals("Cannot invite with system-level role", exception.message)
+        assertThat(exception.message).isEqualTo("Cannot invite with system-level role")
     }
 
     @Test
@@ -131,7 +128,7 @@ class InvitationServiceTest {
         ).thenReturn(Optional.of(existingInvitation))
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
-        assertEquals("An invitation has already been sent to this email", exception.message)
+        assertThat(exception.message).isEqualTo("An invitation has already been sent to this email")
     }
 
     @Test
@@ -157,15 +154,15 @@ class InvitationServiceTest {
 
         val token = invitationService.invite(request, inviter, inviter.organizationId)
 
-        assertNotNull(token)
+        assertThat(token).isNotNull()
         val captor = argumentCaptor<Invitation>()
         verify(invitationRepository, times(2)).save(captor.capture())
 
         val expired = captor.allValues.first { it.status == InvitationStatus.EXPIRED }
-        assertEquals(expiredInvitation.id, expired.id)
+        assertThat(expired.id).isEqualTo(expiredInvitation.id)
 
         val newInvite = captor.allValues.first { it.status == InvitationStatus.PENDING }
-        assertEquals("reinvite@example.com", newInvite.email)
+        assertThat(newInvite.email).isEqualTo("reinvite@example.com")
     }
 
     @Test
@@ -177,10 +174,10 @@ class InvitationServiceTest {
 
         val result = invitationService.validateInvitation("valid-token")
 
-        assertEquals(invitation.email, result.email)
-        assertEquals(invitation.role, result.role)
-        assertEquals(invitation.organizationId, result.organizationId)
-        assertEquals(false, result.existingUser)
+        assertThat(result.email).isEqualTo(invitation.email)
+        assertThat(result.role).isEqualTo(invitation.role)
+        assertThat(result.organizationId).isEqualTo(invitation.organizationId)
+        assertThat(result.existingUser).isEqualTo(false)
     }
 
     @Test
@@ -193,7 +190,7 @@ class InvitationServiceTest {
 
         val result = invitationService.validateInvitation("valid-token")
 
-        assertEquals(true, result.existingUser)
+        assertThat(result.existingUser).isEqualTo(true)
     }
 
     @Test
@@ -201,7 +198,7 @@ class InvitationServiceTest {
         `when`(invitationRepository.findByTokenHash("hashed-bad-token")).thenReturn(Optional.empty())
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.validateInvitation("bad-token") }
-        assertEquals("Invalid or expired invitation token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired invitation token")
     }
 
     @Test
@@ -225,15 +222,15 @@ class InvitationServiceTest {
 
         val result = invitationService.acceptInvitation(request)
 
-        assertNotNull(result)
-        assertEquals("newuser", result.username)
-        assertEquals(invitation.email, result.email)
-        assertEquals(invitation.organizationId, result.organizationId)
+        assertThat(result).isNotNull()
+        assertThat(result.username).isEqualTo("newuser")
+        assertThat(result.email).isEqualTo(invitation.email)
+        assertThat(result.organizationId).isEqualTo(invitation.organizationId)
 
         val userCaptor = argumentCaptor<User>()
         verify(userRepository).save(userCaptor.capture())
-        assertEquals("MEMBER", userCaptor.firstValue.roleAssignments[0].role)
-        assertEquals(invitation.organizationId, userCaptor.firstValue.roleAssignments[0].organizationId)
+        assertThat(userCaptor.firstValue.roleAssignments[0].role).isEqualTo("MEMBER")
+        assertThat(userCaptor.firstValue.roleAssignments[0].organizationId).isEqualTo(invitation.organizationId)
     }
 
     @Test
@@ -260,8 +257,8 @@ class InvitationServiceTest {
 
         val result = invitationService.acceptInvitation(request)
 
-        assertEquals(2, result.roleAssignments.size)
-        assertTrue(result.roleAssignments.any { it.role == "ADMIN" && it.organizationId == invitation.organizationId })
+        assertThat(result.roleAssignments.size).isEqualTo(2)
+        assertThat(result.roleAssignments.any { it.role == "ADMIN" && it.organizationId == invitation.organizationId }).isTrue()
 
         verify(passwordEncoder, never()).encode(any())
     }
@@ -281,7 +278,7 @@ class InvitationServiceTest {
             .thenReturn(null)
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
-        assertEquals("Invalid or expired invitation token", exception.message)
+        assertThat(exception.message).isEqualTo("Invalid or expired invitation token")
     }
 
     @Test
@@ -294,7 +291,7 @@ class InvitationServiceTest {
         `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
-        assertEquals("Username, password, first name, and last name are required for new users", exception.message)
+        assertThat(exception.message).isEqualTo("Username, password, first name, and last name are required for new users")
     }
 
     @Test
@@ -317,7 +314,7 @@ class InvitationServiceTest {
             .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.users index: username"))
 
         val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
-        assertEquals("Username already exists", exception.message)
+        assertThat(exception.message).isEqualTo("Username already exists")
     }
 
     @Test
@@ -331,7 +328,7 @@ class InvitationServiceTest {
 
         val captor = argumentCaptor<Invitation>()
         verify(invitationRepository).save(captor.capture())
-        assertEquals(InvitationStatus.REVOKED, captor.firstValue.status)
+        assertThat(captor.firstValue.status).isEqualTo(InvitationStatus.REVOKED)
     }
 
     @Test
@@ -344,7 +341,7 @@ class InvitationServiceTest {
             assertThrows<IllegalArgumentException> {
                 invitationService.revokeInvitation(invitation.id, "org-123")
             }
-        assertEquals("Invitation not found", exception.message)
+        assertThat(exception.message).isEqualTo("Invitation not found")
     }
 
     @Test
@@ -357,7 +354,7 @@ class InvitationServiceTest {
             assertThrows<IllegalArgumentException> {
                 invitationService.revokeInvitation(invitation.id, "org-123")
             }
-        assertEquals("Invitation is not pending", exception.message)
+        assertThat(exception.message).isEqualTo("Invitation is not pending")
     }
 
     @Test
@@ -369,7 +366,7 @@ class InvitationServiceTest {
 
         val result = invitationService.listInvitations("org-123")
 
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
     }
 
     private fun createMockUser() =


### PR DESCRIPTION
## Summary
Promotes staging to production. Completes Epic #4 (Identity, Roles & Access Control).

### API Key Management (#93)
- `ApiKey` model with hashed storage, key prefix, org-scoped permissions, optional expiry
- Bearer token fallback auth in `TokenAuthenticationFilter` (session first, API key second)
- API keys blocked from `/auth/` endpoints to prevent escalation
- Privilege subset validation — creators cannot grant permissions they don't hold
- Per-IP rate limiting on API key auth attempts (10 failures → 15min block)
- `ApiKeyPrincipal` + `ApiKeyContext` for distinguishing API key auth
- `API_KEY_MANAGE` permission for OWNER/ADMIN roles
- `Permissions.ALL_PERMISSIONS` list for validation
- Bean validation on `CreateApiKeyRequest.permissions` (`@NotEmpty`, `@NotBlank` elements)

### Testing Modernization (#95)
- mockito-kotlin 5.1.0 → 6.3.0
- All test assertions migrated from `kotlin.test` to AssertJ (141 assertions across 6 files)
- Zero `kotlin.test` imports remaining

### Additional Fixes
- Invitation operations scoped to active org via `SessionContext`
- Generic error messages for `DuplicateKeyException` (no MongoDB details leaked)
- `effectiveRoleNames()` returns `distinct()` for multi-org
- Health check broad catch fallback for structured UP/DOWN response
- `ENVIRONMENT_READ` restricted to system-level roles only
- Expired invitation transitions before re-invite
- `autoIndexCreation` enabled for `@Indexed` annotations

## Test plan
- [x] 146 tests pass (1 pre-existing context-load)
- [x] ktlint passes
- [x] All auth-iam epic items complete