### PR TITLE
Add General Ledger with double-entry journal entries and trial balance

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -49,6 +49,10 @@ class RoleSeeder(
                             Permissions.ACCOUNT_READ,
                             Permissions.ACCOUNT_UPDATE,
                             Permissions.ACCOUNT_DELETE,
+                            Permissions.JOURNAL_CREATE,
+                            Permissions.JOURNAL_READ,
+                            Permissions.JOURNAL_POST,
+                            Permissions.JOURNAL_VOID,
                         ),
                 ),
                 Role(
@@ -69,6 +73,9 @@ class RoleSeeder(
                             Permissions.ACCOUNT_CREATE,
                             Permissions.ACCOUNT_READ,
                             Permissions.ACCOUNT_UPDATE,
+                            Permissions.JOURNAL_CREATE,
+                            Permissions.JOURNAL_READ,
+                            Permissions.JOURNAL_POST,
                         ),
                 ),
                 Role(
@@ -83,6 +90,8 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_READ,
                             Permissions.INVITATION_READ,
                             Permissions.ACCOUNT_READ,
+                            Permissions.JOURNAL_CREATE,
+                            Permissions.JOURNAL_READ,
                         ),
                 ),
                 Role(
@@ -94,6 +103,7 @@ class RoleSeeder(
                             Permissions.SESSION_READ,
                             Permissions.ORGANIZATION_READ,
                             Permissions.ACCOUNT_READ,
+                            Permissions.JOURNAL_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -10,7 +10,9 @@ import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.security.ApiKeyContext
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.JournalEntryService
 import jakarta.validation.Valid
+import java.time.LocalDate
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -31,6 +33,7 @@ import java.util.Locale
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class AccountController(
     private val accountService: AccountService,
+    private val journalEntryService: JournalEntryService,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('account:create')")
@@ -117,6 +120,22 @@ class AccountController(
         } catch (e: IllegalArgumentException) {
             val status = if (e.message == "Account not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
             ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to delete account")))
+        }
+    }
+
+    @GetMapping("/{id}/balance")
+    @PreAuthorize("hasAuthority('account:read')")
+    fun getAccountBalance(
+        @PathVariable id: String,
+        @RequestParam(required = false) asOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val balance = journalEntryService.getAccountBalance(id, orgId, asOfDate)
+            ResponseEntity.ok(balance)
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (e.message ?: "Account not found")))
         }
     }
 

--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -12,7 +12,6 @@ import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.AccountService
 import com.froilan.synectix.service.JournalEntryService
 import jakarta.validation.Valid
-import java.time.LocalDate
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -26,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 import java.util.Locale
 
 @RestController

--- a/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
@@ -1,0 +1,183 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateJournalEntryRequest
+import com.froilan.synectix.dto.JournalEntryLineResponse
+import com.froilan.synectix.dto.JournalEntryResponse
+import com.froilan.synectix.dto.VoidJournalEntryRequest
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.User
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.JournalEntryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.util.Locale
+
+@RestController
+@RequestMapping("/finance/journal-entries")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class JournalEntryController(
+    private val journalEntryService: JournalEntryService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('journal:create')")
+    fun createJournalEntry(
+        @Valid @RequestBody request: CreateJournalEntryRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val createdBy = extractUserId() ?: "api-key"
+
+        return try {
+            val entry = journalEntryService.createJournalEntry(request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(entry.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create journal entry")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun listJournalEntries(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) startDate: LocalDate?,
+        @RequestParam(required = false) endDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        val entryStatus =
+            if (status != null) {
+                try {
+                    JournalEntryStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(
+                        mapOf("error" to "Invalid status '$status'"),
+                    )
+                }
+            } else {
+                null
+            }
+
+        val entries = journalEntryService.listJournalEntries(orgId, entryStatus, startDate, endDate)
+        return ResponseEntity.ok(entries.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun getJournalEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val entry = journalEntryService.getJournalEntry(id, orgId)
+            ResponseEntity.ok(entry.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (e.message ?: "Journal entry not found")))
+        }
+    }
+
+    @PostMapping("/{id}/post")
+    @PreAuthorize("hasAuthority('journal:post')")
+    fun postJournalEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val entry = journalEntryService.postJournalEntry(id, orgId)
+            ResponseEntity.ok(entry.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Journal entry not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to post journal entry")))
+        }
+    }
+
+    @PostMapping("/{id}/void")
+    @PreAuthorize("hasAuthority('journal:void')")
+    fun voidJournalEntry(
+        @PathVariable id: String,
+        @Valid @RequestBody request: VoidJournalEntryRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val entry = journalEntryService.voidJournalEntry(id, orgId, request.reason)
+            ResponseEntity.ok(entry.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Journal entry not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to void journal entry")))
+        }
+    }
+
+    @GetMapping("/trial-balance")
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun getTrialBalance(
+        @RequestParam(required = false) asOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val trialBalance = journalEntryService.getTrialBalance(orgId, asOfDate)
+        return ResponseEntity.ok(trialBalance)
+    }
+
+    private fun JournalEntry.toResponse() =
+        JournalEntryResponse(
+            id = id,
+            entryNumber = entryNumber,
+            date = date.toString(),
+            description = description,
+            organizationId = organizationId,
+            status = status.name,
+            source = source.name,
+            sourceReference = sourceReference,
+            lines =
+                lines.map { line ->
+                    JournalEntryLineResponse(
+                        accountId = line.accountId,
+                        accountCode = line.accountCode,
+                        accountName = line.accountName,
+                        debit = line.debit,
+                        credit = line.credit,
+                        description = line.description,
+                    )
+                },
+            createdBy = createdBy,
+            postedAt = postedAt?.toString(),
+            voidedAt = voidedAt?.toString(),
+            voidReason = voidReason,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun extractUserId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return (authentication.principal as? User)?.uuid
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
@@ -28,7 +28,7 @@ import java.time.LocalDate
 import java.util.Locale
 
 @RestController
-@RequestMapping("/finance/journal-entries")
+@RequestMapping("/finance/journal")
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class JournalEntryController(
     private val journalEntryService: JournalEntryService,

--- a/src/main/kotlin/com/froilan/synectix/dto/JournalEntryDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/JournalEntryDtos.kt
@@ -1,5 +1,6 @@
 package com.froilan.synectix.dto
 
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import java.math.BigDecimal
@@ -18,6 +19,7 @@ data class CreateJournalEntryRequest(
     @field:NotBlank(message = "Description is required")
     val description: String,
     @field:NotEmpty(message = "At least one line item is required")
+    @field:Valid
     val lines: List<JournalEntryLineRequest>,
     val sourceReference: String? = null,
 )

--- a/src/main/kotlin/com/froilan/synectix/dto/JournalEntryDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/JournalEntryDtos.kt
@@ -1,0 +1,72 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class JournalEntryLineRequest(
+    @field:NotBlank(message = "Account ID is required")
+    val accountId: String,
+    val debit: BigDecimal = BigDecimal.ZERO,
+    val credit: BigDecimal = BigDecimal.ZERO,
+    val description: String? = null,
+)
+
+data class CreateJournalEntryRequest(
+    val date: LocalDate,
+    @field:NotBlank(message = "Description is required")
+    val description: String,
+    @field:NotEmpty(message = "At least one line item is required")
+    val lines: List<JournalEntryLineRequest>,
+    val sourceReference: String? = null,
+)
+
+data class VoidJournalEntryRequest(
+    @field:NotBlank(message = "Void reason is required")
+    val reason: String,
+)
+
+data class JournalEntryLineResponse(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val debit: BigDecimal,
+    val credit: BigDecimal,
+    val description: String?,
+)
+
+data class JournalEntryResponse(
+    val id: String,
+    val entryNumber: String,
+    val date: String,
+    val description: String,
+    val organizationId: String,
+    val status: String,
+    val source: String,
+    val sourceReference: String?,
+    val lines: List<JournalEntryLineResponse>,
+    val createdBy: String,
+    val postedAt: String?,
+    val voidedAt: String?,
+    val voidReason: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class AccountBalanceResponse(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val accountType: String,
+    val totalDebits: BigDecimal,
+    val totalCredits: BigDecimal,
+    val balance: BigDecimal,
+)
+
+data class TrialBalanceResponse(
+    val accounts: List<AccountBalanceResponse>,
+    val totalDebits: BigDecimal,
+    val totalCredits: BigDecimal,
+    val asOfDate: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/JournalEntry.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/JournalEntry.kt
@@ -1,0 +1,60 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class JournalEntryStatus {
+    DRAFT,
+    POSTED,
+    VOIDED,
+}
+
+enum class JournalEntrySource {
+    MANUAL,
+    SYSTEM,
+}
+
+data class JournalEntryLine(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val debit: BigDecimal = BigDecimal.ZERO,
+    val credit: BigDecimal = BigDecimal.ZERO,
+    val description: String? = null,
+)
+
+@Document(collection = "journal_entries")
+@CompoundIndex(
+    name = "unique_entry_number_per_org",
+    def = "{'organizationId': 1, 'entryNumber': 1}",
+    unique = true,
+)
+data class JournalEntry(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val entryNumber: String,
+    val date: LocalDate,
+    val description: String,
+    @Indexed
+    val organizationId: String,
+    val status: JournalEntryStatus = JournalEntryStatus.DRAFT,
+    val source: JournalEntrySource = JournalEntrySource.MANUAL,
+    val sourceReference: String? = null,
+    val lines: List<JournalEntryLine>,
+    val createdBy: String,
+    val postedAt: LocalDateTime? = null,
+    val voidedAt: LocalDateTime? = null,
+    val voidReason: String? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
@@ -1,0 +1,38 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
+    fun findByOrganizationId(organizationId: String): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: JournalEntryStatus,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndDateBetween(
+        organizationId: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatusAndDateBetween(
+        organizationId: String,
+        status: JournalEntryStatus,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatusAndDateLessThanEqual(
+        organizationId: String,
+        status: JournalEntryStatus,
+        date: LocalDate,
+    ): List<JournalEntry>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
@@ -34,5 +34,21 @@ interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
         date: LocalDate,
     ): List<JournalEntry>
 
+    fun findByOrganizationIdAndDateGreaterThanEqual(
+        organizationId: String,
+        date: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndDateLessThanEqual(
+        organizationId: String,
+        date: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatusAndDateGreaterThanEqual(
+        organizationId: String,
+        status: JournalEntryStatus,
+        date: LocalDate,
+    ): List<JournalEntry>
+
     fun countByOrganizationId(organizationId: String): Long
 }

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -24,6 +24,11 @@ object Permissions {
     const val ACCOUNT_UPDATE = "account:update"
     const val ACCOUNT_DELETE = "account:delete"
 
+    const val JOURNAL_CREATE = "journal:create"
+    const val JOURNAL_READ = "journal:read"
+    const val JOURNAL_POST = "journal:post"
+    const val JOURNAL_VOID = "journal:void"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -42,5 +47,9 @@ object Permissions {
             ACCOUNT_READ,
             ACCOUNT_UPDATE,
             ACCOUNT_DELETE,
+            JOURNAL_CREATE,
+            JOURNAL_READ,
+            JOURNAL_POST,
+            JOURNAL_VOID,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -267,29 +267,27 @@ class JournalEntryService(
             }
         }
 
-        val accountIds = accountTotals.keys.toList()
-        val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
+        val allAccounts = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
 
         val accountBalances =
-            accountTotals
-                .mapNotNull { (accountId, totals) ->
-                    val account = accounts[accountId] ?: return@mapNotNull null
-                    val (totalDebits, totalCredits) = totals
-                    val balance =
-                        when (account.type) {
-                            AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
-                            AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
-                        }
-                    AccountBalanceResponse(
-                        accountId = account.id,
-                        accountCode = account.code,
-                        accountName = account.name,
-                        accountType = account.type.name,
-                        totalDebits = totalDebits,
-                        totalCredits = totalCredits,
-                        balance = balance,
-                    )
-                }.sortedBy { it.accountCode }
+            allAccounts.map { account ->
+                val (totalDebits, totalCredits) =
+                    accountTotals.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
+                val balance =
+                    when (account.type) {
+                        AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
+                        AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
+                    }
+                AccountBalanceResponse(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    accountType = account.type.name,
+                    totalDebits = totalDebits,
+                    totalCredits = totalCredits,
+                    balance = balance,
+                )
+            }.sortedBy { it.accountCode }
 
         val grandTotalDebits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalDebits) }
         val grandTotalCredits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalCredits) }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -273,24 +273,25 @@ class JournalEntryService(
         val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
 
         val accountBalances =
-            accountTotals.mapNotNull { (accountId, totals) ->
-                val account = accounts[accountId] ?: return@mapNotNull null
-                val (totalDebits, totalCredits) = totals
-                val balance =
-                    when (account.type) {
-                        AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
-                        AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
-                    }
-                AccountBalanceResponse(
-                    accountId = account.id,
-                    accountCode = account.code,
-                    accountName = account.name,
-                    accountType = account.type.name,
-                    totalDebits = totalDebits,
-                    totalCredits = totalCredits,
-                    balance = balance,
-                )
-            }.sortedBy { it.accountCode }
+            accountTotals
+                .mapNotNull { (accountId, totals) ->
+                    val account = accounts[accountId] ?: return@mapNotNull null
+                    val (totalDebits, totalCredits) = totals
+                    val balance =
+                        when (account.type) {
+                            AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
+                            AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
+                        }
+                    AccountBalanceResponse(
+                        accountId = account.id,
+                        accountCode = account.code,
+                        accountName = account.name,
+                        accountType = account.type.name,
+                        totalDebits = totalDebits,
+                        totalCredits = totalCredits,
+                        balance = balance,
+                    )
+                }.sortedBy { it.accountCode }
 
         val grandTotalDebits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalDebits) }
         val grandTotalCredits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalCredits) }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -1,0 +1,319 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AccountBalanceResponse
+import com.froilan.synectix.dto.CreateJournalEntryRequest
+import com.froilan.synectix.dto.TrialBalanceResponse
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Service
+class JournalEntryService(
+    private val journalEntryRepository: JournalEntryRepository,
+    private val accountRepository: AccountRepository,
+) {
+    @Transactional
+    fun createJournalEntry(
+        request: CreateJournalEntryRequest,
+        organizationId: String,
+        createdBy: String,
+    ): JournalEntry {
+        if (request.lines.size < 2) {
+            throw IllegalArgumentException("Journal entry must have at least 2 line items")
+        }
+
+        request.lines.forEach { line ->
+            val hasDebit = line.debit.compareTo(BigDecimal.ZERO) > 0
+            val hasCredit = line.credit.compareTo(BigDecimal.ZERO) > 0
+            if (hasDebit && hasCredit) {
+                throw IllegalArgumentException("A line item cannot have both debit and credit")
+            }
+            if (!hasDebit && !hasCredit) {
+                throw IllegalArgumentException("A line item must have either a debit or credit amount")
+            }
+            if (line.debit.compareTo(BigDecimal.ZERO) < 0 || line.credit.compareTo(BigDecimal.ZERO) < 0) {
+                throw IllegalArgumentException("Debit and credit amounts must not be negative")
+            }
+        }
+
+        val totalDebits = request.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
+        val totalCredits = request.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
+        if (totalDebits.compareTo(totalCredits) != 0) {
+            throw IllegalArgumentException(
+                "Journal entry must balance: debits ($totalDebits) != credits ($totalCredits)",
+            )
+        }
+
+        val accountIds = request.lines.map { it.accountId }.distinct()
+        val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
+
+        val lines =
+            request.lines.map { line ->
+                val account =
+                    accounts[line.accountId]
+                        ?: throw IllegalArgumentException("Account '${line.accountId}' not found")
+                if (account.organizationId != organizationId) {
+                    throw IllegalArgumentException("Account '${line.accountId}' not found")
+                }
+                if (!account.isActive) {
+                    throw IllegalArgumentException("Account '${account.code}' is inactive")
+                }
+                JournalEntryLine(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    debit = line.debit,
+                    credit = line.credit,
+                    description = line.description,
+                )
+            }
+
+        val count = journalEntryRepository.countByOrganizationId(organizationId)
+        val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
+
+        val entry =
+            JournalEntry(
+                entryNumber = entryNumber,
+                date = request.date,
+                description = request.description,
+                organizationId = organizationId,
+                lines = lines,
+                createdBy = createdBy,
+                sourceReference = request.sourceReference,
+            )
+        return journalEntryRepository.save(entry)
+    }
+
+    @Transactional
+    fun postJournalEntry(
+        entryId: String,
+        organizationId: String,
+    ): JournalEntry {
+        val entry = findEntry(entryId, organizationId)
+        if (entry.status != JournalEntryStatus.DRAFT) {
+            throw IllegalArgumentException("Only draft entries can be posted")
+        }
+
+        val totalDebits = entry.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
+        val totalCredits = entry.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
+        if (totalDebits.compareTo(totalCredits) != 0) {
+            throw IllegalArgumentException("Journal entry is not balanced")
+        }
+
+        return journalEntryRepository.save(
+            entry.copy(
+                status = JournalEntryStatus.POSTED,
+                postedAt = LocalDateTime.now(),
+            ),
+        )
+    }
+
+    @Transactional
+    fun voidJournalEntry(
+        entryId: String,
+        organizationId: String,
+        reason: String,
+    ): JournalEntry {
+        val entry = findEntry(entryId, organizationId)
+        if (entry.status != JournalEntryStatus.POSTED) {
+            throw IllegalArgumentException("Only posted entries can be voided")
+        }
+
+        val voidedEntry =
+            journalEntryRepository.save(
+                entry.copy(
+                    status = JournalEntryStatus.VOIDED,
+                    voidedAt = LocalDateTime.now(),
+                    voidReason = reason,
+                ),
+            )
+
+        val reversedLines =
+            entry.lines.map { line ->
+                line.copy(debit = line.credit, credit = line.debit)
+            }
+
+        val count = journalEntryRepository.countByOrganizationId(organizationId)
+        val reversingNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
+
+        journalEntryRepository.save(
+            JournalEntry(
+                entryNumber = reversingNumber,
+                date = LocalDate.now(),
+                description = "Reversal of ${entry.entryNumber}: $reason",
+                organizationId = organizationId,
+                status = JournalEntryStatus.POSTED,
+                source = JournalEntrySource.SYSTEM,
+                sourceReference = "VOID-${entry.id}",
+                lines = reversedLines,
+                createdBy = entry.createdBy,
+                postedAt = LocalDateTime.now(),
+            ),
+        )
+
+        return voidedEntry
+    }
+
+    fun getJournalEntry(
+        entryId: String,
+        organizationId: String,
+    ): JournalEntry = findEntry(entryId, organizationId)
+
+    fun listJournalEntries(
+        organizationId: String,
+        status: JournalEntryStatus? = null,
+        startDate: LocalDate? = null,
+        endDate: LocalDate? = null,
+    ): List<JournalEntry> =
+        when {
+            status != null && startDate != null && endDate != null ->
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+                    organizationId,
+                    status,
+                    startDate,
+                    endDate,
+                )
+            status != null ->
+                journalEntryRepository.findByOrganizationIdAndStatus(organizationId, status)
+            startDate != null && endDate != null ->
+                journalEntryRepository.findByOrganizationIdAndDateBetween(organizationId, startDate, endDate)
+            else ->
+                journalEntryRepository.findByOrganizationId(organizationId)
+        }
+
+    fun getAccountBalance(
+        accountId: String,
+        organizationId: String,
+        asOfDate: LocalDate? = null,
+    ): AccountBalanceResponse {
+        val account =
+            accountRepository.findById(accountId).orElseThrow {
+                IllegalArgumentException("Account not found")
+            }
+        if (account.organizationId != organizationId) {
+            throw IllegalArgumentException("Account not found")
+        }
+
+        val entries =
+            if (asOfDate != null) {
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateLessThanEqual(
+                    organizationId,
+                    JournalEntryStatus.POSTED,
+                    asOfDate,
+                )
+            } else {
+                journalEntryRepository.findByOrganizationIdAndStatus(
+                    organizationId,
+                    JournalEntryStatus.POSTED,
+                )
+            }
+
+        var totalDebits = BigDecimal.ZERO
+        var totalCredits = BigDecimal.ZERO
+        entries.forEach { entry ->
+            entry.lines.filter { it.accountId == accountId }.forEach { line ->
+                totalDebits = totalDebits.add(line.debit)
+                totalCredits = totalCredits.add(line.credit)
+            }
+        }
+
+        val balance =
+            when (account.type) {
+                AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
+                AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
+            }
+
+        return AccountBalanceResponse(
+            accountId = account.id,
+            accountCode = account.code,
+            accountName = account.name,
+            accountType = account.type.name,
+            totalDebits = totalDebits,
+            totalCredits = totalCredits,
+            balance = balance,
+        )
+    }
+
+    fun getTrialBalance(
+        organizationId: String,
+        asOfDate: LocalDate? = null,
+    ): TrialBalanceResponse {
+        val entries =
+            if (asOfDate != null) {
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateLessThanEqual(
+                    organizationId,
+                    JournalEntryStatus.POSTED,
+                    asOfDate,
+                )
+            } else {
+                journalEntryRepository.findByOrganizationIdAndStatus(
+                    organizationId,
+                    JournalEntryStatus.POSTED,
+                )
+            }
+
+        val accountTotals = mutableMapOf<String, Pair<BigDecimal, BigDecimal>>()
+        entries.forEach { entry ->
+            entry.lines.forEach { line ->
+                val (debits, credits) = accountTotals.getOrDefault(line.accountId, BigDecimal.ZERO to BigDecimal.ZERO)
+                accountTotals[line.accountId] = debits.add(line.debit) to credits.add(line.credit)
+            }
+        }
+
+        val accountIds = accountTotals.keys.toList()
+        val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
+
+        val accountBalances =
+            accountTotals.mapNotNull { (accountId, totals) ->
+                val account = accounts[accountId] ?: return@mapNotNull null
+                val (totalDebits, totalCredits) = totals
+                val balance =
+                    when (account.type) {
+                        AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
+                        AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
+                    }
+                AccountBalanceResponse(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    accountType = account.type.name,
+                    totalDebits = totalDebits,
+                    totalCredits = totalCredits,
+                    balance = balance,
+                )
+            }.sortedBy { it.accountCode }
+
+        val grandTotalDebits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalDebits) }
+        val grandTotalCredits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalCredits) }
+
+        return TrialBalanceResponse(
+            accounts = accountBalances,
+            totalDebits = grandTotalDebits,
+            totalCredits = grandTotalCredits,
+            asOfDate = asOfDate?.toString(),
+        )
+    }
+
+    private fun findEntry(
+        entryId: String,
+        organizationId: String,
+    ): JournalEntry {
+        val entry =
+            journalEntryRepository.findById(entryId).orElseThrow {
+                IllegalArgumentException("Journal entry not found")
+            }
+        if (entry.organizationId != organizationId) {
+            throw IllegalArgumentException("Journal entry not found")
+        }
+        return entry
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -270,24 +270,25 @@ class JournalEntryService(
         val allAccounts = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
 
         val accountBalances =
-            allAccounts.map { account ->
-                val (totalDebits, totalCredits) =
-                    accountTotals.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
-                val balance =
-                    when (account.type) {
-                        AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
-                        AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
-                    }
-                AccountBalanceResponse(
-                    accountId = account.id,
-                    accountCode = account.code,
-                    accountName = account.name,
-                    accountType = account.type.name,
-                    totalDebits = totalDebits,
-                    totalCredits = totalCredits,
-                    balance = balance,
-                )
-            }.sortedBy { it.accountCode }
+            allAccounts
+                .map { account ->
+                    val (totalDebits, totalCredits) =
+                        accountTotals.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
+                    val balance =
+                        when (account.type) {
+                            AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
+                            AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
+                        }
+                    AccountBalanceResponse(
+                        accountId = account.id,
+                        accountCode = account.code,
+                        accountName = account.name,
+                        accountType = account.type.name,
+                        totalDebits = totalDebits,
+                        totalCredits = totalCredits,
+                        balance = balance,
+                    )
+                }.sortedBy { it.accountCode }
 
         val grandTotalDebits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalDebits) }
         val grandTotalCredits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalCredits) }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -10,6 +10,7 @@ import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -77,10 +78,7 @@ class JournalEntryService(
                 )
             }
 
-        val count = journalEntryRepository.countByOrganizationId(organizationId)
-        val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
-
-        val entry =
+        return saveWithRetry(organizationId) { entryNumber ->
             JournalEntry(
                 entryNumber = entryNumber,
                 date = request.date,
@@ -90,7 +88,7 @@ class JournalEntryService(
                 createdBy = createdBy,
                 sourceReference = request.sourceReference,
             )
-        return journalEntryRepository.save(entry)
+        }
     }
 
     @Transactional
@@ -142,10 +140,7 @@ class JournalEntryService(
                 line.copy(debit = line.credit, credit = line.debit)
             }
 
-        val count = journalEntryRepository.countByOrganizationId(organizationId)
-        val reversingNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
-
-        journalEntryRepository.save(
+        saveWithRetry(organizationId) { reversingNumber ->
             JournalEntry(
                 entryNumber = reversingNumber,
                 date = LocalDate.now(),
@@ -157,8 +152,8 @@ class JournalEntryService(
                 lines = reversedLines,
                 createdBy = entry.createdBy,
                 postedAt = LocalDateTime.now(),
-            ),
-        )
+            )
+        }
 
         return voidedEntry
     }
@@ -316,5 +311,22 @@ class JournalEntryService(
             throw IllegalArgumentException("Journal entry not found")
         }
         return entry
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildEntry: (String) -> JournalEntry,
+    ): JournalEntry {
+        repeat(maxRetries) {
+            val count = journalEntryRepository.countByOrganizationId(organizationId)
+            val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return journalEntryRepository.save(buildEntry(entryNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) throw e
+            }
+        }
+        throw IllegalStateException("Failed to generate unique entry number")
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -32,6 +32,9 @@ class JournalEntryService(
         }
 
         request.lines.forEach { line ->
+            if (line.debit.compareTo(BigDecimal.ZERO) < 0 || line.credit.compareTo(BigDecimal.ZERO) < 0) {
+                throw IllegalArgumentException("Debit and credit amounts must not be negative")
+            }
             val hasDebit = line.debit.compareTo(BigDecimal.ZERO) > 0
             val hasCredit = line.credit.compareTo(BigDecimal.ZERO) > 0
             if (hasDebit && hasCredit) {
@@ -39,9 +42,6 @@ class JournalEntryService(
             }
             if (!hasDebit && !hasCredit) {
                 throw IllegalArgumentException("A line item must have either a debit or credit amount")
-            }
-            if (line.debit.compareTo(BigDecimal.ZERO) < 0 || line.credit.compareTo(BigDecimal.ZERO) < 0) {
-                throw IllegalArgumentException("Debit and credit amounts must not be negative")
             }
         }
 

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -171,16 +171,19 @@ class JournalEntryService(
     ): List<JournalEntry> =
         when {
             status != null && startDate != null && endDate != null ->
-                journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
-                    organizationId,
-                    status,
-                    startDate,
-                    endDate,
-                )
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(organizationId, status, startDate, endDate)
+            status != null && startDate != null ->
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateGreaterThanEqual(organizationId, status, startDate)
+            status != null && endDate != null ->
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateLessThanEqual(organizationId, status, endDate)
             status != null ->
                 journalEntryRepository.findByOrganizationIdAndStatus(organizationId, status)
             startDate != null && endDate != null ->
                 journalEntryRepository.findByOrganizationIdAndDateBetween(organizationId, startDate, endDate)
+            startDate != null ->
+                journalEntryRepository.findByOrganizationIdAndDateGreaterThanEqual(organizationId, startDate)
+            endDate != null ->
+                journalEntryRepository.findByOrganizationIdAndDateLessThanEqual(organizationId, endDate)
             else ->
                 journalEntryRepository.findByOrganizationId(organizationId)
         }

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -69,6 +69,10 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.ACCOUNT_UPDATE,
                         Permissions.ACCOUNT_DELETE,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
+                        Permissions.JOURNAL_POST,
+                        Permissions.JOURNAL_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -130,6 +134,10 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.ACCOUNT_UPDATE,
                         Permissions.ACCOUNT_DELETE,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
+                        Permissions.JOURNAL_POST,
+                        Permissions.JOURNAL_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -218,6 +226,10 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.ACCOUNT_UPDATE,
                         Permissions.ACCOUNT_DELETE,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
+                        Permissions.JOURNAL_POST,
+                        Permissions.JOURNAL_VOID,
                     ),
             )
         val admin =
@@ -239,6 +251,9 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_CREATE,
                         Permissions.ACCOUNT_READ,
                         Permissions.ACCOUNT_UPDATE,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
+                        Permissions.JOURNAL_POST,
                     ),
             )
         val member =
@@ -254,6 +269,8 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.INVITATION_READ,
                         Permissions.ACCOUNT_READ,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
                     ),
             )
         val viewer =
@@ -261,7 +278,13 @@ class RoleSeederTest {
                 name = "VIEWER",
                 description = "Read-only organization access",
                 level = RoleLevel.ORGANIZATION,
-                permissions = listOf(Permissions.SESSION_READ, Permissions.ORGANIZATION_READ, Permissions.ACCOUNT_READ),
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ACCOUNT_READ,
+                        Permissions.JOURNAL_READ,
+                    ),
             )
 
         `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(superAdmin))

--- a/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
@@ -18,6 +18,7 @@ import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AccountService
 import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.JournalEntryService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -80,6 +81,9 @@ class AccountControllerTest {
 
     @MockitoBean
     private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
@@ -143,7 +143,7 @@ class JournalEntryControllerTest {
 
         mockMvc
             .perform(
-                post("/finance/journal-entries")
+                post("/finance/journal")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         """
@@ -176,7 +176,7 @@ class JournalEntryControllerTest {
 
         mockMvc
             .perform(
-                post("/finance/journal-entries")
+                post("/finance/journal")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         """
@@ -200,7 +200,7 @@ class JournalEntryControllerTest {
         `when`(journalEntryService.listJournalEntries(any(), anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(entries)
 
         mockMvc
-            .perform(get("/finance/journal-entries"))
+            .perform(get("/finance/journal"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.length()").value(1))
             .andExpect(jsonPath("$[0].id").value("je-123"))
@@ -215,7 +215,7 @@ class JournalEntryControllerTest {
         `when`(journalEntryService.getJournalEntry(any(), any())).thenReturn(entry)
 
         mockMvc
-            .perform(get("/finance/journal-entries/je-123"))
+            .perform(get("/finance/journal/je-123"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value("je-123"))
             .andExpect(jsonPath("$.entryNumber").value("JE-0001"))
@@ -230,7 +230,7 @@ class JournalEntryControllerTest {
             .thenThrow(IllegalArgumentException("Journal entry not found"))
 
         mockMvc
-            .perform(get("/finance/journal-entries/nonexistent"))
+            .perform(get("/finance/journal/nonexistent"))
             .andExpect(status().isNotFound)
             .andExpect(jsonPath("$.error").value("Journal entry not found"))
     }
@@ -241,7 +241,7 @@ class JournalEntryControllerTest {
         `when`(journalEntryService.postJournalEntry(any(), any())).thenReturn(entry)
 
         mockMvc
-            .perform(post("/finance/journal-entries/je-123/post"))
+            .perform(post("/finance/journal/je-123/post"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value("je-123"))
             .andExpect(jsonPath("$.status").value("POSTED"))
@@ -254,7 +254,7 @@ class JournalEntryControllerTest {
 
         mockMvc
             .perform(
-                post("/finance/journal-entries/je-123/void")
+                post("/finance/journal/je-123/void")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"reason": "Error correction"}"""),
             ).andExpect(status().isOk)
@@ -295,7 +295,7 @@ class JournalEntryControllerTest {
 
         val result =
             mockMvc
-                .perform(get("/finance/journal-entries/trial-balance"))
+                .perform(get("/finance/journal/trial-balance"))
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.accounts.length()").value(2))
                 .andExpect(jsonPath("$.accounts[0].accountCode").value("1000"))
@@ -313,7 +313,7 @@ class JournalEntryControllerTest {
 
         mockMvc
             .perform(
-                post("/finance/journal-entries")
+                post("/finance/journal")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(
                         """

--- a/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
@@ -1,0 +1,332 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.dto.AccountBalanceResponse
+import com.froilan.synectix.dto.TrialBalanceResponse
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.JournalEntryService
+import com.froilan.synectix.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@WebMvcTest(controllers = [JournalEntryController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class JournalEntryControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var apiKeyRepository: ApiKeyRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("journal:create", "journal:read", "journal:post", "journal:void", "account:read")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    private fun createMockJournalEntry() =
+        JournalEntry(
+            id = "je-123",
+            entryNumber = "JE-0001",
+            date = LocalDate.of(2026, 1, 15),
+            description = "Test entry",
+            organizationId = "org-123",
+            status = JournalEntryStatus.DRAFT,
+            source = JournalEntrySource.MANUAL,
+            lines =
+                listOf(
+                    JournalEntryLine("acc-1", "1000", "Cash", BigDecimal("100.00"), BigDecimal.ZERO, null),
+                    JournalEntryLine("acc-2", "4000", "Sales Revenue", BigDecimal.ZERO, BigDecimal("100.00"), null),
+                ),
+            createdBy = "user-123",
+        )
+
+    @Test
+    fun `POST journal-entries should return 201 when created`() {
+        val entry = createMockJournalEntry()
+        `when`(journalEntryService.createJournalEntry(any(), any(), any())).thenReturn(entry)
+
+        mockMvc
+            .perform(
+                post("/finance/journal-entries")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "date": "2026-01-15",
+                            "description": "Test entry",
+                            "lines": [
+                                {"accountId": "acc-1", "debit": 100.00, "credit": 0},
+                                {"accountId": "acc-2", "debit": 0, "credit": 100.00}
+                            ]
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value("je-123"))
+            .andExpect(jsonPath("$.entryNumber").value("JE-0001"))
+            .andExpect(jsonPath("$.date").value("2026-01-15"))
+            .andExpect(jsonPath("$.description").value("Test entry"))
+            .andExpect(jsonPath("$.organizationId").value("org-123"))
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+            .andExpect(jsonPath("$.source").value("MANUAL"))
+            .andExpect(jsonPath("$.lines.length()").value(2))
+            .andExpect(jsonPath("$.createdBy").value("user-123"))
+    }
+
+    @Test
+    fun `POST journal-entries should return 400 when unbalanced`() {
+        `when`(journalEntryService.createJournalEntry(any(), any(), any()))
+            .thenThrow(IllegalArgumentException("Journal entry must balance: debits (100.00) != credits (50.00)"))
+
+        mockMvc
+            .perform(
+                post("/finance/journal-entries")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "date": "2026-01-15",
+                            "description": "Unbalanced entry",
+                            "lines": [
+                                {"accountId": "acc-1", "debit": 100.00, "credit": 0},
+                                {"accountId": "acc-2", "debit": 0, "credit": 50.00}
+                            ]
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Journal entry must balance: debits (100.00) != credits (50.00)"))
+    }
+
+    @Test
+    fun `GET journal-entries should return 200 with entry list`() {
+        val entries = listOf(createMockJournalEntry())
+        `when`(journalEntryService.listJournalEntries(any(), anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(entries)
+
+        mockMvc
+            .perform(get("/finance/journal-entries"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value("je-123"))
+            .andExpect(jsonPath("$[0].entryNumber").value("JE-0001"))
+            .andExpect(jsonPath("$[0].status").value("DRAFT"))
+            .andExpect(jsonPath("$[0].lines.length()").value(2))
+    }
+
+    @Test
+    fun `GET journal-entries by id should return 200`() {
+        val entry = createMockJournalEntry()
+        `when`(journalEntryService.getJournalEntry(any(), any())).thenReturn(entry)
+
+        mockMvc
+            .perform(get("/finance/journal-entries/je-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("je-123"))
+            .andExpect(jsonPath("$.entryNumber").value("JE-0001"))
+            .andExpect(jsonPath("$.date").value("2026-01-15"))
+            .andExpect(jsonPath("$.description").value("Test entry"))
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+    }
+
+    @Test
+    fun `GET journal-entries by id should return 404 when not found`() {
+        `when`(journalEntryService.getJournalEntry(any(), any()))
+            .thenThrow(IllegalArgumentException("Journal entry not found"))
+
+        mockMvc
+            .perform(get("/finance/journal-entries/nonexistent"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.error").value("Journal entry not found"))
+    }
+
+    @Test
+    fun `POST journal-entries id post should return 200`() {
+        val entry = createMockJournalEntry().copy(status = JournalEntryStatus.POSTED)
+        `when`(journalEntryService.postJournalEntry(any(), any())).thenReturn(entry)
+
+        mockMvc
+            .perform(post("/finance/journal-entries/je-123/post"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("je-123"))
+            .andExpect(jsonPath("$.status").value("POSTED"))
+    }
+
+    @Test
+    fun `POST journal-entries id void should return 200`() {
+        val entry = createMockJournalEntry().copy(status = JournalEntryStatus.VOIDED)
+        `when`(journalEntryService.voidJournalEntry(any(), any(), any())).thenReturn(entry)
+
+        mockMvc
+            .perform(
+                post("/finance/journal-entries/je-123/void")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"reason": "Error correction"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("je-123"))
+            .andExpect(jsonPath("$.status").value("VOIDED"))
+    }
+
+    @Test
+    fun `GET trial-balance should return 200`() {
+        val trialBalance =
+            TrialBalanceResponse(
+                accounts =
+                    listOf(
+                        AccountBalanceResponse(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            accountType = "ASSET",
+                            totalDebits = BigDecimal("100.00"),
+                            totalCredits = BigDecimal.ZERO,
+                            balance = BigDecimal("100.00"),
+                        ),
+                        AccountBalanceResponse(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Sales Revenue",
+                            accountType = "REVENUE",
+                            totalDebits = BigDecimal.ZERO,
+                            totalCredits = BigDecimal("100.00"),
+                            balance = BigDecimal("100.00"),
+                        ),
+                    ),
+                totalDebits = BigDecimal("100.00"),
+                totalCredits = BigDecimal("100.00"),
+                asOfDate = null,
+            )
+        `when`(journalEntryService.getTrialBalance(any(), anyOrNull())).thenReturn(trialBalance)
+
+        val result =
+            mockMvc
+                .perform(get("/finance/journal-entries/trial-balance"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.accounts.length()").value(2))
+                .andExpect(jsonPath("$.accounts[0].accountCode").value("1000"))
+                .andExpect(jsonPath("$.accounts[1].accountCode").value("4000"))
+                .andExpect(jsonPath("$.totalDebits").value(100.00))
+                .andExpect(jsonPath("$.totalCredits").value(100.00))
+                .andReturn()
+
+        assertThat(result.response.status).isEqualTo(200)
+    }
+
+    @Test
+    fun `POST journal-entries should return 403 without journal create permission`() {
+        setupAuthWithPermissions("journal:read")
+
+        mockMvc
+            .perform(
+                post("/finance/journal-entries")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "date": "2026-01-15",
+                            "description": "Test entry",
+                            "lines": [
+                                {"accountId": "acc-1", "debit": 100.00, "credit": 0},
+                                {"accountId": "acc-2", "debit": 0, "credit": 100.00}
+                            ]
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -537,7 +537,7 @@ class JournalEntryServiceTest {
             )
 
         `when`(journalEntryRepository.findByOrganizationIdAndStatus(orgId, JournalEntryStatus.POSTED)).thenReturn(entries)
-        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(cashAccount, revenueAccount))
 
         val result = journalEntryService.getTrialBalance(orgId)
 

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -1,0 +1,594 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateJournalEntryRequest
+import com.froilan.synectix.dto.JournalEntryLineRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class JournalEntryServiceTest {
+    private lateinit var journalEntryService: JournalEntryService
+    private lateinit var journalEntryRepository: JournalEntryRepository
+    private lateinit var accountRepository: AccountRepository
+
+    private val orgId = "org-123"
+    private val createdBy = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        journalEntryRepository = mock(JournalEntryRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        journalEntryService =
+            JournalEntryService(
+                journalEntryRepository = journalEntryRepository,
+                accountRepository = accountRepository,
+            )
+    }
+
+    @Test
+    fun `create should save balanced journal entry as DRAFT`() {
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        val revenueAccount = createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = orgId)
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Sale received",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
+
+        assertThat(result.status).isEqualTo(JournalEntryStatus.DRAFT)
+        assertThat(result.source).isEqualTo(JournalEntrySource.MANUAL)
+        assertThat(result.description).isEqualTo("Sale received")
+        assertThat(result.organizationId).isEqualTo(orgId)
+        assertThat(result.createdBy).isEqualTo(createdBy)
+        assertThat(result.lines).hasSize(2)
+        assertThat(result.lines[0].debit).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(result.lines[1].credit).isEqualByComparingTo(BigDecimal("100.00"))
+
+        val captor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(captor.capture())
+        assertThat(captor.firstValue.status).isEqualTo(JournalEntryStatus.DRAFT)
+    }
+
+    @Test
+    fun `create should throw when less than 2 lines`() {
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Bad entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("at least 2 line items")
+    }
+
+    @Test
+    fun `create should throw when line has both debit and credit`() {
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Bad entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal("50.00")),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("50.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("cannot have both debit and credit")
+    }
+
+    @Test
+    fun `create should throw when line has zero debit and credit`() {
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Bad entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal.ZERO, credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("must have either a debit or credit amount")
+    }
+
+    @Test
+    fun `create should throw when entry is unbalanced`() {
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Unbalanced entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("50.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("must balance")
+    }
+
+    @Test
+    fun `create should throw when account not found`() {
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-missing"))).thenReturn(
+            listOf(createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)),
+        )
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Missing account",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-missing", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("not found")
+    }
+
+    @Test
+    fun `create should throw when account is inactive`() {
+        val inactiveAccount =
+            createMockAccount(
+                id = "acc-2",
+                code = "4000",
+                name = "Old Revenue",
+                type = AccountType.REVENUE,
+                orgId = orgId,
+            ).copy(isActive = false)
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, inactiveAccount))
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Inactive account entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("inactive")
+    }
+
+    @Test
+    fun `create should throw when account is in different org`() {
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        val otherOrgAccount =
+            createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = "other-org")
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, otherOrgAccount))
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Wrong org entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("not found")
+    }
+
+    @Test
+    fun `create should generate sequential entry number`() {
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        val revenueAccount = createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = orgId)
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(5L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Sequential test",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
+
+        assertThat(result.entryNumber).isEqualTo("JE-0006")
+    }
+
+    @Test
+    fun `post should change status from DRAFT to POSTED`() {
+        val draftEntry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.DRAFT,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(draftEntry))
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val result = journalEntryService.postJournalEntry("entry-1", orgId)
+
+        assertThat(result.status).isEqualTo(JournalEntryStatus.POSTED)
+        assertThat(result.postedAt).isNotNull()
+
+        val captor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(captor.capture())
+        assertThat(captor.firstValue.status).isEqualTo(JournalEntryStatus.POSTED)
+    }
+
+    @Test
+    fun `post should throw when entry is not DRAFT`() {
+        val postedEntry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.POSTED,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(postedEntry))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.postJournalEntry("entry-1", orgId)
+            }
+        assertThat(exception.message).contains("Only draft entries can be posted")
+    }
+
+    @Test
+    fun `void should change status to VOIDED and create reversing entry`() {
+        val postedEntry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.POSTED,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("200.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("200.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(postedEntry))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val result = journalEntryService.voidJournalEntry("entry-1", orgId, "Incorrect amount")
+
+        assertThat(result.status).isEqualTo(JournalEntryStatus.VOIDED)
+        assertThat(result.voidedAt).isNotNull()
+        assertThat(result.voidReason).isEqualTo("Incorrect amount")
+
+        val captor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository, times(2)).save(captor.capture())
+
+        val allSaved = captor.allValues
+        assertThat(allSaved).hasSize(2)
+
+        // First save is the voided entry
+        val voidedSave = allSaved[0]
+        assertThat(voidedSave.status).isEqualTo(JournalEntryStatus.VOIDED)
+
+        // Second save is the reversing entry
+        val reversingSave = allSaved[1]
+        assertThat(reversingSave.status).isEqualTo(JournalEntryStatus.POSTED)
+        assertThat(reversingSave.source).isEqualTo(JournalEntrySource.SYSTEM)
+        assertThat(reversingSave.description).contains("Reversal of JE-0001")
+        assertThat(reversingSave.lines[0].debit).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(reversingSave.lines[0].credit).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(reversingSave.lines[1].debit).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(reversingSave.lines[1].credit).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `void should throw when entry is not POSTED`() {
+        val draftEntry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.DRAFT,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(draftEntry))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.voidJournalEntry("entry-1", orgId, "Some reason")
+            }
+        assertThat(exception.message).contains("Only posted entries can be voided")
+    }
+
+    @Test
+    fun `getAccountBalance should sum debits and credits from posted entries`() {
+        val account = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
+
+        val entries =
+            listOf(
+                createMockEntry(
+                    id = "entry-1",
+                    entryNumber = "JE-0001",
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-1",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal("500.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-2",
+                                accountCode = "4000",
+                                accountName = "Revenue",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("500.00"),
+                            ),
+                        ),
+                    orgId = orgId,
+                ),
+                createMockEntry(
+                    id = "entry-2",
+                    entryNumber = "JE-0002",
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-3",
+                                accountCode = "5000",
+                                accountName = "Expense",
+                                debit = BigDecimal("150.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-1",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("150.00"),
+                            ),
+                        ),
+                    orgId = orgId,
+                ),
+            )
+
+        `when`(journalEntryRepository.findByOrganizationIdAndStatus(orgId, JournalEntryStatus.POSTED)).thenReturn(entries)
+
+        val result = journalEntryService.getAccountBalance("acc-1", orgId)
+
+        assertThat(result.accountId).isEqualTo("acc-1")
+        assertThat(result.accountCode).isEqualTo("1000")
+        assertThat(result.accountName).isEqualTo("Cash")
+        assertThat(result.accountType).isEqualTo("ASSET")
+        assertThat(result.totalDebits).isEqualByComparingTo(BigDecimal("500.00"))
+        assertThat(result.totalCredits).isEqualByComparingTo(BigDecimal("150.00"))
+        // ASSET: balance = debits - credits
+        assertThat(result.balance).isEqualByComparingTo(BigDecimal("350.00"))
+    }
+
+    @Test
+    fun `getTrialBalance should return all account balances`() {
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        val revenueAccount = createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = orgId)
+
+        val entries =
+            listOf(
+                createMockEntry(
+                    id = "entry-1",
+                    entryNumber = "JE-0001",
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-1",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal("300.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-2",
+                                accountCode = "4000",
+                                accountName = "Revenue",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("300.00"),
+                            ),
+                        ),
+                    orgId = orgId,
+                ),
+            )
+
+        `when`(journalEntryRepository.findByOrganizationIdAndStatus(orgId, JournalEntryStatus.POSTED)).thenReturn(entries)
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, revenueAccount))
+
+        val result = journalEntryService.getTrialBalance(orgId)
+
+        assertThat(result.accounts).hasSize(2)
+        assertThat(result.totalDebits).isEqualByComparingTo(BigDecimal("300.00"))
+        assertThat(result.totalCredits).isEqualByComparingTo(BigDecimal("300.00"))
+        // Trial balance must balance: total debits == total credits
+        assertThat(result.totalDebits).isEqualByComparingTo(result.totalCredits)
+
+        val cashBalance = result.accounts.find { it.accountId == "acc-1" }
+        assertThat(cashBalance).isNotNull
+        assertThat(cashBalance!!.totalDebits).isEqualByComparingTo(BigDecimal("300.00"))
+        assertThat(cashBalance.balance).isEqualByComparingTo(BigDecimal("300.00"))
+
+        val revenueBalance = result.accounts.find { it.accountId == "acc-2" }
+        assertThat(revenueBalance).isNotNull
+        assertThat(revenueBalance!!.totalCredits).isEqualByComparingTo(BigDecimal("300.00"))
+        // REVENUE: balance = credits - debits
+        assertThat(revenueBalance.balance).isEqualByComparingTo(BigDecimal("300.00"))
+    }
+
+    private fun createMockAccount(
+        id: String = "acc-1",
+        code: String = "1000",
+        name: String = "Cash",
+        type: AccountType = AccountType.ASSET,
+        orgId: String = "org-123",
+    ) = Account(
+        id = id,
+        code = code,
+        name = name,
+        type = type,
+        organizationId = orgId,
+        isActive = true,
+        isSystemAccount = false,
+    )
+
+    private fun createMockEntry(
+        id: String = "entry-1",
+        entryNumber: String = "JE-0001",
+        status: JournalEntryStatus = JournalEntryStatus.DRAFT,
+        lines: List<JournalEntryLine> = emptyList(),
+        orgId: String = "org-123",
+    ) = JournalEntry(
+        id = id,
+        entryNumber = entryNumber,
+        date = LocalDate.of(2026, 1, 15),
+        description = "Test entry",
+        organizationId = orgId,
+        status = status,
+        lines = lines,
+        createdBy = "user-1",
+    )
+}


### PR DESCRIPTION
## Summary
Core transaction engine for the ERP. Implements double-entry bookkeeping with balanced debit/credit journal entries posted against Chart of Accounts.

### Journal Entry Lifecycle
- **DRAFT** → **POSTED** → **VOIDED** (two-step: create as draft, separate post action)
- Voiding creates an auto-reversing entry (debits/credits swapped, source=SYSTEM)
- Posted entries are immutable — can only be voided, not edited

### Key Features
- Balance enforcement: total debits must equal total credits
- Line validation: each line has debit XOR credit (not both, not zero, not negative)
- Account validation: all referenced accounts must be active and in the same org
- Sequential entry numbering per org with retry on collision (JE-0001, JE-0002, ...)
- Denormalized account code/name on lines for fast reads
- Account balance calculation (debit-normal for ASSET/EXPENSE, credit-normal for LIABILITY/EQUITY/REVENUE)
- Trial balance report with ALL active accounts (including zero-balance) and grand totals
- BigDecimal for all monetary amounts
- Open-ended date range filtering (startDate only, endDate only, or both)
- API key + session auth support via extractOrganizationId()

### Endpoints
| Method | Path | Permission | Description |
|--------|------|-----------|-------------|
| POST | `/finance/journal` | `journal:create` | Create draft entry |
| GET | `/finance/journal` | `journal:read` | List entries (filter: status, startDate, endDate) |
| GET | `/finance/journal/{id}` | `journal:read` | Get single entry |
| POST | `/finance/journal/{id}/post` | `journal:post` | Post draft entry |
| POST | `/finance/journal/{id}/void` | `journal:void` | Void posted entry |
| GET | `/finance/accounts/{id}/balance` | `account:read` | Account balance (optional asOfDate) |
| GET | `/finance/journal/trial-balance` | `journal:read` | Trial balance report (optional asOfDate) |

### Permissions
- OWNER: journal:create, journal:read, journal:post, journal:void
- ADMIN: journal:create, journal:read, journal:post
- MEMBER: journal:create, journal:read
- VIEWER: journal:read

### Tests
- 24 new tests (15 service + 9 controller)

## Test plan
- [x] 200/201 tests pass (1 pre-existing context-load failure)
- [x] ktlint passes

Closes #25