### PR TITLE
Release: Chart of Accounts and General Ledger

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -45,6 +45,10 @@ class RoleSeeder(
                             Permissions.INVITATION_READ,
                             Permissions.INVITATION_WRITE,
                             Permissions.API_KEY_MANAGE,
+                            Permissions.ACCOUNT_CREATE,
+                            Permissions.ACCOUNT_READ,
+                            Permissions.ACCOUNT_UPDATE,
+                            Permissions.ACCOUNT_DELETE,
                         ),
                 ),
                 Role(
@@ -62,6 +66,9 @@ class RoleSeeder(
                             Permissions.INVITATION_READ,
                             Permissions.INVITATION_WRITE,
                             Permissions.API_KEY_MANAGE,
+                            Permissions.ACCOUNT_CREATE,
+                            Permissions.ACCOUNT_READ,
+                            Permissions.ACCOUNT_UPDATE,
                         ),
                 ),
                 Role(
@@ -75,6 +82,7 @@ class RoleSeeder(
                             Permissions.USER_READ,
                             Permissions.ORGANIZATION_READ,
                             Permissions.INVITATION_READ,
+                            Permissions.ACCOUNT_READ,
                         ),
                 ),
                 Role(
@@ -85,6 +93,7 @@ class RoleSeeder(
                         listOf(
                             Permissions.SESSION_READ,
                             Permissions.ORGANIZATION_READ,
+                            Permissions.ACCOUNT_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -49,6 +49,10 @@ class RoleSeeder(
                             Permissions.ACCOUNT_READ,
                             Permissions.ACCOUNT_UPDATE,
                             Permissions.ACCOUNT_DELETE,
+                            Permissions.JOURNAL_CREATE,
+                            Permissions.JOURNAL_READ,
+                            Permissions.JOURNAL_POST,
+                            Permissions.JOURNAL_VOID,
                         ),
                 ),
                 Role(
@@ -69,6 +73,9 @@ class RoleSeeder(
                             Permissions.ACCOUNT_CREATE,
                             Permissions.ACCOUNT_READ,
                             Permissions.ACCOUNT_UPDATE,
+                            Permissions.JOURNAL_CREATE,
+                            Permissions.JOURNAL_READ,
+                            Permissions.JOURNAL_POST,
                         ),
                 ),
                 Role(
@@ -83,6 +90,8 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_READ,
                             Permissions.INVITATION_READ,
                             Permissions.ACCOUNT_READ,
+                            Permissions.JOURNAL_CREATE,
+                            Permissions.JOURNAL_READ,
                         ),
                 ),
                 Role(
@@ -94,6 +103,7 @@ class RoleSeeder(
                             Permissions.SESSION_READ,
                             Permissions.ORGANIZATION_READ,
                             Permissions.ACCOUNT_READ,
+                            Permissions.JOURNAL_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -51,6 +51,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.DELETE, "/auth/invitations/*").authenticated()
                 it.requestMatchers("/auth/organizations", "/auth/organizations/**").authenticated()
                 it.requestMatchers("/auth/api-keys", "/auth/api-keys/**").authenticated()
+                it.requestMatchers("/finance/**").authenticated()
                 it.requestMatchers("/auth/**").permitAll()
                 it.requestMatchers("/health/**").permitAll()
                 it.requestMatchers("/actuator/health/**").permitAll()

--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -1,0 +1,151 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.AccountResponse
+import com.froilan.synectix.dto.CreateAccountRequest
+import com.froilan.synectix.dto.UpdateAccountRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.AccountService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/finance/accounts")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class AccountController(
+    private val accountService: AccountService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('account:create')")
+    fun createAccount(
+        @Valid @RequestBody request: CreateAccountRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val account = accountService.createAccount(request, orgId)
+            ResponseEntity.status(HttpStatus.CREATED).body(account.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create account")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('account:read')")
+    fun listAccounts(
+        @RequestParam(required = false) type: String?,
+        @RequestParam(required = false) parentId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        val accountType =
+            if (type != null) {
+                try {
+                    AccountType.valueOf(type.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(
+                        mapOf("error" to "Invalid account type '$type'"),
+                    )
+                }
+            } else {
+                null
+            }
+
+        val accounts = accountService.listAccounts(orgId, accountType, parentId)
+        return ResponseEntity.ok(accounts.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('account:read')")
+    fun getAccount(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val account = accountService.getAccount(id, orgId)
+            ResponseEntity.ok(account.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (e.message ?: "Account not found")))
+        }
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('account:update')")
+    fun updateAccount(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateAccountRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val account = accountService.updateAccount(id, request, orgId)
+            ResponseEntity.ok(account.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Account not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to update account")))
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('account:delete')")
+    fun deleteAccount(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            accountService.deleteAccount(id, orgId)
+            ResponseEntity.ok(mapOf("message" to "Account deactivated"))
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Account not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to delete account")))
+        }
+    }
+
+    private fun Account.toResponse() =
+        AccountResponse(
+            id = id,
+            code = code,
+            name = name,
+            description = description,
+            type = type.name,
+            parentId = parentId,
+            organizationId = organizationId,
+            isActive = isActive,
+            isSystemAccount = isSystemAccount,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -10,6 +10,7 @@ import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.security.ApiKeyContext
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.JournalEntryService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 import java.util.Locale
 
 @RestController
@@ -31,6 +33,7 @@ import java.util.Locale
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class AccountController(
     private val accountService: AccountService,
+    private val journalEntryService: JournalEntryService,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('account:create')")
@@ -117,6 +120,22 @@ class AccountController(
         } catch (e: IllegalArgumentException) {
             val status = if (e.message == "Account not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
             ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to delete account")))
+        }
+    }
+
+    @GetMapping("/{id}/balance")
+    @PreAuthorize("hasAuthority('account:read')")
+    fun getAccountBalance(
+        @PathVariable id: String,
+        @RequestParam(required = false) asOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val balance = journalEntryService.getAccountBalance(id, orgId, asOfDate)
+            ResponseEntity.ok(balance)
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (e.message ?: "Account not found")))
         }
     }
 

--- a/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
@@ -1,0 +1,183 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateJournalEntryRequest
+import com.froilan.synectix.dto.JournalEntryLineResponse
+import com.froilan.synectix.dto.JournalEntryResponse
+import com.froilan.synectix.dto.VoidJournalEntryRequest
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.User
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.JournalEntryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.util.Locale
+
+@RestController
+@RequestMapping("/finance/journal")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class JournalEntryController(
+    private val journalEntryService: JournalEntryService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('journal:create')")
+    fun createJournalEntry(
+        @Valid @RequestBody request: CreateJournalEntryRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val createdBy = extractUserId() ?: "api-key"
+
+        return try {
+            val entry = journalEntryService.createJournalEntry(request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(entry.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create journal entry")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun listJournalEntries(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) startDate: LocalDate?,
+        @RequestParam(required = false) endDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        val entryStatus =
+            if (status != null) {
+                try {
+                    JournalEntryStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(
+                        mapOf("error" to "Invalid status '$status'"),
+                    )
+                }
+            } else {
+                null
+            }
+
+        val entries = journalEntryService.listJournalEntries(orgId, entryStatus, startDate, endDate)
+        return ResponseEntity.ok(entries.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun getJournalEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val entry = journalEntryService.getJournalEntry(id, orgId)
+            ResponseEntity.ok(entry.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (e.message ?: "Journal entry not found")))
+        }
+    }
+
+    @PostMapping("/{id}/post")
+    @PreAuthorize("hasAuthority('journal:post')")
+    fun postJournalEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val entry = journalEntryService.postJournalEntry(id, orgId)
+            ResponseEntity.ok(entry.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Journal entry not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to post journal entry")))
+        }
+    }
+
+    @PostMapping("/{id}/void")
+    @PreAuthorize("hasAuthority('journal:void')")
+    fun voidJournalEntry(
+        @PathVariable id: String,
+        @Valid @RequestBody request: VoidJournalEntryRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val entry = journalEntryService.voidJournalEntry(id, orgId, request.reason)
+            ResponseEntity.ok(entry.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Journal entry not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to void journal entry")))
+        }
+    }
+
+    @GetMapping("/trial-balance")
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun getTrialBalance(
+        @RequestParam(required = false) asOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val trialBalance = journalEntryService.getTrialBalance(orgId, asOfDate)
+        return ResponseEntity.ok(trialBalance)
+    }
+
+    private fun JournalEntry.toResponse() =
+        JournalEntryResponse(
+            id = id,
+            entryNumber = entryNumber,
+            date = date.toString(),
+            description = description,
+            organizationId = organizationId,
+            status = status.name,
+            source = source.name,
+            sourceReference = sourceReference,
+            lines =
+                lines.map { line ->
+                    JournalEntryLineResponse(
+                        accountId = line.accountId,
+                        accountCode = line.accountCode,
+                        accountName = line.accountName,
+                        debit = line.debit,
+                        credit = line.credit,
+                        description = line.description,
+                    )
+                },
+            createdBy = createdBy,
+            postedAt = postedAt?.toString(),
+            voidedAt = voidedAt?.toString(),
+            voidReason = voidReason,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun extractUserId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return (authentication.principal as? User)?.uuid
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/AccountDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/AccountDtos.kt
@@ -1,0 +1,33 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreateAccountRequest(
+    @field:NotBlank(message = "Account code is required")
+    val code: String,
+    @field:NotBlank(message = "Account name is required")
+    val name: String,
+    @field:NotBlank(message = "Account type is required")
+    val type: String,
+    val parentId: String? = null,
+    val description: String? = null,
+)
+
+data class UpdateAccountRequest(
+    val name: String? = null,
+    val description: String? = null,
+)
+
+data class AccountResponse(
+    val id: String,
+    val code: String,
+    val name: String,
+    val description: String?,
+    val type: String,
+    val parentId: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val isSystemAccount: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/dto/JournalEntryDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/JournalEntryDtos.kt
@@ -1,0 +1,74 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class JournalEntryLineRequest(
+    @field:NotBlank(message = "Account ID is required")
+    val accountId: String,
+    val debit: BigDecimal = BigDecimal.ZERO,
+    val credit: BigDecimal = BigDecimal.ZERO,
+    val description: String? = null,
+)
+
+data class CreateJournalEntryRequest(
+    val date: LocalDate,
+    @field:NotBlank(message = "Description is required")
+    val description: String,
+    @field:NotEmpty(message = "At least one line item is required")
+    @field:Valid
+    val lines: List<JournalEntryLineRequest>,
+    val sourceReference: String? = null,
+)
+
+data class VoidJournalEntryRequest(
+    @field:NotBlank(message = "Void reason is required")
+    val reason: String,
+)
+
+data class JournalEntryLineResponse(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val debit: BigDecimal,
+    val credit: BigDecimal,
+    val description: String?,
+)
+
+data class JournalEntryResponse(
+    val id: String,
+    val entryNumber: String,
+    val date: String,
+    val description: String,
+    val organizationId: String,
+    val status: String,
+    val source: String,
+    val sourceReference: String?,
+    val lines: List<JournalEntryLineResponse>,
+    val createdBy: String,
+    val postedAt: String?,
+    val voidedAt: String?,
+    val voidReason: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class AccountBalanceResponse(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val accountType: String,
+    val totalDebits: BigDecimal,
+    val totalCredits: BigDecimal,
+    val balance: BigDecimal,
+)
+
+data class TrialBalanceResponse(
+    val accounts: List<AccountBalanceResponse>,
+    val totalDebits: BigDecimal,
+    val totalCredits: BigDecimal,
+    val asOfDate: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Account.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Account.kt
@@ -1,0 +1,38 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class AccountType {
+    ASSET,
+    LIABILITY,
+    EQUITY,
+    REVENUE,
+    EXPENSE,
+}
+
+@Document(collection = "accounts")
+@CompoundIndex(name = "unique_code_per_org", def = "{'organizationId': 1, 'code': 1}", unique = true)
+data class Account(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val code: String,
+    val name: String,
+    val description: String? = null,
+    val type: AccountType,
+    val parentId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    val isSystemAccount: Boolean = false,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/JournalEntry.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/JournalEntry.kt
@@ -1,0 +1,60 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class JournalEntryStatus {
+    DRAFT,
+    POSTED,
+    VOIDED,
+}
+
+enum class JournalEntrySource {
+    MANUAL,
+    SYSTEM,
+}
+
+data class JournalEntryLine(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val debit: BigDecimal = BigDecimal.ZERO,
+    val credit: BigDecimal = BigDecimal.ZERO,
+    val description: String? = null,
+)
+
+@Document(collection = "journal_entries")
+@CompoundIndex(
+    name = "unique_entry_number_per_org",
+    def = "{'organizationId': 1, 'entryNumber': 1}",
+    unique = true,
+)
+data class JournalEntry(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val entryNumber: String,
+    val date: LocalDate,
+    val description: String,
+    @Indexed
+    val organizationId: String,
+    val status: JournalEntryStatus = JournalEntryStatus.DRAFT,
+    val source: JournalEntrySource = JournalEntrySource.MANUAL,
+    val sourceReference: String? = null,
+    val lines: List<JournalEntryLine>,
+    val createdBy: String,
+    val postedAt: LocalDateTime? = null,
+    val voidedAt: LocalDateTime? = null,
+    val voidReason: String? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/AccountRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/AccountRepository.kt
@@ -1,0 +1,55 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface AccountRepository : MongoRepository<Account, String> {
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Account>
+
+    fun findByOrganizationIdAndTypeAndIsActive(
+        organizationId: String,
+        type: AccountType,
+        isActive: Boolean,
+    ): List<Account>
+
+    fun findByOrganizationIdAndParentIdAndIsActive(
+        organizationId: String,
+        parentId: String,
+        isActive: Boolean,
+    ): List<Account>
+
+    fun findByOrganizationIdAndTypeAndParentIdAndIsActive(
+        organizationId: String,
+        type: AccountType,
+        parentId: String,
+        isActive: Boolean,
+    ): List<Account>
+
+    fun findByOrganizationIdAndCode(
+        organizationId: String,
+        code: String,
+    ): Optional<Account>
+
+    fun existsByOrganizationIdAndCode(
+        organizationId: String,
+        code: String,
+    ): Boolean
+
+    fun existsByOrganizationIdAndParentId(
+        organizationId: String,
+        parentId: String,
+    ): Boolean
+
+    fun existsByOrganizationIdAndParentIdAndIsActive(
+        organizationId: String,
+        parentId: String,
+        isActive: Boolean,
+    ): Boolean
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
@@ -50,5 +50,16 @@ interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
         date: LocalDate,
     ): List<JournalEntry>
 
+    fun findByOrganizationIdAndStatusIn(
+        organizationId: String,
+        statuses: List<JournalEntryStatus>,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatusInAndDateLessThanEqual(
+        organizationId: String,
+        statuses: List<JournalEntryStatus>,
+        date: LocalDate,
+    ): List<JournalEntry>
+
     fun countByOrganizationId(organizationId: String): Long
 }

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
@@ -1,0 +1,54 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
+    fun findByOrganizationId(organizationId: String): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: JournalEntryStatus,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndDateBetween(
+        organizationId: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatusAndDateBetween(
+        organizationId: String,
+        status: JournalEntryStatus,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatusAndDateLessThanEqual(
+        organizationId: String,
+        status: JournalEntryStatus,
+        date: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndDateGreaterThanEqual(
+        organizationId: String,
+        date: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndDateLessThanEqual(
+        organizationId: String,
+        date: LocalDate,
+    ): List<JournalEntry>
+
+    fun findByOrganizationIdAndStatusAndDateGreaterThanEqual(
+        organizationId: String,
+        status: JournalEntryStatus,
+        date: LocalDate,
+    ): List<JournalEntry>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -24,6 +24,11 @@ object Permissions {
     const val ACCOUNT_UPDATE = "account:update"
     const val ACCOUNT_DELETE = "account:delete"
 
+    const val JOURNAL_CREATE = "journal:create"
+    const val JOURNAL_READ = "journal:read"
+    const val JOURNAL_POST = "journal:post"
+    const val JOURNAL_VOID = "journal:void"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -42,5 +47,9 @@ object Permissions {
             ACCOUNT_READ,
             ACCOUNT_UPDATE,
             ACCOUNT_DELETE,
+            JOURNAL_CREATE,
+            JOURNAL_READ,
+            JOURNAL_POST,
+            JOURNAL_VOID,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -19,6 +19,11 @@ object Permissions {
 
     const val API_KEY_MANAGE = "apikey:manage"
 
+    const val ACCOUNT_CREATE = "account:create"
+    const val ACCOUNT_READ = "account:read"
+    const val ACCOUNT_UPDATE = "account:update"
+    const val ACCOUNT_DELETE = "account:delete"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -33,5 +38,9 @@ object Permissions {
             INVITATION_READ,
             INVITATION_WRITE,
             API_KEY_MANAGE,
+            ACCOUNT_CREATE,
+            ACCOUNT_READ,
+            ACCOUNT_UPDATE,
+            ACCOUNT_DELETE,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
@@ -272,9 +272,8 @@ class AccountService(
                     isSystemAccount = true,
                 ),
             )
-        val existing = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
-        if (existing.isNotEmpty()) {
-            log.info("Accounts already exist for org: {}. Skipping seed.", organizationId)
+        if (accountRepository.existsByOrganizationIdAndCode(organizationId, "1000")) {
+            log.info("Default accounts already exist for org: {}. Skipping seed.", organizationId)
             return
         }
         accountRepository.saveAll(defaults)

--- a/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
@@ -1,0 +1,283 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateAccountRequest
+import com.froilan.synectix.dto.UpdateAccountRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.repository.AccountRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.Locale
+
+@Service
+class AccountService(
+    private val accountRepository: AccountRepository,
+) {
+    private val log = LoggerFactory.getLogger(AccountService::class.java)
+
+    @Transactional
+    fun createAccount(
+        request: CreateAccountRequest,
+        organizationId: String,
+    ): Account {
+        val type =
+            try {
+                AccountType.valueOf(request.type.uppercase(Locale.ROOT))
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException(
+                    "Invalid account type '${request.type}'. Must be one of: ${AccountType.entries.joinToString()}",
+                )
+            }
+
+        if (request.parentId != null) {
+            val parent =
+                accountRepository.findById(request.parentId).orElseThrow {
+                    IllegalArgumentException("Parent account not found")
+                }
+            if (parent.organizationId != organizationId) {
+                throw IllegalArgumentException("Parent account not found")
+            }
+            if (parent.type != type) {
+                throw IllegalArgumentException("Parent account must be the same type")
+            }
+        }
+
+        val account =
+            Account(
+                code = request.code,
+                name = request.name,
+                description = request.description,
+                type = type,
+                parentId = request.parentId,
+                organizationId = organizationId,
+            )
+        return try {
+            accountRepository.save(account)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException("Account code '${request.code}' already exists in this organization")
+        }
+    }
+
+    @Transactional
+    fun updateAccount(
+        accountId: String,
+        request: UpdateAccountRequest,
+        organizationId: String,
+    ): Account {
+        val account =
+            accountRepository.findById(accountId).orElseThrow {
+                IllegalArgumentException("Account not found")
+            }
+        if (account.organizationId != organizationId) {
+            throw IllegalArgumentException("Account not found")
+        }
+        if (request.name != null && request.name.isBlank()) {
+            throw IllegalArgumentException("Account name must not be blank")
+        }
+
+        val updated =
+            account.copy(
+                name = request.name ?: account.name,
+                description = request.description ?: account.description,
+            )
+        return accountRepository.save(updated)
+    }
+
+    fun getAccount(
+        accountId: String,
+        organizationId: String,
+    ): Account {
+        val account =
+            accountRepository.findById(accountId).orElseThrow {
+                IllegalArgumentException("Account not found")
+            }
+        if (account.organizationId != organizationId) {
+            throw IllegalArgumentException("Account not found")
+        }
+        return account
+    }
+
+    fun listAccounts(
+        organizationId: String,
+        type: AccountType? = null,
+        parentId: String? = null,
+    ): List<Account> =
+        when {
+            type != null && parentId != null ->
+                accountRepository.findByOrganizationIdAndTypeAndParentIdAndIsActive(organizationId, type, parentId, true)
+            type != null -> accountRepository.findByOrganizationIdAndTypeAndIsActive(organizationId, type, true)
+            parentId != null -> accountRepository.findByOrganizationIdAndParentIdAndIsActive(organizationId, parentId, true)
+            else -> accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        }
+
+    @Transactional
+    fun deleteAccount(
+        accountId: String,
+        organizationId: String,
+    ) {
+        val account =
+            accountRepository.findById(accountId).orElseThrow {
+                IllegalArgumentException("Account not found")
+            }
+        if (account.organizationId != organizationId) {
+            throw IllegalArgumentException("Account not found")
+        }
+        if (account.isSystemAccount) {
+            throw IllegalArgumentException("System accounts cannot be deleted")
+        }
+        if (accountRepository.existsByOrganizationIdAndParentIdAndIsActive(organizationId, accountId, true)) {
+            throw IllegalArgumentException("Cannot delete account with child accounts")
+        }
+        accountRepository.save(account.copy(isActive = false))
+    }
+
+    @Transactional
+    fun seedDefaultAccounts(organizationId: String) {
+        val defaults =
+            listOf(
+                Account(code = "1000", name = "Cash", type = AccountType.ASSET, organizationId = organizationId, isSystemAccount = true),
+                Account(
+                    code = "1100",
+                    name = "Accounts Receivable",
+                    type = AccountType.ASSET,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "1200",
+                    name = "Inventory",
+                    type = AccountType.ASSET,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "1300",
+                    name = "Prepaid Expenses",
+                    type = AccountType.ASSET,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "1500",
+                    name = "Fixed Assets",
+                    type = AccountType.ASSET,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "2000",
+                    name = "Accounts Payable",
+                    type = AccountType.LIABILITY,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "2100",
+                    name = "Accrued Expenses",
+                    type = AccountType.LIABILITY,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "2200",
+                    name = "Short-term Loans",
+                    type = AccountType.LIABILITY,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "2500",
+                    name = "Long-term Debt",
+                    type = AccountType.LIABILITY,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "3000",
+                    name = "Owner's Equity",
+                    type = AccountType.EQUITY,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "3100",
+                    name = "Retained Earnings",
+                    type = AccountType.EQUITY,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "4000",
+                    name = "Sales Revenue",
+                    type = AccountType.REVENUE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "4100",
+                    name = "Service Revenue",
+                    type = AccountType.REVENUE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "4200",
+                    name = "Other Income",
+                    type = AccountType.REVENUE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "5000",
+                    name = "Cost of Goods Sold",
+                    type = AccountType.EXPENSE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "5100",
+                    name = "Salaries & Wages",
+                    type = AccountType.EXPENSE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "5200",
+                    name = "Rent Expense",
+                    type = AccountType.EXPENSE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "5300",
+                    name = "Utilities",
+                    type = AccountType.EXPENSE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "5400",
+                    name = "Office Supplies",
+                    type = AccountType.EXPENSE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "5500",
+                    name = "Depreciation",
+                    type = AccountType.EXPENSE,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+            )
+        val existing = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        if (existing.isNotEmpty()) {
+            log.info("Accounts already exist for org: {}. Skipping seed.", organizationId)
+            return
+        }
+        accountRepository.saveAll(defaults)
+        log.info("Seeded {} default accounts for org: {}", defaults.size, organizationId)
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -37,6 +37,7 @@ class AuthService(
     private val sessionTokenRepository: SessionTokenRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
     private val passwordResetTokenRepository: PasswordResetTokenRepository,
+    private val accountService: AccountService,
     private val mongoTemplate: MongoTemplate,
     private val tokenHasher: TokenHasher,
     private val passwordEncoder: PasswordEncoder,
@@ -62,6 +63,7 @@ class AuthService(
                     legalName = request.orgLegalName,
                 )
             val savedOrganization = organizationRepository.save(organization)
+            accountService.seedDefaultAccounts(savedOrganization.uuid)
 
             val user =
                 User(

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -1,0 +1,334 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AccountBalanceResponse
+import com.froilan.synectix.dto.CreateJournalEntryRequest
+import com.froilan.synectix.dto.TrialBalanceResponse
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Service
+class JournalEntryService(
+    private val journalEntryRepository: JournalEntryRepository,
+    private val accountRepository: AccountRepository,
+) {
+    @Transactional
+    fun createJournalEntry(
+        request: CreateJournalEntryRequest,
+        organizationId: String,
+        createdBy: String,
+    ): JournalEntry {
+        if (request.lines.size < 2) {
+            throw IllegalArgumentException("Journal entry must have at least 2 line items")
+        }
+
+        request.lines.forEach { line ->
+            if (line.debit.compareTo(BigDecimal.ZERO) < 0 || line.credit.compareTo(BigDecimal.ZERO) < 0) {
+                throw IllegalArgumentException("Debit and credit amounts must not be negative")
+            }
+            val hasDebit = line.debit.compareTo(BigDecimal.ZERO) > 0
+            val hasCredit = line.credit.compareTo(BigDecimal.ZERO) > 0
+            if (hasDebit && hasCredit) {
+                throw IllegalArgumentException("A line item cannot have both debit and credit")
+            }
+            if (!hasDebit && !hasCredit) {
+                throw IllegalArgumentException("A line item must have either a debit or credit amount")
+            }
+        }
+
+        val totalDebits = request.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
+        val totalCredits = request.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
+        if (totalDebits.compareTo(totalCredits) != 0) {
+            throw IllegalArgumentException(
+                "Journal entry must balance: debits ($totalDebits) != credits ($totalCredits)",
+            )
+        }
+
+        val accountIds = request.lines.map { it.accountId }.distinct()
+        val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
+
+        val lines =
+            request.lines.map { line ->
+                val account =
+                    accounts[line.accountId]
+                        ?: throw IllegalArgumentException("Account '${line.accountId}' not found")
+                if (account.organizationId != organizationId) {
+                    throw IllegalArgumentException("Account '${line.accountId}' not found")
+                }
+                if (!account.isActive) {
+                    throw IllegalArgumentException("Account '${account.code}' is inactive")
+                }
+                JournalEntryLine(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    debit = line.debit,
+                    credit = line.credit,
+                    description = line.description,
+                )
+            }
+
+        return saveWithRetry(organizationId) { entryNumber ->
+            JournalEntry(
+                entryNumber = entryNumber,
+                date = request.date,
+                description = request.description,
+                organizationId = organizationId,
+                lines = lines,
+                createdBy = createdBy,
+                sourceReference = request.sourceReference,
+            )
+        }
+    }
+
+    @Transactional
+    fun postJournalEntry(
+        entryId: String,
+        organizationId: String,
+    ): JournalEntry {
+        val entry = findEntry(entryId, organizationId)
+        if (entry.status != JournalEntryStatus.DRAFT) {
+            throw IllegalArgumentException("Only draft entries can be posted")
+        }
+
+        val totalDebits = entry.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
+        val totalCredits = entry.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
+        if (totalDebits.compareTo(totalCredits) != 0) {
+            throw IllegalArgumentException("Journal entry is not balanced")
+        }
+
+        return journalEntryRepository.save(
+            entry.copy(
+                status = JournalEntryStatus.POSTED,
+                postedAt = LocalDateTime.now(),
+            ),
+        )
+    }
+
+    @Transactional
+    fun voidJournalEntry(
+        entryId: String,
+        organizationId: String,
+        reason: String,
+    ): JournalEntry {
+        val entry = findEntry(entryId, organizationId)
+        if (entry.status != JournalEntryStatus.POSTED) {
+            throw IllegalArgumentException("Only posted entries can be voided")
+        }
+
+        val voidedEntry =
+            journalEntryRepository.save(
+                entry.copy(
+                    status = JournalEntryStatus.VOIDED,
+                    voidedAt = LocalDateTime.now(),
+                    voidReason = reason,
+                ),
+            )
+
+        val reversedLines =
+            entry.lines.map { line ->
+                line.copy(debit = line.credit, credit = line.debit)
+            }
+
+        saveWithRetry(organizationId) { reversingNumber ->
+            JournalEntry(
+                entryNumber = reversingNumber,
+                date = LocalDate.now(),
+                description = "Reversal of ${entry.entryNumber}: $reason",
+                organizationId = organizationId,
+                status = JournalEntryStatus.POSTED,
+                source = JournalEntrySource.SYSTEM,
+                sourceReference = "VOID-${entry.id}",
+                lines = reversedLines,
+                createdBy = entry.createdBy,
+                postedAt = LocalDateTime.now(),
+            )
+        }
+
+        return voidedEntry
+    }
+
+    fun getJournalEntry(
+        entryId: String,
+        organizationId: String,
+    ): JournalEntry = findEntry(entryId, organizationId)
+
+    fun listJournalEntries(
+        organizationId: String,
+        status: JournalEntryStatus? = null,
+        startDate: LocalDate? = null,
+        endDate: LocalDate? = null,
+    ): List<JournalEntry> =
+        when {
+            status != null && startDate != null && endDate != null ->
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(organizationId, status, startDate, endDate)
+            status != null && startDate != null ->
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateGreaterThanEqual(organizationId, status, startDate)
+            status != null && endDate != null ->
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateLessThanEqual(organizationId, status, endDate)
+            status != null ->
+                journalEntryRepository.findByOrganizationIdAndStatus(organizationId, status)
+            startDate != null && endDate != null ->
+                journalEntryRepository.findByOrganizationIdAndDateBetween(organizationId, startDate, endDate)
+            startDate != null ->
+                journalEntryRepository.findByOrganizationIdAndDateGreaterThanEqual(organizationId, startDate)
+            endDate != null ->
+                journalEntryRepository.findByOrganizationIdAndDateLessThanEqual(organizationId, endDate)
+            else ->
+                journalEntryRepository.findByOrganizationId(organizationId)
+        }
+
+    fun getAccountBalance(
+        accountId: String,
+        organizationId: String,
+        asOfDate: LocalDate? = null,
+    ): AccountBalanceResponse {
+        val account =
+            accountRepository.findById(accountId).orElseThrow {
+                IllegalArgumentException("Account not found")
+            }
+        if (account.organizationId != organizationId) {
+            throw IllegalArgumentException("Account not found")
+        }
+
+        val entries =
+            if (asOfDate != null) {
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateLessThanEqual(
+                    organizationId,
+                    JournalEntryStatus.POSTED,
+                    asOfDate,
+                )
+            } else {
+                journalEntryRepository.findByOrganizationIdAndStatus(
+                    organizationId,
+                    JournalEntryStatus.POSTED,
+                )
+            }
+
+        var totalDebits = BigDecimal.ZERO
+        var totalCredits = BigDecimal.ZERO
+        entries.forEach { entry ->
+            entry.lines.filter { it.accountId == accountId }.forEach { line ->
+                totalDebits = totalDebits.add(line.debit)
+                totalCredits = totalCredits.add(line.credit)
+            }
+        }
+
+        val balance =
+            when (account.type) {
+                AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
+                AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
+            }
+
+        return AccountBalanceResponse(
+            accountId = account.id,
+            accountCode = account.code,
+            accountName = account.name,
+            accountType = account.type.name,
+            totalDebits = totalDebits,
+            totalCredits = totalCredits,
+            balance = balance,
+        )
+    }
+
+    fun getTrialBalance(
+        organizationId: String,
+        asOfDate: LocalDate? = null,
+    ): TrialBalanceResponse {
+        val entries =
+            if (asOfDate != null) {
+                journalEntryRepository.findByOrganizationIdAndStatusAndDateLessThanEqual(
+                    organizationId,
+                    JournalEntryStatus.POSTED,
+                    asOfDate,
+                )
+            } else {
+                journalEntryRepository.findByOrganizationIdAndStatus(
+                    organizationId,
+                    JournalEntryStatus.POSTED,
+                )
+            }
+
+        val accountTotals = mutableMapOf<String, Pair<BigDecimal, BigDecimal>>()
+        entries.forEach { entry ->
+            entry.lines.forEach { line ->
+                val (debits, credits) = accountTotals.getOrDefault(line.accountId, BigDecimal.ZERO to BigDecimal.ZERO)
+                accountTotals[line.accountId] = debits.add(line.debit) to credits.add(line.credit)
+            }
+        }
+
+        val allAccounts = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
+
+        val accountBalances =
+            allAccounts
+                .map { account ->
+                    val (totalDebits, totalCredits) =
+                        accountTotals.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
+                    val balance =
+                        when (account.type) {
+                            AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
+                            AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
+                        }
+                    AccountBalanceResponse(
+                        accountId = account.id,
+                        accountCode = account.code,
+                        accountName = account.name,
+                        accountType = account.type.name,
+                        totalDebits = totalDebits,
+                        totalCredits = totalCredits,
+                        balance = balance,
+                    )
+                }.sortedBy { it.accountCode }
+
+        val grandTotalDebits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalDebits) }
+        val grandTotalCredits = accountBalances.fold(BigDecimal.ZERO) { sum, ab -> sum.add(ab.totalCredits) }
+
+        return TrialBalanceResponse(
+            accounts = accountBalances,
+            totalDebits = grandTotalDebits,
+            totalCredits = grandTotalCredits,
+            asOfDate = asOfDate?.toString(),
+        )
+    }
+
+    private fun findEntry(
+        entryId: String,
+        organizationId: String,
+    ): JournalEntry {
+        val entry =
+            journalEntryRepository.findById(entryId).orElseThrow {
+                IllegalArgumentException("Journal entry not found")
+            }
+        if (entry.organizationId != organizationId) {
+            throw IllegalArgumentException("Journal entry not found")
+        }
+        return entry
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildEntry: (String) -> JournalEntry,
+    ): JournalEntry {
+        repeat(maxRetries) {
+            val count = journalEntryRepository.countByOrganizationId(organizationId)
+            val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return journalEntryRepository.save(buildEntry(entryNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) throw e
+            }
+        }
+        throw IllegalStateException("Failed to generate unique entry number")
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -201,17 +201,18 @@ class JournalEntryService(
             throw IllegalArgumentException("Account not found")
         }
 
+        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
         val entries =
             if (asOfDate != null) {
-                journalEntryRepository.findByOrganizationIdAndStatusAndDateLessThanEqual(
+                journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
                     organizationId,
-                    JournalEntryStatus.POSTED,
+                    postedStatuses,
                     asOfDate,
                 )
             } else {
-                journalEntryRepository.findByOrganizationIdAndStatus(
+                journalEntryRepository.findByOrganizationIdAndStatusIn(
                     organizationId,
-                    JournalEntryStatus.POSTED,
+                    postedStatuses,
                 )
             }
 
@@ -245,17 +246,18 @@ class JournalEntryService(
         organizationId: String,
         asOfDate: LocalDate? = null,
     ): TrialBalanceResponse {
+        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
         val entries =
             if (asOfDate != null) {
-                journalEntryRepository.findByOrganizationIdAndStatusAndDateLessThanEqual(
+                journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
                     organizationId,
-                    JournalEntryStatus.POSTED,
+                    postedStatuses,
                     asOfDate,
                 )
             } else {
-                journalEntryRepository.findByOrganizationIdAndStatus(
+                journalEntryRepository.findByOrganizationIdAndStatusIn(
                     organizationId,
-                    JournalEntryStatus.POSTED,
+                    postedStatuses,
                 )
             }
 

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -65,6 +65,10 @@ class RoleSeederTest {
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
                         Permissions.API_KEY_MANAGE,
+                        Permissions.ACCOUNT_CREATE,
+                        Permissions.ACCOUNT_READ,
+                        Permissions.ACCOUNT_UPDATE,
+                        Permissions.ACCOUNT_DELETE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -122,6 +126,10 @@ class RoleSeederTest {
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
                         Permissions.API_KEY_MANAGE,
+                        Permissions.ACCOUNT_CREATE,
+                        Permissions.ACCOUNT_READ,
+                        Permissions.ACCOUNT_UPDATE,
+                        Permissions.ACCOUNT_DELETE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -206,6 +214,10 @@ class RoleSeederTest {
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
                         Permissions.API_KEY_MANAGE,
+                        Permissions.ACCOUNT_CREATE,
+                        Permissions.ACCOUNT_READ,
+                        Permissions.ACCOUNT_UPDATE,
+                        Permissions.ACCOUNT_DELETE,
                     ),
             )
         val admin =
@@ -224,6 +236,9 @@ class RoleSeederTest {
                         Permissions.INVITATION_READ,
                         Permissions.INVITATION_WRITE,
                         Permissions.API_KEY_MANAGE,
+                        Permissions.ACCOUNT_CREATE,
+                        Permissions.ACCOUNT_READ,
+                        Permissions.ACCOUNT_UPDATE,
                     ),
             )
         val member =
@@ -238,6 +253,7 @@ class RoleSeederTest {
                         Permissions.USER_READ,
                         Permissions.ORGANIZATION_READ,
                         Permissions.INVITATION_READ,
+                        Permissions.ACCOUNT_READ,
                     ),
             )
         val viewer =
@@ -245,7 +261,7 @@ class RoleSeederTest {
                 name = "VIEWER",
                 description = "Read-only organization access",
                 level = RoleLevel.ORGANIZATION,
-                permissions = listOf(Permissions.SESSION_READ, Permissions.ORGANIZATION_READ),
+                permissions = listOf(Permissions.SESSION_READ, Permissions.ORGANIZATION_READ, Permissions.ACCOUNT_READ),
             )
 
         `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(superAdmin))

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -69,6 +69,10 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.ACCOUNT_UPDATE,
                         Permissions.ACCOUNT_DELETE,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
+                        Permissions.JOURNAL_POST,
+                        Permissions.JOURNAL_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -130,6 +134,10 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.ACCOUNT_UPDATE,
                         Permissions.ACCOUNT_DELETE,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
+                        Permissions.JOURNAL_POST,
+                        Permissions.JOURNAL_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -218,6 +226,10 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.ACCOUNT_UPDATE,
                         Permissions.ACCOUNT_DELETE,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
+                        Permissions.JOURNAL_POST,
+                        Permissions.JOURNAL_VOID,
                     ),
             )
         val admin =
@@ -239,6 +251,9 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_CREATE,
                         Permissions.ACCOUNT_READ,
                         Permissions.ACCOUNT_UPDATE,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
+                        Permissions.JOURNAL_POST,
                     ),
             )
         val member =
@@ -254,6 +269,8 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.INVITATION_READ,
                         Permissions.ACCOUNT_READ,
+                        Permissions.JOURNAL_CREATE,
+                        Permissions.JOURNAL_READ,
                     ),
             )
         val viewer =
@@ -261,7 +278,13 @@ class RoleSeederTest {
                 name = "VIEWER",
                 description = "Read-only organization access",
                 level = RoleLevel.ORGANIZATION,
-                permissions = listOf(Permissions.SESSION_READ, Permissions.ORGANIZATION_READ, Permissions.ACCOUNT_READ),
+                permissions =
+                    listOf(
+                        Permissions.SESSION_READ,
+                        Permissions.ORGANIZATION_READ,
+                        Permissions.ACCOUNT_READ,
+                        Permissions.JOURNAL_READ,
+                    ),
             )
 
         `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(superAdmin))

--- a/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
@@ -18,6 +18,7 @@ import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AccountService
 import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.JournalEntryService
 import com.froilan.synectix.util.TokenHasher
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -80,6 +81,9 @@ class AccountControllerTest {
 
     @MockitoBean
     private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
@@ -1,0 +1,264 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [AccountController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class AccountControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("account:create", "account:read", "account:update", "account:delete")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    private fun createMockAccount() =
+        Account(
+            id = "acc-123",
+            code = "1000",
+            name = "Cash",
+            type = AccountType.ASSET,
+            organizationId = "org-123",
+            isSystemAccount = false,
+        )
+
+    @Test
+    fun `POST accounts should return 201 when created`() {
+        val account = createMockAccount()
+        `when`(accountService.createAccount(any(), any())).thenReturn(account)
+
+        mockMvc
+            .perform(
+                post("/finance/accounts")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"code": "1000", "name": "Cash", "type": "ASSET"}"""),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value("acc-123"))
+            .andExpect(jsonPath("$.code").value("1000"))
+            .andExpect(jsonPath("$.name").value("Cash"))
+            .andExpect(jsonPath("$.type").value("ASSET"))
+            .andExpect(jsonPath("$.organizationId").value("org-123"))
+            .andExpect(jsonPath("$.systemAccount").value(false))
+    }
+
+    @Test
+    fun `POST accounts should return 400 when code is blank`() {
+        mockMvc
+            .perform(
+                post("/finance/accounts")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"code": "", "name": "Cash", "type": "ASSET"}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST accounts should return 400 when duplicate code`() {
+        `when`(accountService.createAccount(any(), any()))
+            .thenThrow(IllegalArgumentException("Account with code '1000' already exists"))
+
+        mockMvc
+            .perform(
+                post("/finance/accounts")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"code": "1000", "name": "Cash", "type": "ASSET"}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Account with code '1000' already exists"))
+    }
+
+    @Test
+    fun `GET accounts should return 200 with account list`() {
+        val accounts = listOf(createMockAccount())
+        `when`(accountService.listAccounts(any(), anyOrNull(), anyOrNull())).thenReturn(accounts)
+
+        mockMvc
+            .perform(get("/finance/accounts"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value("acc-123"))
+            .andExpect(jsonPath("$[0].code").value("1000"))
+            .andExpect(jsonPath("$[0].name").value("Cash"))
+            .andExpect(jsonPath("$[0].type").value("ASSET"))
+    }
+
+    @Test
+    fun `GET accounts by id should return 200`() {
+        val account = createMockAccount()
+        `when`(accountService.getAccount(any(), any())).thenReturn(account)
+
+        mockMvc
+            .perform(get("/finance/accounts/acc-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("acc-123"))
+            .andExpect(jsonPath("$.code").value("1000"))
+            .andExpect(jsonPath("$.name").value("Cash"))
+            .andExpect(jsonPath("$.type").value("ASSET"))
+    }
+
+    @Test
+    fun `GET accounts by id should return 404 when not found`() {
+        `when`(accountService.getAccount(any(), any()))
+            .thenThrow(IllegalArgumentException("Account not found"))
+
+        mockMvc
+            .perform(get("/finance/accounts/nonexistent"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.error").value("Account not found"))
+    }
+
+    @Test
+    fun `PUT accounts should return 200 when updated`() {
+        val account = createMockAccount().copy(name = "Updated Cash")
+        `when`(accountService.updateAccount(any(), any(), any())).thenReturn(account)
+
+        mockMvc
+            .perform(
+                put("/finance/accounts/acc-123")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Updated Cash"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("acc-123"))
+            .andExpect(jsonPath("$.name").value("Updated Cash"))
+    }
+
+    @Test
+    fun `DELETE accounts should return 200 when deactivated`() {
+        mockMvc
+            .perform(delete("/finance/accounts/acc-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("Account deactivated"))
+    }
+
+    @Test
+    fun `DELETE accounts should return 400 for system account`() {
+        `when`(accountService.deleteAccount(any(), any()))
+            .thenThrow(IllegalArgumentException("System accounts cannot be deleted"))
+
+        mockMvc
+            .perform(delete("/finance/accounts/acc-123"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("System accounts cannot be deleted"))
+    }
+
+    @Test
+    fun `POST accounts should return 403 without account create permission`() {
+        setupAuthWithPermissions("account:read")
+
+        mockMvc
+            .perform(
+                post("/finance/accounts")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"code": "1000", "name": "Cash", "type": "ASSET"}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `DELETE accounts should return 403 without account delete permission`() {
+        setupAuthWithPermissions("account:read")
+
+        mockMvc
+            .perform(delete("/finance/accounts/acc-123"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GET accounts should return 400 for invalid type query param`() {
+        mockMvc
+            .perform(get("/finance/accounts").param("type", "INVALID"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Invalid account type 'INVALID'"))
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
@@ -1,0 +1,332 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.dto.AccountBalanceResponse
+import com.froilan.synectix.dto.TrialBalanceResponse
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.JournalEntryService
+import com.froilan.synectix.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@WebMvcTest(controllers = [JournalEntryController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class JournalEntryControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var apiKeyRepository: ApiKeyRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("journal:create", "journal:read", "journal:post", "journal:void", "account:read")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    private fun createMockJournalEntry() =
+        JournalEntry(
+            id = "je-123",
+            entryNumber = "JE-0001",
+            date = LocalDate.of(2026, 1, 15),
+            description = "Test entry",
+            organizationId = "org-123",
+            status = JournalEntryStatus.DRAFT,
+            source = JournalEntrySource.MANUAL,
+            lines =
+                listOf(
+                    JournalEntryLine("acc-1", "1000", "Cash", BigDecimal("100.00"), BigDecimal.ZERO, null),
+                    JournalEntryLine("acc-2", "4000", "Sales Revenue", BigDecimal.ZERO, BigDecimal("100.00"), null),
+                ),
+            createdBy = "user-123",
+        )
+
+    @Test
+    fun `POST journal-entries should return 201 when created`() {
+        val entry = createMockJournalEntry()
+        `when`(journalEntryService.createJournalEntry(any(), any(), any())).thenReturn(entry)
+
+        mockMvc
+            .perform(
+                post("/finance/journal")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "date": "2026-01-15",
+                            "description": "Test entry",
+                            "lines": [
+                                {"accountId": "acc-1", "debit": 100.00, "credit": 0},
+                                {"accountId": "acc-2", "debit": 0, "credit": 100.00}
+                            ]
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value("je-123"))
+            .andExpect(jsonPath("$.entryNumber").value("JE-0001"))
+            .andExpect(jsonPath("$.date").value("2026-01-15"))
+            .andExpect(jsonPath("$.description").value("Test entry"))
+            .andExpect(jsonPath("$.organizationId").value("org-123"))
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+            .andExpect(jsonPath("$.source").value("MANUAL"))
+            .andExpect(jsonPath("$.lines.length()").value(2))
+            .andExpect(jsonPath("$.createdBy").value("user-123"))
+    }
+
+    @Test
+    fun `POST journal-entries should return 400 when unbalanced`() {
+        `when`(journalEntryService.createJournalEntry(any(), any(), any()))
+            .thenThrow(IllegalArgumentException("Journal entry must balance: debits (100.00) != credits (50.00)"))
+
+        mockMvc
+            .perform(
+                post("/finance/journal")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "date": "2026-01-15",
+                            "description": "Unbalanced entry",
+                            "lines": [
+                                {"accountId": "acc-1", "debit": 100.00, "credit": 0},
+                                {"accountId": "acc-2", "debit": 0, "credit": 50.00}
+                            ]
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Journal entry must balance: debits (100.00) != credits (50.00)"))
+    }
+
+    @Test
+    fun `GET journal-entries should return 200 with entry list`() {
+        val entries = listOf(createMockJournalEntry())
+        `when`(journalEntryService.listJournalEntries(any(), anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(entries)
+
+        mockMvc
+            .perform(get("/finance/journal"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value("je-123"))
+            .andExpect(jsonPath("$[0].entryNumber").value("JE-0001"))
+            .andExpect(jsonPath("$[0].status").value("DRAFT"))
+            .andExpect(jsonPath("$[0].lines.length()").value(2))
+    }
+
+    @Test
+    fun `GET journal-entries by id should return 200`() {
+        val entry = createMockJournalEntry()
+        `when`(journalEntryService.getJournalEntry(any(), any())).thenReturn(entry)
+
+        mockMvc
+            .perform(get("/finance/journal/je-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("je-123"))
+            .andExpect(jsonPath("$.entryNumber").value("JE-0001"))
+            .andExpect(jsonPath("$.date").value("2026-01-15"))
+            .andExpect(jsonPath("$.description").value("Test entry"))
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+    }
+
+    @Test
+    fun `GET journal-entries by id should return 404 when not found`() {
+        `when`(journalEntryService.getJournalEntry(any(), any()))
+            .thenThrow(IllegalArgumentException("Journal entry not found"))
+
+        mockMvc
+            .perform(get("/finance/journal/nonexistent"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.error").value("Journal entry not found"))
+    }
+
+    @Test
+    fun `POST journal-entries id post should return 200`() {
+        val entry = createMockJournalEntry().copy(status = JournalEntryStatus.POSTED)
+        `when`(journalEntryService.postJournalEntry(any(), any())).thenReturn(entry)
+
+        mockMvc
+            .perform(post("/finance/journal/je-123/post"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("je-123"))
+            .andExpect(jsonPath("$.status").value("POSTED"))
+    }
+
+    @Test
+    fun `POST journal-entries id void should return 200`() {
+        val entry = createMockJournalEntry().copy(status = JournalEntryStatus.VOIDED)
+        `when`(journalEntryService.voidJournalEntry(any(), any(), any())).thenReturn(entry)
+
+        mockMvc
+            .perform(
+                post("/finance/journal/je-123/void")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"reason": "Error correction"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("je-123"))
+            .andExpect(jsonPath("$.status").value("VOIDED"))
+    }
+
+    @Test
+    fun `GET trial-balance should return 200`() {
+        val trialBalance =
+            TrialBalanceResponse(
+                accounts =
+                    listOf(
+                        AccountBalanceResponse(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            accountType = "ASSET",
+                            totalDebits = BigDecimal("100.00"),
+                            totalCredits = BigDecimal.ZERO,
+                            balance = BigDecimal("100.00"),
+                        ),
+                        AccountBalanceResponse(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Sales Revenue",
+                            accountType = "REVENUE",
+                            totalDebits = BigDecimal.ZERO,
+                            totalCredits = BigDecimal("100.00"),
+                            balance = BigDecimal("100.00"),
+                        ),
+                    ),
+                totalDebits = BigDecimal("100.00"),
+                totalCredits = BigDecimal("100.00"),
+                asOfDate = null,
+            )
+        `when`(journalEntryService.getTrialBalance(any(), anyOrNull())).thenReturn(trialBalance)
+
+        val result =
+            mockMvc
+                .perform(get("/finance/journal/trial-balance"))
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.accounts.length()").value(2))
+                .andExpect(jsonPath("$.accounts[0].accountCode").value("1000"))
+                .andExpect(jsonPath("$.accounts[1].accountCode").value("4000"))
+                .andExpect(jsonPath("$.totalDebits").value(100.00))
+                .andExpect(jsonPath("$.totalCredits").value(100.00))
+                .andReturn()
+
+        assertThat(result.response.status).isEqualTo(200)
+    }
+
+    @Test
+    fun `POST journal-entries should return 403 without journal create permission`() {
+        setupAuthWithPermissions("journal:read")
+
+        mockMvc
+            .perform(
+                post("/finance/journal")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "date": "2026-01-15",
+                            "description": "Test entry",
+                            "lines": [
+                                {"accountId": "acc-1", "debit": 100.00, "credit": 0},
+                                {"accountId": "acc-2", "debit": 0, "credit": 100.00}
+                            ]
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/AccountServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AccountServiceTest.kt
@@ -1,0 +1,373 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateAccountRequest
+import com.froilan.synectix.dto.UpdateAccountRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.repository.AccountRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.springframework.dao.DuplicateKeyException
+import java.util.Optional
+
+class AccountServiceTest {
+    private lateinit var accountService: AccountService
+    private lateinit var accountRepository: AccountRepository
+
+    @BeforeEach
+    fun setup() {
+        accountRepository = mock(AccountRepository::class.java)
+        accountService = AccountService(accountRepository = accountRepository)
+    }
+
+    @Test
+    fun `createAccount should create and return account`() {
+        `when`(accountRepository.save(any<Account>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateAccountRequest(
+                code = "1000",
+                name = "Cash",
+                type = "ASSET",
+                parentId = null,
+                description = "Cash account",
+            )
+
+        val result = accountService.createAccount(request, "org-123")
+
+        assertThat(result.code).isEqualTo("1000")
+        assertThat(result.name).isEqualTo("Cash")
+        assertThat(result.type).isEqualTo(AccountType.ASSET)
+        assertThat(result.description).isEqualTo("Cash account")
+        assertThat(result.organizationId).isEqualTo("org-123")
+        assertThat(result.isActive).isTrue()
+        assertThat(result.isSystemAccount).isFalse()
+
+        val captor = argumentCaptor<Account>()
+        verify(accountRepository).save(captor.capture())
+        assertThat(captor.firstValue.code).isEqualTo("1000")
+        assertThat(captor.firstValue.organizationId).isEqualTo("org-123")
+    }
+
+    @Test
+    fun `createAccount should throw when code already exists`() {
+        `when`(accountRepository.save(any<Account>())).thenThrow(DuplicateKeyException("duplicate"))
+
+        val request =
+            CreateAccountRequest(
+                code = "1000",
+                name = "Cash",
+                type = "ASSET",
+                parentId = null,
+                description = null,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.createAccount(request, "org-123")
+            }
+        assertThat(exception.message).contains("Account code '1000' already exists")
+    }
+
+    @Test
+    fun `createAccount should throw when type is invalid`() {
+        val request =
+            CreateAccountRequest(
+                code = "1000",
+                name = "Bad Type",
+                type = "INVALID_TYPE",
+                parentId = null,
+                description = null,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.createAccount(request, "org-123")
+            }
+        assertThat(exception.message).contains("Invalid account type")
+        assertThat(exception.message).contains("INVALID_TYPE")
+    }
+
+    @Test
+    fun `createAccount should throw when parent not found`() {
+        `when`(accountRepository.findById("parent-999")).thenReturn(Optional.empty())
+
+        val request =
+            CreateAccountRequest(
+                code = "1001",
+                name = "Sub Cash",
+                type = "ASSET",
+                parentId = "parent-999",
+                description = null,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.createAccount(request, "org-123")
+            }
+        assertThat(exception.message).isEqualTo("Parent account not found")
+    }
+
+    @Test
+    fun `createAccount should throw when parent is different type`() {
+        val parent =
+            createMockAccount(
+                id = "parent-1",
+                type = AccountType.ASSET,
+                organizationId = "org-123",
+            )
+        `when`(accountRepository.findById("parent-1")).thenReturn(Optional.of(parent))
+
+        val request =
+            CreateAccountRequest(
+                code = "5001",
+                name = "Expense Sub",
+                type = "EXPENSE",
+                parentId = "parent-1",
+                description = null,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.createAccount(request, "org-123")
+            }
+        assertThat(exception.message).isEqualTo("Parent account must be the same type")
+    }
+
+    @Test
+    fun `createAccount should throw when parent is different org`() {
+        val parent =
+            createMockAccount(
+                id = "parent-1",
+                type = AccountType.ASSET,
+                organizationId = "other-org",
+            )
+        `when`(accountRepository.findById("parent-1")).thenReturn(Optional.of(parent))
+
+        val request =
+            CreateAccountRequest(
+                code = "1001",
+                name = "Sub Cash",
+                type = "ASSET",
+                parentId = "parent-1",
+                description = null,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.createAccount(request, "org-123")
+            }
+        assertThat(exception.message).isEqualTo("Parent account not found")
+    }
+
+    @Test
+    fun `updateAccount should update name and description`() {
+        val existing = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET)
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(existing))
+        `when`(accountRepository.save(any<Account>())).thenAnswer { it.arguments[0] }
+
+        val request = UpdateAccountRequest(name = "Updated Cash", description = "Updated desc")
+
+        val result = accountService.updateAccount("acc-1", request, "org-123")
+
+        assertThat(result.name).isEqualTo("Updated Cash")
+        assertThat(result.description).isEqualTo("Updated desc")
+        assertThat(result.code).isEqualTo("1000")
+        assertThat(result.type).isEqualTo(AccountType.ASSET)
+
+        val captor = argumentCaptor<Account>()
+        verify(accountRepository).save(captor.capture())
+        assertThat(captor.firstValue.code).isEqualTo("1000")
+        assertThat(captor.firstValue.type).isEqualTo(AccountType.ASSET)
+    }
+
+    @Test
+    fun `updateAccount should throw when account not found`() {
+        `when`(accountRepository.findById("acc-999")).thenReturn(Optional.empty())
+
+        val request = UpdateAccountRequest(name = "New Name")
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.updateAccount("acc-999", request, "org-123")
+            }
+        assertThat(exception.message).isEqualTo("Account not found")
+    }
+
+    @Test
+    fun `updateAccount should throw when wrong org`() {
+        val existing = createMockAccount(id = "acc-1", organizationId = "other-org")
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(existing))
+
+        val request = UpdateAccountRequest(name = "New Name")
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.updateAccount("acc-1", request, "org-123")
+            }
+        assertThat(exception.message).isEqualTo("Account not found")
+    }
+
+    @Test
+    fun `getAccount should return account`() {
+        val account = createMockAccount(id = "acc-1")
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
+
+        val result = accountService.getAccount("acc-1", "org-123")
+
+        assertThat(result.id).isEqualTo("acc-1")
+        assertThat(result.organizationId).isEqualTo("org-123")
+    }
+
+    @Test
+    fun `getAccount should throw when wrong org`() {
+        val account = createMockAccount(id = "acc-1", organizationId = "other-org")
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.getAccount("acc-1", "org-123")
+            }
+        assertThat(exception.message).isEqualTo("Account not found")
+    }
+
+    @Test
+    fun `listAccounts should return active accounts`() {
+        val accounts =
+            listOf(
+                createMockAccount(id = "acc-1"),
+                createMockAccount(id = "acc-2", name = "Receivables"),
+            )
+        `when`(accountRepository.findByOrganizationIdAndIsActive("org-123", true)).thenReturn(accounts)
+
+        val result = accountService.listAccounts("org-123", type = null, parentId = null)
+
+        assertThat(result).hasSize(2)
+        verify(accountRepository).findByOrganizationIdAndIsActive("org-123", true)
+    }
+
+    @Test
+    fun `listAccounts should filter by type`() {
+        val accounts = listOf(createMockAccount(id = "acc-1", type = AccountType.EXPENSE))
+        `when`(
+            accountRepository.findByOrganizationIdAndTypeAndIsActive("org-123", AccountType.EXPENSE, true),
+        ).thenReturn(accounts)
+
+        val result = accountService.listAccounts("org-123", type = AccountType.EXPENSE, parentId = null)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].type).isEqualTo(AccountType.EXPENSE)
+        verify(accountRepository).findByOrganizationIdAndTypeAndIsActive("org-123", AccountType.EXPENSE, true)
+    }
+
+    @Test
+    fun `listAccounts should filter by parentId`() {
+        val accounts = listOf(createMockAccount(id = "acc-2", parentId = "acc-1"))
+        `when`(
+            accountRepository.findByOrganizationIdAndParentIdAndIsActive("org-123", "acc-1", true),
+        ).thenReturn(accounts)
+
+        val result = accountService.listAccounts("org-123", type = null, parentId = "acc-1")
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].parentId).isEqualTo("acc-1")
+        verify(accountRepository).findByOrganizationIdAndParentIdAndIsActive("org-123", "acc-1", true)
+    }
+
+    @Test
+    fun `listAccounts should filter by type and parentId combined`() {
+        val accounts = listOf(createMockAccount(id = "acc-1"))
+        `when`(
+            accountRepository.findByOrganizationIdAndTypeAndParentIdAndIsActive("org-123", AccountType.ASSET, "parent-1", true),
+        ).thenReturn(accounts)
+
+        val result = accountService.listAccounts("org-123", type = AccountType.ASSET, parentId = "parent-1")
+
+        assertThat(result).hasSize(1)
+        verify(accountRepository).findByOrganizationIdAndTypeAndParentIdAndIsActive("org-123", AccountType.ASSET, "parent-1", true)
+    }
+
+    @Test
+    fun `deleteAccount should soft delete account`() {
+        val account = createMockAccount(id = "acc-1", isSystemAccount = false)
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
+        `when`(accountRepository.existsByOrganizationIdAndParentIdAndIsActive("org-123", "acc-1", true)).thenReturn(false)
+        `when`(accountRepository.save(any<Account>())).thenAnswer { it.arguments[0] }
+
+        accountService.deleteAccount("acc-1", "org-123")
+
+        val captor = argumentCaptor<Account>()
+        verify(accountRepository).save(captor.capture())
+        assertThat(captor.firstValue.isActive).isFalse()
+        assertThat(captor.firstValue.id).isEqualTo("acc-1")
+    }
+
+    @Test
+    fun `deleteAccount should throw when system account`() {
+        val account = createMockAccount(id = "acc-1", isSystemAccount = true)
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.deleteAccount("acc-1", "org-123")
+            }
+        assertThat(exception.message).isEqualTo("System accounts cannot be deleted")
+    }
+
+    @Test
+    fun `deleteAccount should throw when has children`() {
+        val account = createMockAccount(id = "acc-1", isSystemAccount = false)
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
+        `when`(accountRepository.existsByOrganizationIdAndParentIdAndIsActive("org-123", "acc-1", true)).thenReturn(true)
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                accountService.deleteAccount("acc-1", "org-123")
+            }
+        assertThat(exception.message).isEqualTo("Cannot delete account with child accounts")
+    }
+
+    @Test
+    fun `seedDefaultAccounts should create 20 default accounts`() {
+        `when`(accountRepository.saveAll(any<List<Account>>())).thenAnswer { it.arguments[0] }
+
+        accountService.seedDefaultAccounts("org-123")
+
+        @Suppress("UNCHECKED_CAST")
+        val captor = argumentCaptor<List<Account>>()
+        verify(accountRepository).saveAll(captor.capture())
+
+        val savedAccounts = captor.firstValue
+        assertThat(savedAccounts).hasSize(20)
+        assertThat(savedAccounts).allMatch { it.isSystemAccount }
+        assertThat(savedAccounts).allMatch { it.organizationId == "org-123" }
+        assertThat(savedAccounts).allMatch { it.isActive }
+    }
+
+    private fun createMockAccount(
+        id: String = "acc-1",
+        code: String = "1000",
+        name: String = "Cash",
+        type: AccountType = AccountType.ASSET,
+        parentId: String? = null,
+        organizationId: String = "org-123",
+        isActive: Boolean = true,
+        isSystemAccount: Boolean = false,
+    ) = Account(
+        id = id,
+        code = code,
+        name = name,
+        type = type,
+        parentId = parentId,
+        organizationId = organizationId,
+        isActive = isActive,
+        isSystemAccount = isSystemAccount,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -41,6 +41,7 @@ class AuthServiceTest {
     private lateinit var sessionTokenRepository: SessionTokenRepository
     private lateinit var refreshTokenRepository: RefreshTokenRepository
     private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+    private lateinit var accountService: AccountService
     private lateinit var mongoTemplate: MongoTemplate
     private lateinit var tokenHasher: TokenHasher
     private lateinit var passwordEncoder: PasswordEncoder
@@ -52,6 +53,7 @@ class AuthServiceTest {
         sessionTokenRepository = mock(SessionTokenRepository::class.java)
         refreshTokenRepository = mock(RefreshTokenRepository::class.java)
         passwordResetTokenRepository = mock(PasswordResetTokenRepository::class.java)
+        accountService = mock(AccountService::class.java)
         mongoTemplate = mock(MongoTemplate::class.java)
         tokenHasher = mock(TokenHasher::class.java)
         passwordEncoder = mock(PasswordEncoder::class.java)
@@ -66,6 +68,7 @@ class AuthServiceTest {
                 sessionTokenRepository = sessionTokenRepository,
                 refreshTokenRepository = refreshTokenRepository,
                 passwordResetTokenRepository = passwordResetTokenRepository,
+                accountService = accountService,
                 mongoTemplate = mongoTemplate,
                 tokenHasher = tokenHasher,
                 passwordEncoder = passwordEncoder,
@@ -120,6 +123,7 @@ class AuthServiceTest {
         assertThat(userCaptor.firstValue.passwordHash).isEqualTo(encodedPassword)
         assertThat(userCaptor.firstValue.organizationId).isEqualTo(savedOrg.uuid)
         assertThat(userCaptor.firstValue.roleAssignments).isEqualTo(listOf(RoleAssignment("OWNER", savedOrg.uuid)))
+        verify(accountService).seedDefaultAccounts(savedOrg.uuid)
     }
 
     @Test
@@ -165,6 +169,7 @@ class AuthServiceTest {
                 authService.register(request)
             }
         assertThat(exception.message).isEqualTo("Organization slug already exists")
+        verify(accountService, never()).seedDefaultAccounts(any())
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -490,7 +490,8 @@ class JournalEntryServiceTest {
                 ),
             )
 
-        `when`(journalEntryRepository.findByOrganizationIdAndStatusIn(orgId, listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED))).thenReturn(entries)
+        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
+        `when`(journalEntryRepository.findByOrganizationIdAndStatusIn(orgId, postedStatuses)).thenReturn(entries)
 
         val result = journalEntryService.getAccountBalance("acc-1", orgId)
 
@@ -536,7 +537,8 @@ class JournalEntryServiceTest {
                 ),
             )
 
-        `when`(journalEntryRepository.findByOrganizationIdAndStatusIn(orgId, listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED))).thenReturn(entries)
+        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
+        `when`(journalEntryRepository.findByOrganizationIdAndStatusIn(orgId, postedStatuses)).thenReturn(entries)
         `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(cashAccount, revenueAccount))
 
         val result = journalEntryService.getTrialBalance(orgId)

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -490,7 +490,7 @@ class JournalEntryServiceTest {
                 ),
             )
 
-        `when`(journalEntryRepository.findByOrganizationIdAndStatus(orgId, JournalEntryStatus.POSTED)).thenReturn(entries)
+        `when`(journalEntryRepository.findByOrganizationIdAndStatusIn(orgId, listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED))).thenReturn(entries)
 
         val result = journalEntryService.getAccountBalance("acc-1", orgId)
 
@@ -536,7 +536,7 @@ class JournalEntryServiceTest {
                 ),
             )
 
-        `when`(journalEntryRepository.findByOrganizationIdAndStatus(orgId, JournalEntryStatus.POSTED)).thenReturn(entries)
+        `when`(journalEntryRepository.findByOrganizationIdAndStatusIn(orgId, listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED))).thenReturn(entries)
         `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(cashAccount, revenueAccount))
 
         val result = journalEntryService.getTrialBalance(orgId)

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -1,0 +1,594 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateJournalEntryRequest
+import com.froilan.synectix.dto.JournalEntryLineRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class JournalEntryServiceTest {
+    private lateinit var journalEntryService: JournalEntryService
+    private lateinit var journalEntryRepository: JournalEntryRepository
+    private lateinit var accountRepository: AccountRepository
+
+    private val orgId = "org-123"
+    private val createdBy = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        journalEntryRepository = mock(JournalEntryRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        journalEntryService =
+            JournalEntryService(
+                journalEntryRepository = journalEntryRepository,
+                accountRepository = accountRepository,
+            )
+    }
+
+    @Test
+    fun `create should save balanced journal entry as DRAFT`() {
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        val revenueAccount = createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = orgId)
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Sale received",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
+
+        assertThat(result.status).isEqualTo(JournalEntryStatus.DRAFT)
+        assertThat(result.source).isEqualTo(JournalEntrySource.MANUAL)
+        assertThat(result.description).isEqualTo("Sale received")
+        assertThat(result.organizationId).isEqualTo(orgId)
+        assertThat(result.createdBy).isEqualTo(createdBy)
+        assertThat(result.lines).hasSize(2)
+        assertThat(result.lines[0].debit).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(result.lines[1].credit).isEqualByComparingTo(BigDecimal("100.00"))
+
+        val captor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(captor.capture())
+        assertThat(captor.firstValue.status).isEqualTo(JournalEntryStatus.DRAFT)
+    }
+
+    @Test
+    fun `create should throw when less than 2 lines`() {
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Bad entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("at least 2 line items")
+    }
+
+    @Test
+    fun `create should throw when line has both debit and credit`() {
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Bad entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal("50.00")),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("50.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("cannot have both debit and credit")
+    }
+
+    @Test
+    fun `create should throw when line has zero debit and credit`() {
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Bad entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal.ZERO, credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("must have either a debit or credit amount")
+    }
+
+    @Test
+    fun `create should throw when entry is unbalanced`() {
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Unbalanced entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("50.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("must balance")
+    }
+
+    @Test
+    fun `create should throw when account not found`() {
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-missing"))).thenReturn(
+            listOf(createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)),
+        )
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Missing account",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-missing", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("not found")
+    }
+
+    @Test
+    fun `create should throw when account is inactive`() {
+        val inactiveAccount =
+            createMockAccount(
+                id = "acc-2",
+                code = "4000",
+                name = "Old Revenue",
+                type = AccountType.REVENUE,
+                orgId = orgId,
+            ).copy(isActive = false)
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, inactiveAccount))
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Inactive account entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("inactive")
+    }
+
+    @Test
+    fun `create should throw when account is in different org`() {
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        val otherOrgAccount =
+            createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = "other-org")
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, otherOrgAccount))
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Wrong org entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("not found")
+    }
+
+    @Test
+    fun `create should generate sequential entry number`() {
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        val revenueAccount = createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = orgId)
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2"))).thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(5L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Sequential test",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(accountId = "acc-1", debit = BigDecimal("100.00"), credit = BigDecimal.ZERO),
+                        JournalEntryLineRequest(accountId = "acc-2", debit = BigDecimal.ZERO, credit = BigDecimal("100.00")),
+                    ),
+            )
+
+        val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
+
+        assertThat(result.entryNumber).isEqualTo("JE-0006")
+    }
+
+    @Test
+    fun `post should change status from DRAFT to POSTED`() {
+        val draftEntry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.DRAFT,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(draftEntry))
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val result = journalEntryService.postJournalEntry("entry-1", orgId)
+
+        assertThat(result.status).isEqualTo(JournalEntryStatus.POSTED)
+        assertThat(result.postedAt).isNotNull()
+
+        val captor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(captor.capture())
+        assertThat(captor.firstValue.status).isEqualTo(JournalEntryStatus.POSTED)
+    }
+
+    @Test
+    fun `post should throw when entry is not DRAFT`() {
+        val postedEntry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.POSTED,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(postedEntry))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.postJournalEntry("entry-1", orgId)
+            }
+        assertThat(exception.message).contains("Only draft entries can be posted")
+    }
+
+    @Test
+    fun `void should change status to VOIDED and create reversing entry`() {
+        val postedEntry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.POSTED,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("200.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("200.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(postedEntry))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val result = journalEntryService.voidJournalEntry("entry-1", orgId, "Incorrect amount")
+
+        assertThat(result.status).isEqualTo(JournalEntryStatus.VOIDED)
+        assertThat(result.voidedAt).isNotNull()
+        assertThat(result.voidReason).isEqualTo("Incorrect amount")
+
+        val captor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository, times(2)).save(captor.capture())
+
+        val allSaved = captor.allValues
+        assertThat(allSaved).hasSize(2)
+
+        // First save is the voided entry
+        val voidedSave = allSaved[0]
+        assertThat(voidedSave.status).isEqualTo(JournalEntryStatus.VOIDED)
+
+        // Second save is the reversing entry
+        val reversingSave = allSaved[1]
+        assertThat(reversingSave.status).isEqualTo(JournalEntryStatus.POSTED)
+        assertThat(reversingSave.source).isEqualTo(JournalEntrySource.SYSTEM)
+        assertThat(reversingSave.description).contains("Reversal of JE-0001")
+        assertThat(reversingSave.lines[0].debit).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(reversingSave.lines[0].credit).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(reversingSave.lines[1].debit).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(reversingSave.lines[1].credit).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `void should throw when entry is not POSTED`() {
+        val draftEntry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.DRAFT,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(draftEntry))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.voidJournalEntry("entry-1", orgId, "Some reason")
+            }
+        assertThat(exception.message).contains("Only posted entries can be voided")
+    }
+
+    @Test
+    fun `getAccountBalance should sum debits and credits from posted entries`() {
+        val account = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
+
+        val entries =
+            listOf(
+                createMockEntry(
+                    id = "entry-1",
+                    entryNumber = "JE-0001",
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-1",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal("500.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-2",
+                                accountCode = "4000",
+                                accountName = "Revenue",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("500.00"),
+                            ),
+                        ),
+                    orgId = orgId,
+                ),
+                createMockEntry(
+                    id = "entry-2",
+                    entryNumber = "JE-0002",
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-3",
+                                accountCode = "5000",
+                                accountName = "Expense",
+                                debit = BigDecimal("150.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-1",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("150.00"),
+                            ),
+                        ),
+                    orgId = orgId,
+                ),
+            )
+
+        `when`(journalEntryRepository.findByOrganizationIdAndStatus(orgId, JournalEntryStatus.POSTED)).thenReturn(entries)
+
+        val result = journalEntryService.getAccountBalance("acc-1", orgId)
+
+        assertThat(result.accountId).isEqualTo("acc-1")
+        assertThat(result.accountCode).isEqualTo("1000")
+        assertThat(result.accountName).isEqualTo("Cash")
+        assertThat(result.accountType).isEqualTo("ASSET")
+        assertThat(result.totalDebits).isEqualByComparingTo(BigDecimal("500.00"))
+        assertThat(result.totalCredits).isEqualByComparingTo(BigDecimal("150.00"))
+        // ASSET: balance = debits - credits
+        assertThat(result.balance).isEqualByComparingTo(BigDecimal("350.00"))
+    }
+
+    @Test
+    fun `getTrialBalance should return all account balances`() {
+        val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
+        val revenueAccount = createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = orgId)
+
+        val entries =
+            listOf(
+                createMockEntry(
+                    id = "entry-1",
+                    entryNumber = "JE-0001",
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-1",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal("300.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-2",
+                                accountCode = "4000",
+                                accountName = "Revenue",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("300.00"),
+                            ),
+                        ),
+                    orgId = orgId,
+                ),
+            )
+
+        `when`(journalEntryRepository.findByOrganizationIdAndStatus(orgId, JournalEntryStatus.POSTED)).thenReturn(entries)
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(cashAccount, revenueAccount))
+
+        val result = journalEntryService.getTrialBalance(orgId)
+
+        assertThat(result.accounts).hasSize(2)
+        assertThat(result.totalDebits).isEqualByComparingTo(BigDecimal("300.00"))
+        assertThat(result.totalCredits).isEqualByComparingTo(BigDecimal("300.00"))
+        // Trial balance must balance: total debits == total credits
+        assertThat(result.totalDebits).isEqualByComparingTo(result.totalCredits)
+
+        val cashBalance = result.accounts.find { it.accountId == "acc-1" }
+        assertThat(cashBalance).isNotNull
+        assertThat(cashBalance!!.totalDebits).isEqualByComparingTo(BigDecimal("300.00"))
+        assertThat(cashBalance.balance).isEqualByComparingTo(BigDecimal("300.00"))
+
+        val revenueBalance = result.accounts.find { it.accountId == "acc-2" }
+        assertThat(revenueBalance).isNotNull
+        assertThat(revenueBalance!!.totalCredits).isEqualByComparingTo(BigDecimal("300.00"))
+        // REVENUE: balance = credits - debits
+        assertThat(revenueBalance.balance).isEqualByComparingTo(BigDecimal("300.00"))
+    }
+
+    private fun createMockAccount(
+        id: String = "acc-1",
+        code: String = "1000",
+        name: String = "Cash",
+        type: AccountType = AccountType.ASSET,
+        orgId: String = "org-123",
+    ) = Account(
+        id = id,
+        code = code,
+        name = name,
+        type = type,
+        organizationId = orgId,
+        isActive = true,
+        isSystemAccount = false,
+    )
+
+    private fun createMockEntry(
+        id: String = "entry-1",
+        entryNumber: String = "JE-0001",
+        status: JournalEntryStatus = JournalEntryStatus.DRAFT,
+        lines: List<JournalEntryLine> = emptyList(),
+        orgId: String = "org-123",
+    ) = JournalEntry(
+        id = id,
+        entryNumber = entryNumber,
+        date = LocalDate.of(2026, 1, 15),
+        description = "Test entry",
+        organizationId = orgId,
+        status = status,
+        lines = lines,
+        createdBy = "user-1",
+    )
+}


### PR DESCRIPTION
## Summary
Promotes staging to production with the first two finance modules.

### Chart of Accounts (#97)
- Account model with hierarchy, compound unique index (orgId + code)
- CRUD with create/read/update/delete permissions
- 20 default system accounts seeded on org registration
- System accounts protected from deletion
- Parent-child hierarchy enforced (same type)
- API key + session auth support

### General Ledger (#98)
- Double-entry journal entries with balanced debit/credit enforcement
- DRAFT → POSTED → VOIDED lifecycle with auto-reversing entries
- BigDecimal for all monetary amounts
- Sequential entry numbering with collision retry
- Account balance calculation (debit/credit-normal by account type)
- Trial balance report with all active accounts
- Open-ended date range filtering
- Cascading bean validation on line items
- 4 granular permissions: journal:create, journal:read, journal:post, journal:void

### New Endpoints
| Path | Description |
|------|-------------|
| `/finance/accounts` | Account CRUD |
| `/finance/accounts/{id}/balance` | Account balance |
| `/finance/journal` | Journal entry CRUD + post/void |
| `/finance/journal/trial-balance` | Trial balance report |

## Test plan
- [x] 200/201 tests pass (1 pre-existing context-load)
- [x] ktlint passes