### PR TITLE
Fiscal period management & close process (#30)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -53,6 +53,9 @@ class RoleSeeder(
                             Permissions.JOURNAL_READ,
                             Permissions.JOURNAL_POST,
                             Permissions.JOURNAL_VOID,
+                            Permissions.FISCAL_CREATE,
+                            Permissions.FISCAL_READ,
+                            Permissions.FISCAL_CLOSE,
                         ),
                 ),
                 Role(
@@ -76,6 +79,9 @@ class RoleSeeder(
                             Permissions.JOURNAL_CREATE,
                             Permissions.JOURNAL_READ,
                             Permissions.JOURNAL_POST,
+                            Permissions.FISCAL_CREATE,
+                            Permissions.FISCAL_READ,
+                            Permissions.FISCAL_CLOSE,
                         ),
                 ),
                 Role(
@@ -92,6 +98,7 @@ class RoleSeeder(
                             Permissions.ACCOUNT_READ,
                             Permissions.JOURNAL_CREATE,
                             Permissions.JOURNAL_READ,
+                            Permissions.FISCAL_READ,
                         ),
                 ),
                 Role(
@@ -104,6 +111,7 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_READ,
                             Permissions.ACCOUNT_READ,
                             Permissions.JOURNAL_READ,
+                            Permissions.FISCAL_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -63,7 +63,8 @@ class FiscalYearController(
             val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
             ResponseEntity.ok(fiscalYear.toResponse())
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND)
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(mapOf("error" to (e.message ?: "Fiscal year not found")))
         }
     }
@@ -82,7 +83,8 @@ class FiscalYearController(
             ResponseEntity.ok(fiscalYear.toResponse())
         } catch (e: IllegalArgumentException) {
             val status = if (e.message == "Fiscal period not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to close period")))
         }
     }
@@ -101,7 +103,8 @@ class FiscalYearController(
             ResponseEntity.ok(fiscalYear.toResponse())
         } catch (e: IllegalArgumentException) {
             val status = if (e.message == "Fiscal period not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to reopen period")))
         }
     }
@@ -120,7 +123,8 @@ class FiscalYearController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Fiscal year not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to close fiscal year")))
         }
     }
@@ -133,20 +137,21 @@ class FiscalYearController(
             endDate = endDate.toString(),
             status = status.name,
             organizationId = organizationId,
-            periods = periods.map { period ->
-                FiscalPeriodResponse(
-                    id = period.id,
-                    periodNumber = period.periodNumber,
-                    name = period.name,
-                    startDate = period.startDate.toString(),
-                    endDate = period.endDate.toString(),
-                    status = period.status.name,
-                    closedAt = period.closedAt?.toString(),
-                    closedBy = period.closedBy,
-                    reopenedAt = period.reopenedAt?.toString(),
-                    reopenedBy = period.reopenedBy,
-                )
-            },
+            periods =
+                periods.map { period ->
+                    FiscalPeriodResponse(
+                        id = period.id,
+                        periodNumber = period.periodNumber,
+                        name = period.name,
+                        startDate = period.startDate.toString(),
+                        endDate = period.endDate.toString(),
+                        status = period.status.name,
+                        closedAt = period.closedAt?.toString(),
+                        closedBy = period.closedBy,
+                        reopenedAt = period.reopenedAt?.toString(),
+                        reopenedBy = period.reopenedBy,
+                    )
+                },
             closedAt = closedAt?.toString(),
             closedBy = closedBy,
             closingEntryId = closingEntryId,

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -126,6 +126,10 @@ class FiscalYearController(
             ResponseEntity
                 .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to close fiscal year")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to generate closing entry")))
         }
     }
 

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -1,0 +1,187 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateFiscalYearRequest
+import com.froilan.synectix.dto.FiscalPeriodResponse
+import com.froilan.synectix.dto.FiscalYearResponse
+import com.froilan.synectix.dto.FiscalYearSummaryResponse
+import com.froilan.synectix.model.FiscalYear
+import com.froilan.synectix.model.User
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.FiscalYearService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/finance/fiscal-years")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class FiscalYearController(
+    private val fiscalYearService: FiscalYearService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('fiscal:create')")
+    fun createFiscalYear(
+        @Valid @RequestBody request: CreateFiscalYearRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val fiscalYear = fiscalYearService.createFiscalYear(request, orgId)
+            ResponseEntity.status(HttpStatus.CREATED).body(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create fiscal year")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('fiscal:read')")
+    fun listFiscalYears(): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val fiscalYears = fiscalYearService.listFiscalYears(orgId)
+        return ResponseEntity.ok(fiscalYears.map { it.toSummaryResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('fiscal:read')")
+    fun getFiscalYear(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
+            ResponseEntity.ok(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Fiscal year not found")))
+        }
+    }
+
+    @PostMapping("/{id}/periods/{periodId}/close")
+    @PreAuthorize("hasAuthority('fiscal:close')")
+    fun closePeriod(
+        @PathVariable id: String,
+        @PathVariable periodId: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val fiscalYear = fiscalYearService.closePeriod(id, periodId, orgId, userId)
+            ResponseEntity.ok(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Fiscal period not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to close period")))
+        }
+    }
+
+    @PostMapping("/{id}/periods/{periodId}/reopen")
+    @PreAuthorize("hasAuthority('fiscal:close')")
+    fun reopenPeriod(
+        @PathVariable id: String,
+        @PathVariable periodId: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val fiscalYear = fiscalYearService.reopenPeriod(id, periodId, orgId, userId)
+            ResponseEntity.ok(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Fiscal period not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to reopen period")))
+        }
+    }
+
+    @PostMapping("/{id}/close")
+    @PreAuthorize("hasAuthority('fiscal:close')")
+    fun closeYear(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val fiscalYear = fiscalYearService.closeYear(id, orgId, userId)
+            ResponseEntity.ok(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Fiscal year not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to close fiscal year")))
+        }
+    }
+
+    private fun FiscalYear.toResponse() =
+        FiscalYearResponse(
+            id = id,
+            name = name,
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
+            status = status.name,
+            organizationId = organizationId,
+            periods = periods.map { period ->
+                FiscalPeriodResponse(
+                    id = period.id,
+                    periodNumber = period.periodNumber,
+                    name = period.name,
+                    startDate = period.startDate.toString(),
+                    endDate = period.endDate.toString(),
+                    status = period.status.name,
+                    closedAt = period.closedAt?.toString(),
+                    closedBy = period.closedBy,
+                    reopenedAt = period.reopenedAt?.toString(),
+                    reopenedBy = period.reopenedBy,
+                )
+            },
+            closedAt = closedAt?.toString(),
+            closedBy = closedBy,
+            closingEntryId = closingEntryId,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun FiscalYear.toSummaryResponse() =
+        FiscalYearSummaryResponse(
+            id = id,
+            name = name,
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
+            status = status.name,
+            organizationId = organizationId,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun extractUserId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return (authentication.principal as? User)?.uuid
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/finance/fiscal-years")
+@RequestMapping("/finance/fiscal")
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class FiscalYearController(
     private val fiscalYearService: FiscalYearService,

--- a/src/main/kotlin/com/froilan/synectix/dto/FiscalYearDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/FiscalYearDtos.kt
@@ -1,0 +1,50 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDate
+
+data class CreateFiscalYearRequest(
+    @field:NotBlank(message = "Fiscal year name is required")
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+)
+
+data class FiscalPeriodResponse(
+    val id: String,
+    val periodNumber: Int,
+    val name: String,
+    val startDate: String,
+    val endDate: String,
+    val status: String,
+    val closedAt: String?,
+    val closedBy: String?,
+    val reopenedAt: String?,
+    val reopenedBy: String?,
+)
+
+data class FiscalYearResponse(
+    val id: String,
+    val name: String,
+    val startDate: String,
+    val endDate: String,
+    val status: String,
+    val organizationId: String,
+    val periods: List<FiscalPeriodResponse>,
+    val closedAt: String?,
+    val closedBy: String?,
+    val closingEntryId: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class FiscalYearSummaryResponse(
+    val id: String,
+    val name: String,
+    val startDate: String,
+    val endDate: String,
+    val status: String,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/FiscalYear.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/FiscalYear.kt
@@ -1,0 +1,60 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class FiscalYearStatus {
+    ACTIVE,
+    CLOSED,
+}
+
+enum class FiscalPeriodStatus {
+    OPEN,
+    CLOSED,
+    REOPENED,
+}
+
+data class FiscalPeriod(
+    val id: String = UUID.randomUUID().toString(),
+    val periodNumber: Int,
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val status: FiscalPeriodStatus = FiscalPeriodStatus.OPEN,
+    val closedAt: LocalDateTime? = null,
+    val closedBy: String? = null,
+    val reopenedAt: LocalDateTime? = null,
+    val reopenedBy: String? = null,
+)
+
+@Document(collection = "fiscal_years")
+@CompoundIndex(
+    name = "unique_name_per_org",
+    def = "{'organizationId': 1, 'name': 1}",
+    unique = true,
+)
+data class FiscalYear(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val status: FiscalYearStatus = FiscalYearStatus.ACTIVE,
+    @Indexed
+    val organizationId: String,
+    val periods: List<FiscalPeriod> = emptyList(),
+    val closedAt: LocalDateTime? = null,
+    val closedBy: String? = null,
+    val closingEntryId: String? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/FiscalYearRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/FiscalYearRepository.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.FiscalYear
+import com.froilan.synectix.model.FiscalYearStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FiscalYearRepository : MongoRepository<FiscalYear, String> {
+    fun findByOrganizationId(organizationId: String): List<FiscalYear>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: FiscalYearStatus,
+    ): List<FiscalYear>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
@@ -62,4 +62,9 @@ interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
     ): List<JournalEntry>
 
     fun countByOrganizationId(organizationId: String): Long
+
+    fun existsByOrganizationIdAndSourceReference(
+        organizationId: String,
+        sourceReference: String,
+    ): Boolean
 }

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
@@ -55,6 +55,13 @@ interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
         statuses: List<JournalEntryStatus>,
     ): List<JournalEntry>
 
+    fun findByOrganizationIdAndStatusInAndDateBetween(
+        organizationId: String,
+        statuses: List<JournalEntryStatus>,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<JournalEntry>
+
     fun findByOrganizationIdAndStatusInAndDateLessThanEqual(
         organizationId: String,
         statuses: List<JournalEntryStatus>,

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -29,6 +29,10 @@ object Permissions {
     const val JOURNAL_POST = "journal:post"
     const val JOURNAL_VOID = "journal:void"
 
+    const val FISCAL_CREATE = "fiscal:create"
+    const val FISCAL_READ = "fiscal:read"
+    const val FISCAL_CLOSE = "fiscal:close"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -51,5 +55,8 @@ object Permissions {
             JOURNAL_READ,
             JOURNAL_POST,
             JOURNAL_VOID,
+            FISCAL_CREATE,
+            FISCAL_READ,
+            FISCAL_CLOSE,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -39,8 +39,15 @@ class FiscalYearService(
 
         val existing = fiscalYearRepository.findByOrganizationId(organizationId)
 
+        val activeFiscalYear = existing.firstOrNull { it.status == FiscalYearStatus.ACTIVE }
+        if (activeFiscalYear != null) {
+            throw IllegalArgumentException(
+                "An active fiscal year '${activeFiscalYear.name}' already exists in this organization",
+            )
+        }
+
         existing.forEach { fy ->
-            if (request.startDate.isBefore(fy.endDate) && request.endDate.isAfter(fy.startDate)) {
+            if (!request.startDate.isAfter(fy.endDate) && !request.endDate.isBefore(fy.startDate)) {
                 throw IllegalArgumentException(
                     "Date range overlaps with existing fiscal year '${fy.name}'",
                 )
@@ -191,7 +198,7 @@ class FiscalYearService(
         )
     }
 
-    fun findOpenPeriodForDate(
+    fun findPeriodForDate(
         organizationId: String,
         date: LocalDate,
     ): FiscalPeriod? {
@@ -224,6 +231,11 @@ class FiscalYearService(
         organizationId: String,
         closedBy: String,
     ): JournalEntry? {
+        val sourceRef = "YEAR-END-CLOSE-${fiscalYear.id}"
+        if (journalEntryRepository.existsByOrganizationIdAndSourceReference(organizationId, sourceRef)) {
+            throw IllegalArgumentException("Year-end closing entry already exists for this fiscal year")
+        }
+
         val entries =
             journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
                 organizationId,
@@ -246,7 +258,7 @@ class FiscalYearService(
 
         val accounts =
             accountRepository
-                .findByOrganizationIdAndIsActive(organizationId, true)
+                .findAllById(accountTotals.keys)
                 .associateBy { it.id }
 
         val closingLines = mutableListOf<JournalEntryLine>()
@@ -319,7 +331,7 @@ class FiscalYearService(
                 organizationId = organizationId,
                 status = JournalEntryStatus.POSTED,
                 source = JournalEntrySource.SYSTEM,
-                sourceReference = "YEAR-END-CLOSE-${fiscalYear.id}",
+                sourceReference = sourceRef,
                 lines = closingLines,
                 createdBy = closedBy,
                 postedAt = LocalDateTime.now(),

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -1,0 +1,378 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateFiscalYearRequest
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.FiscalPeriod
+import com.froilan.synectix.model.FiscalPeriodStatus
+import com.froilan.synectix.model.FiscalYear
+import com.froilan.synectix.model.FiscalYearStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.FiscalYearRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.TextStyle
+import java.util.Locale
+
+@Service
+class FiscalYearService(
+    private val fiscalYearRepository: FiscalYearRepository,
+    private val journalEntryRepository: JournalEntryRepository,
+    private val accountRepository: AccountRepository,
+) {
+    @Transactional
+    fun createFiscalYear(
+        request: CreateFiscalYearRequest,
+        organizationId: String,
+    ): FiscalYear {
+        if (!request.startDate.isBefore(request.endDate)) {
+            throw IllegalArgumentException("Start date must be before end date")
+        }
+
+        val existing = fiscalYearRepository.findByOrganizationId(organizationId)
+
+        existing.forEach { fy ->
+            if (request.startDate.isBefore(fy.endDate) && request.endDate.isAfter(fy.startDate)) {
+                throw IllegalArgumentException(
+                    "Date range overlaps with existing fiscal year '${fy.name}'",
+                )
+            }
+        }
+
+        val periods = generateMonthlyPeriods(request.startDate, request.endDate)
+
+        val fiscalYear = FiscalYear(
+            name = request.name,
+            startDate = request.startDate,
+            endDate = request.endDate,
+            organizationId = organizationId,
+            periods = periods,
+        )
+
+        return try {
+            fiscalYearRepository.save(fiscalYear)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Fiscal year '${request.name}' already exists in this organization",
+            )
+        }
+    }
+
+    fun getFiscalYear(
+        fiscalYearId: String,
+        organizationId: String,
+    ): FiscalYear = findFiscalYear(fiscalYearId, organizationId)
+
+    fun listFiscalYears(organizationId: String): List<FiscalYear> =
+        fiscalYearRepository.findByOrganizationId(organizationId)
+
+    @Transactional
+    fun closePeriod(
+        fiscalYearId: String,
+        periodId: String,
+        organizationId: String,
+        closedBy: String,
+    ): FiscalYear {
+        val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
+
+        if (fiscalYear.status == FiscalYearStatus.CLOSED) {
+            throw IllegalArgumentException("Fiscal year is already closed")
+        }
+
+        val periodIndex = fiscalYear.periods.indexOfFirst { it.id == periodId }
+        if (periodIndex == -1) {
+            throw IllegalArgumentException("Fiscal period not found")
+        }
+
+        val period = fiscalYear.periods[periodIndex]
+        if (period.status == FiscalPeriodStatus.CLOSED) {
+            throw IllegalArgumentException("Fiscal period is already closed")
+        }
+
+        val precedingOpen = fiscalYear.periods
+            .take(periodIndex)
+            .any { it.status != FiscalPeriodStatus.CLOSED }
+        if (precedingOpen) {
+            throw IllegalArgumentException("All preceding periods must be closed first")
+        }
+
+        val updatedPeriods = fiscalYear.periods.toMutableList()
+        updatedPeriods[periodIndex] = period.copy(
+            status = FiscalPeriodStatus.CLOSED,
+            closedAt = LocalDateTime.now(),
+            closedBy = closedBy,
+        )
+
+        return fiscalYearRepository.save(
+            fiscalYear.copy(periods = updatedPeriods),
+        )
+    }
+
+    @Transactional
+    fun reopenPeriod(
+        fiscalYearId: String,
+        periodId: String,
+        organizationId: String,
+        reopenedBy: String,
+    ): FiscalYear {
+        val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
+
+        if (fiscalYear.status == FiscalYearStatus.CLOSED) {
+            throw IllegalArgumentException("Cannot reopen period in a closed fiscal year")
+        }
+
+        val periodIndex = fiscalYear.periods.indexOfFirst { it.id == periodId }
+        if (periodIndex == -1) {
+            throw IllegalArgumentException("Fiscal period not found")
+        }
+
+        val period = fiscalYear.periods[periodIndex]
+        if (period.status != FiscalPeriodStatus.CLOSED) {
+            throw IllegalArgumentException("Only closed periods can be reopened")
+        }
+
+        val subsequentOpen = fiscalYear.periods
+            .drop(periodIndex + 1)
+            .any { it.status != FiscalPeriodStatus.CLOSED }
+        if (subsequentOpen) {
+            throw IllegalArgumentException("All subsequent periods must be closed first")
+        }
+
+        val updatedPeriods = fiscalYear.periods.toMutableList()
+        updatedPeriods[periodIndex] = period.copy(
+            status = FiscalPeriodStatus.REOPENED,
+            reopenedAt = LocalDateTime.now(),
+            reopenedBy = reopenedBy,
+        )
+
+        return fiscalYearRepository.save(
+            fiscalYear.copy(periods = updatedPeriods),
+        )
+    }
+
+    @Transactional
+    fun closeYear(
+        fiscalYearId: String,
+        organizationId: String,
+        closedBy: String,
+    ): FiscalYear {
+        val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
+
+        if (fiscalYear.status == FiscalYearStatus.CLOSED) {
+            throw IllegalArgumentException("Fiscal year is already closed")
+        }
+
+        val allPeriodsClosed = fiscalYear.periods.all { it.status == FiscalPeriodStatus.CLOSED }
+        if (!allPeriodsClosed) {
+            throw IllegalArgumentException("All periods must be closed before closing the fiscal year")
+        }
+
+        val closingEntry = createClosingEntry(fiscalYear, organizationId, closedBy)
+
+        return fiscalYearRepository.save(
+            fiscalYear.copy(
+                status = FiscalYearStatus.CLOSED,
+                closedAt = LocalDateTime.now(),
+                closedBy = closedBy,
+                closingEntryId = closingEntry?.id,
+            ),
+        )
+    }
+
+    fun findOpenPeriodForDate(
+        organizationId: String,
+        date: LocalDate,
+    ): FiscalPeriod? {
+        val activeFiscalYears = fiscalYearRepository.findByOrganizationIdAndStatus(
+            organizationId,
+            FiscalYearStatus.ACTIVE,
+        )
+        if (activeFiscalYears.isEmpty()) return null
+
+        for (fy in activeFiscalYears) {
+            for (period in fy.periods) {
+                if (!date.isBefore(period.startDate) && !date.isAfter(period.endDate)) {
+                    return period
+                }
+            }
+        }
+        return null
+    }
+
+    fun hasActiveFiscalYear(organizationId: String): Boolean =
+        fiscalYearRepository.findByOrganizationIdAndStatus(
+            organizationId,
+            FiscalYearStatus.ACTIVE,
+        ).isNotEmpty()
+
+    private fun createClosingEntry(
+        fiscalYear: FiscalYear,
+        organizationId: String,
+        closedBy: String,
+    ): JournalEntry? {
+        val entries = journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+            organizationId,
+            JournalEntryStatus.POSTED,
+            fiscalYear.startDate,
+            fiscalYear.endDate,
+        )
+
+        val accountTotals = mutableMapOf<String, Pair<BigDecimal, BigDecimal>>()
+        entries.forEach { entry ->
+            entry.lines.forEach { line ->
+                val (debits, credits) = accountTotals.getOrDefault(
+                    line.accountId,
+                    BigDecimal.ZERO to BigDecimal.ZERO,
+                )
+                accountTotals[line.accountId] = debits.add(line.debit) to credits.add(line.credit)
+            }
+        }
+
+        val accounts = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
+            .associateBy { it.id }
+
+        val closingLines = mutableListOf<JournalEntryLine>()
+
+        accountTotals.forEach { (accountId, totals) ->
+            val account = accounts[accountId] ?: return@forEach
+            val (totalDebits, totalCredits) = totals
+
+            when (account.type) {
+                AccountType.REVENUE -> {
+                    val balance = totalCredits.subtract(totalDebits)
+                    if (balance.compareTo(BigDecimal.ZERO) != 0) {
+                        closingLines.add(
+                            JournalEntryLine(
+                                accountId = account.id,
+                                accountCode = account.code,
+                                accountName = account.name,
+                                debit = if (balance > BigDecimal.ZERO) balance else BigDecimal.ZERO,
+                                credit = if (balance < BigDecimal.ZERO) balance.negate() else BigDecimal.ZERO,
+                            ),
+                        )
+                    }
+                }
+                AccountType.EXPENSE -> {
+                    val balance = totalDebits.subtract(totalCredits)
+                    if (balance.compareTo(BigDecimal.ZERO) != 0) {
+                        closingLines.add(
+                            JournalEntryLine(
+                                accountId = account.id,
+                                accountCode = account.code,
+                                accountName = account.name,
+                                debit = if (balance < BigDecimal.ZERO) balance.negate() else BigDecimal.ZERO,
+                                credit = if (balance > BigDecimal.ZERO) balance else BigDecimal.ZERO,
+                            ),
+                        )
+                    }
+                }
+                else -> {}
+            }
+        }
+
+        if (closingLines.isEmpty()) return null
+
+        val totalClosingDebits = closingLines.fold(BigDecimal.ZERO) { sum, l -> sum.add(l.debit) }
+        val totalClosingCredits = closingLines.fold(BigDecimal.ZERO) { sum, l -> sum.add(l.credit) }
+        val netIncome = totalClosingCredits.subtract(totalClosingDebits)
+
+        val retainedEarnings = accountRepository.findByOrganizationIdAndCode(organizationId, "3100")
+            .orElseThrow {
+                IllegalStateException("Retained Earnings account (3100) not found")
+            }
+
+        closingLines.add(
+            JournalEntryLine(
+                accountId = retainedEarnings.id,
+                accountCode = retainedEarnings.code,
+                accountName = retainedEarnings.name,
+                debit = if (netIncome < BigDecimal.ZERO) netIncome.negate() else BigDecimal.ZERO,
+                credit = if (netIncome > BigDecimal.ZERO) netIncome else BigDecimal.ZERO,
+            ),
+        )
+
+        return saveWithRetry(organizationId) { entryNumber ->
+            JournalEntry(
+                entryNumber = entryNumber,
+                date = fiscalYear.endDate,
+                description = "Year-end closing entry for ${fiscalYear.name}",
+                organizationId = organizationId,
+                status = JournalEntryStatus.POSTED,
+                source = JournalEntrySource.SYSTEM,
+                sourceReference = "YEAR-END-CLOSE-${fiscalYear.id}",
+                lines = closingLines,
+                createdBy = closedBy,
+                postedAt = LocalDateTime.now(),
+            )
+        }
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildEntry: (String) -> JournalEntry,
+    ): JournalEntry {
+        repeat(maxRetries) {
+            val count = journalEntryRepository.countByOrganizationId(organizationId)
+            val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return journalEntryRepository.save(buildEntry(entryNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) throw e
+            }
+        }
+        throw IllegalStateException("Failed to generate unique entry number")
+    }
+
+    private fun generateMonthlyPeriods(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<FiscalPeriod> {
+        val periods = mutableListOf<FiscalPeriod>()
+        var periodStart = startDate
+        var periodNumber = 1
+
+        while (periodStart.isBefore(endDate) || periodStart.isEqual(endDate)) {
+            val monthEnd = periodStart.withDayOfMonth(periodStart.lengthOfMonth())
+            val periodEnd = if (monthEnd.isAfter(endDate)) endDate else monthEnd
+
+            val monthName = periodStart.month.getDisplayName(TextStyle.FULL, Locale.ENGLISH)
+            val name = "$monthName ${periodStart.year}"
+
+            periods.add(
+                FiscalPeriod(
+                    periodNumber = periodNumber,
+                    name = name,
+                    startDate = periodStart,
+                    endDate = periodEnd,
+                ),
+            )
+
+            periodStart = periodEnd.plusDays(1)
+            periodNumber++
+        }
+
+        return periods
+    }
+
+    private fun findFiscalYear(
+        fiscalYearId: String,
+        organizationId: String,
+    ): FiscalYear {
+        val fiscalYear = fiscalYearRepository.findById(fiscalYearId).orElseThrow {
+            IllegalArgumentException("Fiscal year not found")
+        }
+        if (fiscalYear.organizationId != organizationId) {
+            throw IllegalArgumentException("Fiscal year not found")
+        }
+        return fiscalYear
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -236,10 +236,11 @@ class FiscalYearService(
             throw IllegalArgumentException("Year-end closing entry already exists for this fiscal year")
         }
 
+        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
         val entries =
-            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
                 organizationId,
-                JournalEntryStatus.POSTED,
+                postedStatuses,
                 fiscalYear.startDate,
                 fiscalYear.endDate,
             )

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -49,13 +49,14 @@ class FiscalYearService(
 
         val periods = generateMonthlyPeriods(request.startDate, request.endDate)
 
-        val fiscalYear = FiscalYear(
-            name = request.name,
-            startDate = request.startDate,
-            endDate = request.endDate,
-            organizationId = organizationId,
-            periods = periods,
-        )
+        val fiscalYear =
+            FiscalYear(
+                name = request.name,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                organizationId = organizationId,
+                periods = periods,
+            )
 
         return try {
             fiscalYearRepository.save(fiscalYear)
@@ -71,8 +72,7 @@ class FiscalYearService(
         organizationId: String,
     ): FiscalYear = findFiscalYear(fiscalYearId, organizationId)
 
-    fun listFiscalYears(organizationId: String): List<FiscalYear> =
-        fiscalYearRepository.findByOrganizationId(organizationId)
+    fun listFiscalYears(organizationId: String): List<FiscalYear> = fiscalYearRepository.findByOrganizationId(organizationId)
 
     @Transactional
     fun closePeriod(
@@ -97,19 +97,21 @@ class FiscalYearService(
             throw IllegalArgumentException("Fiscal period is already closed")
         }
 
-        val precedingOpen = fiscalYear.periods
-            .take(periodIndex)
-            .any { it.status != FiscalPeriodStatus.CLOSED }
+        val precedingOpen =
+            fiscalYear.periods
+                .take(periodIndex)
+                .any { it.status != FiscalPeriodStatus.CLOSED }
         if (precedingOpen) {
             throw IllegalArgumentException("All preceding periods must be closed first")
         }
 
         val updatedPeriods = fiscalYear.periods.toMutableList()
-        updatedPeriods[periodIndex] = period.copy(
-            status = FiscalPeriodStatus.CLOSED,
-            closedAt = LocalDateTime.now(),
-            closedBy = closedBy,
-        )
+        updatedPeriods[periodIndex] =
+            period.copy(
+                status = FiscalPeriodStatus.CLOSED,
+                closedAt = LocalDateTime.now(),
+                closedBy = closedBy,
+            )
 
         return fiscalYearRepository.save(
             fiscalYear.copy(periods = updatedPeriods),
@@ -139,19 +141,21 @@ class FiscalYearService(
             throw IllegalArgumentException("Only closed periods can be reopened")
         }
 
-        val subsequentOpen = fiscalYear.periods
-            .drop(periodIndex + 1)
-            .any { it.status != FiscalPeriodStatus.CLOSED }
+        val subsequentOpen =
+            fiscalYear.periods
+                .drop(periodIndex + 1)
+                .any { it.status != FiscalPeriodStatus.CLOSED }
         if (subsequentOpen) {
             throw IllegalArgumentException("All subsequent periods must be closed first")
         }
 
         val updatedPeriods = fiscalYear.periods.toMutableList()
-        updatedPeriods[periodIndex] = period.copy(
-            status = FiscalPeriodStatus.REOPENED,
-            reopenedAt = LocalDateTime.now(),
-            reopenedBy = reopenedBy,
-        )
+        updatedPeriods[periodIndex] =
+            period.copy(
+                status = FiscalPeriodStatus.REOPENED,
+                reopenedAt = LocalDateTime.now(),
+                reopenedBy = reopenedBy,
+            )
 
         return fiscalYearRepository.save(
             fiscalYear.copy(periods = updatedPeriods),
@@ -191,10 +195,11 @@ class FiscalYearService(
         organizationId: String,
         date: LocalDate,
     ): FiscalPeriod? {
-        val activeFiscalYears = fiscalYearRepository.findByOrganizationIdAndStatus(
-            organizationId,
-            FiscalYearStatus.ACTIVE,
-        )
+        val activeFiscalYears =
+            fiscalYearRepository.findByOrganizationIdAndStatus(
+                organizationId,
+                FiscalYearStatus.ACTIVE,
+            )
         if (activeFiscalYears.isEmpty()) return null
 
         for (fy in activeFiscalYears) {
@@ -208,36 +213,41 @@ class FiscalYearService(
     }
 
     fun hasActiveFiscalYear(organizationId: String): Boolean =
-        fiscalYearRepository.findByOrganizationIdAndStatus(
-            organizationId,
-            FiscalYearStatus.ACTIVE,
-        ).isNotEmpty()
+        fiscalYearRepository
+            .findByOrganizationIdAndStatus(
+                organizationId,
+                FiscalYearStatus.ACTIVE,
+            ).isNotEmpty()
 
     private fun createClosingEntry(
         fiscalYear: FiscalYear,
         organizationId: String,
         closedBy: String,
     ): JournalEntry? {
-        val entries = journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
-            organizationId,
-            JournalEntryStatus.POSTED,
-            fiscalYear.startDate,
-            fiscalYear.endDate,
-        )
+        val entries =
+            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+                organizationId,
+                JournalEntryStatus.POSTED,
+                fiscalYear.startDate,
+                fiscalYear.endDate,
+            )
 
         val accountTotals = mutableMapOf<String, Pair<BigDecimal, BigDecimal>>()
         entries.forEach { entry ->
             entry.lines.forEach { line ->
-                val (debits, credits) = accountTotals.getOrDefault(
-                    line.accountId,
-                    BigDecimal.ZERO to BigDecimal.ZERO,
-                )
+                val (debits, credits) =
+                    accountTotals.getOrDefault(
+                        line.accountId,
+                        BigDecimal.ZERO to BigDecimal.ZERO,
+                    )
                 accountTotals[line.accountId] = debits.add(line.debit) to credits.add(line.credit)
             }
         }
 
-        val accounts = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
-            .associateBy { it.id }
+        val accounts =
+            accountRepository
+                .findByOrganizationIdAndIsActive(organizationId, true)
+                .associateBy { it.id }
 
         val closingLines = mutableListOf<JournalEntryLine>()
 
@@ -282,20 +292,22 @@ class FiscalYearService(
 
         val totalClosingDebits = closingLines.fold(BigDecimal.ZERO) { sum, l -> sum.add(l.debit) }
         val totalClosingCredits = closingLines.fold(BigDecimal.ZERO) { sum, l -> sum.add(l.credit) }
-        val netIncome = totalClosingCredits.subtract(totalClosingDebits)
+        val difference = totalClosingDebits.subtract(totalClosingCredits)
 
-        val retainedEarnings = accountRepository.findByOrganizationIdAndCode(organizationId, "3100")
-            .orElseThrow {
-                IllegalStateException("Retained Earnings account (3100) not found")
-            }
+        val retainedEarnings =
+            accountRepository
+                .findByOrganizationIdAndCode(organizationId, "3100")
+                .orElseThrow {
+                    IllegalStateException("Retained Earnings account (3100) not found")
+                }
 
         closingLines.add(
             JournalEntryLine(
                 accountId = retainedEarnings.id,
                 accountCode = retainedEarnings.code,
                 accountName = retainedEarnings.name,
-                debit = if (netIncome < BigDecimal.ZERO) netIncome.negate() else BigDecimal.ZERO,
-                credit = if (netIncome > BigDecimal.ZERO) netIncome else BigDecimal.ZERO,
+                debit = if (difference < BigDecimal.ZERO) difference.negate() else BigDecimal.ZERO,
+                credit = if (difference > BigDecimal.ZERO) difference else BigDecimal.ZERO,
             ),
         )
 
@@ -367,9 +379,10 @@ class FiscalYearService(
         fiscalYearId: String,
         organizationId: String,
     ): FiscalYear {
-        val fiscalYear = fiscalYearRepository.findById(fiscalYearId).orElseThrow {
-            IllegalArgumentException("Fiscal year not found")
-        }
+        val fiscalYear =
+            fiscalYearRepository.findById(fiscalYearId).orElseThrow {
+                IllegalArgumentException("Fiscal year not found")
+            }
         if (fiscalYear.organizationId != organizationId) {
             throw IllegalArgumentException("Fiscal year not found")
         }

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -202,14 +202,10 @@ class FiscalYearService(
         organizationId: String,
         date: LocalDate,
     ): FiscalPeriod? {
-        val activeFiscalYears =
-            fiscalYearRepository.findByOrganizationIdAndStatus(
-                organizationId,
-                FiscalYearStatus.ACTIVE,
-            )
-        if (activeFiscalYears.isEmpty()) return null
+        val allFiscalYears = fiscalYearRepository.findByOrganizationId(organizationId)
+        if (allFiscalYears.isEmpty()) return null
 
-        for (fy in activeFiscalYears) {
+        for (fy in allFiscalYears) {
             for (period in fy.periods) {
                 if (!date.isBefore(period.startDate) && !date.isAfter(period.endDate)) {
                     return period
@@ -219,12 +215,7 @@ class FiscalYearService(
         return null
     }
 
-    fun hasActiveFiscalYear(organizationId: String): Boolean =
-        fiscalYearRepository
-            .findByOrganizationIdAndStatus(
-                organizationId,
-                FiscalYearStatus.ACTIVE,
-            ).isNotEmpty()
+    fun hasFiscalYears(organizationId: String): Boolean = fiscalYearRepository.findByOrganizationId(organizationId).isNotEmpty()
 
     private fun createClosingEntry(
         fiscalYear: FiscalYear,
@@ -261,10 +252,17 @@ class FiscalYearService(
                 .findAllById(accountTotals.keys)
                 .associateBy { it.id }
 
+        val missingAccountIds = accountTotals.keys - accounts.keys
+        if (missingAccountIds.isNotEmpty()) {
+            throw IllegalStateException(
+                "Cannot create closing entry: missing accounts ${missingAccountIds.sorted().joinToString(", ")}",
+            )
+        }
+
         val closingLines = mutableListOf<JournalEntryLine>()
 
         accountTotals.forEach { (accountId, totals) ->
-            val account = accounts[accountId] ?: return@forEach
+            val account = accounts.getValue(accountId)
             val (totalDebits, totalCredits) = totals
 
             when (account.type) {
@@ -306,22 +304,24 @@ class FiscalYearService(
         val totalClosingCredits = closingLines.fold(BigDecimal.ZERO) { sum, l -> sum.add(l.credit) }
         val difference = totalClosingDebits.subtract(totalClosingCredits)
 
-        val retainedEarnings =
-            accountRepository
-                .findByOrganizationIdAndCode(organizationId, "3100")
-                .orElseThrow {
-                    IllegalStateException("Retained Earnings account (3100) not found")
-                }
+        if (difference.compareTo(BigDecimal.ZERO) != 0) {
+            val retainedEarnings =
+                accountRepository
+                    .findByOrganizationIdAndCode(organizationId, "3100")
+                    .orElseThrow {
+                        IllegalStateException("Retained Earnings account (3100) not found")
+                    }
 
-        closingLines.add(
-            JournalEntryLine(
-                accountId = retainedEarnings.id,
-                accountCode = retainedEarnings.code,
-                accountName = retainedEarnings.name,
-                debit = if (difference < BigDecimal.ZERO) difference.negate() else BigDecimal.ZERO,
-                credit = if (difference > BigDecimal.ZERO) difference else BigDecimal.ZERO,
-            ),
-        )
+            closingLines.add(
+                JournalEntryLine(
+                    accountId = retainedEarnings.id,
+                    accountCode = retainedEarnings.code,
+                    accountName = retainedEarnings.name,
+                    debit = if (difference < BigDecimal.ZERO) difference.negate() else BigDecimal.ZERO,
+                    credit = if (difference > BigDecimal.ZERO) difference else BigDecimal.ZERO,
+                ),
+            )
+        }
 
         return saveWithRetry(organizationId) { entryNumber ->
             JournalEntry(

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -27,6 +27,7 @@ class FiscalYearService(
     private val fiscalYearRepository: FiscalYearRepository,
     private val journalEntryRepository: JournalEntryRepository,
     private val accountRepository: AccountRepository,
+    private val entryNumberGenerator: JournalEntryNumberGenerator,
 ) {
     @Transactional
     fun createFiscalYear(
@@ -201,21 +202,29 @@ class FiscalYearService(
     fun findPeriodForDate(
         organizationId: String,
         date: LocalDate,
-    ): FiscalPeriod? {
+    ): PeriodLookupResult {
         val allFiscalYears = fiscalYearRepository.findByOrganizationId(organizationId)
-        if (allFiscalYears.isEmpty()) return null
+        if (allFiscalYears.isEmpty()) return PeriodLookupResult.NoFiscalYears
 
         for (fy in allFiscalYears) {
             for (period in fy.periods) {
                 if (!date.isBefore(period.startDate) && !date.isAfter(period.endDate)) {
-                    return period
+                    return PeriodLookupResult.Found(period)
                 }
             }
         }
-        return null
+        return PeriodLookupResult.NotFound
     }
 
-    fun hasFiscalYears(organizationId: String): Boolean = fiscalYearRepository.findByOrganizationId(organizationId).isNotEmpty()
+    sealed class PeriodLookupResult {
+        data object NoFiscalYears : PeriodLookupResult()
+
+        data object NotFound : PeriodLookupResult()
+
+        data class Found(
+            val period: FiscalPeriod,
+        ) : PeriodLookupResult()
+    }
 
     private fun createClosingEntry(
         fiscalYear: FiscalYear,
@@ -323,7 +332,7 @@ class FiscalYearService(
             )
         }
 
-        return saveWithRetry(organizationId) { entryNumber ->
+        return entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
             JournalEntry(
                 entryNumber = entryNumber,
                 date = fiscalYear.endDate,
@@ -337,23 +346,6 @@ class FiscalYearService(
                 postedAt = LocalDateTime.now(),
             )
         }
-    }
-
-    private fun saveWithRetry(
-        organizationId: String,
-        maxRetries: Int = 3,
-        buildEntry: (String) -> JournalEntry,
-    ): JournalEntry {
-        repeat(maxRetries) {
-            val count = journalEntryRepository.countByOrganizationId(organizationId)
-            val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
-            try {
-                return journalEntryRepository.save(buildEntry(entryNumber))
-            } catch (e: DuplicateKeyException) {
-                if (it == maxRetries - 1) throw e
-            }
-        }
-        throw IllegalStateException("Failed to generate unique entry number")
     }
 
     private fun generateMonthlyPeriods(

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
@@ -1,0 +1,28 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Component
+
+@Component
+class JournalEntryNumberGenerator(
+    private val journalEntryRepository: JournalEntryRepository,
+) {
+    fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildEntry: (String) -> JournalEntry,
+    ): JournalEntry {
+        repeat(maxRetries) {
+            val count = journalEntryRepository.countByOrganizationId(organizationId)
+            val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return journalEntryRepository.save(buildEntry(entryNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) throw e
+            }
+        }
+        throw IllegalStateException("Failed to generate unique entry number")
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -4,11 +4,11 @@ import com.froilan.synectix.dto.AccountBalanceResponse
 import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.TrialBalanceResponse
 import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
-import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.springframework.dao.DuplicateKeyException

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -327,7 +327,7 @@ class JournalEntryService(
         organizationId: String,
         date: LocalDate,
     ) {
-        if (!fiscalYearService.hasActiveFiscalYear(organizationId)) return
+        if (!fiscalYearService.hasFiscalYears(organizationId)) return
 
         val period =
             fiscalYearService.findPeriodForDate(organizationId, date)

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -8,6 +8,7 @@ import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.springframework.dao.DuplicateKeyException
@@ -21,6 +22,7 @@ import java.time.LocalDateTime
 class JournalEntryService(
     private val journalEntryRepository: JournalEntryRepository,
     private val accountRepository: AccountRepository,
+    private val fiscalYearService: FiscalYearService,
 ) {
     @Transactional
     fun createJournalEntry(
@@ -78,6 +80,8 @@ class JournalEntryService(
                 )
             }
 
+        validateFiscalPeriodOpen(organizationId, request.date)
+
         return saveWithRetry(organizationId) { entryNumber ->
             JournalEntry(
                 entryNumber = entryNumber,
@@ -106,6 +110,8 @@ class JournalEntryService(
         if (totalDebits.compareTo(totalCredits) != 0) {
             throw IllegalArgumentException("Journal entry is not balanced")
         }
+
+        validateFiscalPeriodOpen(organizationId, entry.date)
 
         return journalEntryRepository.save(
             entry.copy(
@@ -315,6 +321,21 @@ class JournalEntryService(
             throw IllegalArgumentException("Journal entry not found")
         }
         return entry
+    }
+
+    private fun validateFiscalPeriodOpen(
+        organizationId: String,
+        date: LocalDate,
+    ) {
+        if (!fiscalYearService.hasActiveFiscalYear(organizationId)) return
+
+        val period = fiscalYearService.findOpenPeriodForDate(organizationId, date)
+        if (period == null) {
+            throw IllegalArgumentException("No open fiscal period covers the date $date")
+        }
+        if (period.status == FiscalPeriodStatus.CLOSED) {
+            throw IllegalArgumentException("Fiscal period '${period.name}' is closed")
+        }
     }
 
     private fun saveWithRetry(

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -329,10 +329,10 @@ class JournalEntryService(
     ) {
         if (!fiscalYearService.hasActiveFiscalYear(organizationId)) return
 
-        val period = fiscalYearService.findOpenPeriodForDate(organizationId, date)
-        if (period == null) {
-            throw IllegalArgumentException("No open fiscal period covers the date $date")
-        }
+        val period =
+            fiscalYearService.findPeriodForDate(organizationId, date)
+                ?: throw IllegalArgumentException("No fiscal period covers the date $date")
+
         if (period.status == FiscalPeriodStatus.CLOSED) {
             throw IllegalArgumentException("Fiscal period '${period.name}' is closed")
         }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -11,7 +11,6 @@ import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
-import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -23,6 +22,7 @@ class JournalEntryService(
     private val journalEntryRepository: JournalEntryRepository,
     private val accountRepository: AccountRepository,
     private val fiscalYearService: FiscalYearService,
+    private val entryNumberGenerator: JournalEntryNumberGenerator,
 ) {
     @Transactional
     fun createJournalEntry(
@@ -82,7 +82,7 @@ class JournalEntryService(
 
         validateFiscalPeriodOpen(organizationId, request.date)
 
-        return saveWithRetry(organizationId) { entryNumber ->
+        return entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
             JournalEntry(
                 entryNumber = entryNumber,
                 date = request.date,
@@ -146,7 +146,7 @@ class JournalEntryService(
                 line.copy(debit = line.credit, credit = line.debit)
             }
 
-        saveWithRetry(organizationId) { reversingNumber ->
+        entryNumberGenerator.saveWithRetry(organizationId) { reversingNumber ->
             JournalEntry(
                 entryNumber = reversingNumber,
                 date = LocalDate.now(),
@@ -327,31 +327,15 @@ class JournalEntryService(
         organizationId: String,
         date: LocalDate,
     ) {
-        if (!fiscalYearService.hasFiscalYears(organizationId)) return
-
-        val period =
-            fiscalYearService.findPeriodForDate(organizationId, date)
-                ?: throw IllegalArgumentException("No fiscal period covers the date $date")
-
-        if (period.status == FiscalPeriodStatus.CLOSED) {
-            throw IllegalArgumentException("Fiscal period '${period.name}' is closed")
-        }
-    }
-
-    private fun saveWithRetry(
-        organizationId: String,
-        maxRetries: Int = 3,
-        buildEntry: (String) -> JournalEntry,
-    ): JournalEntry {
-        repeat(maxRetries) {
-            val count = journalEntryRepository.countByOrganizationId(organizationId)
-            val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
-            try {
-                return journalEntryRepository.save(buildEntry(entryNumber))
-            } catch (e: DuplicateKeyException) {
-                if (it == maxRetries - 1) throw e
+        when (val result = fiscalYearService.findPeriodForDate(organizationId, date)) {
+            is FiscalYearService.PeriodLookupResult.NoFiscalYears -> return
+            is FiscalYearService.PeriodLookupResult.NotFound ->
+                throw IllegalArgumentException("No fiscal period covers the date $date")
+            is FiscalYearService.PeriodLookupResult.Found -> {
+                if (result.period.status == FiscalPeriodStatus.CLOSED) {
+                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
+                }
             }
         }
-        throw IllegalStateException("Failed to generate unique entry number")
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -73,6 +73,9 @@ class RoleSeederTest {
                         Permissions.JOURNAL_READ,
                         Permissions.JOURNAL_POST,
                         Permissions.JOURNAL_VOID,
+                        Permissions.FISCAL_CREATE,
+                        Permissions.FISCAL_READ,
+                        Permissions.FISCAL_CLOSE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -138,6 +141,9 @@ class RoleSeederTest {
                         Permissions.JOURNAL_READ,
                         Permissions.JOURNAL_POST,
                         Permissions.JOURNAL_VOID,
+                        Permissions.FISCAL_CREATE,
+                        Permissions.FISCAL_READ,
+                        Permissions.FISCAL_CLOSE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -230,6 +236,9 @@ class RoleSeederTest {
                         Permissions.JOURNAL_READ,
                         Permissions.JOURNAL_POST,
                         Permissions.JOURNAL_VOID,
+                        Permissions.FISCAL_CREATE,
+                        Permissions.FISCAL_READ,
+                        Permissions.FISCAL_CLOSE,
                     ),
             )
         val admin =
@@ -254,6 +263,9 @@ class RoleSeederTest {
                         Permissions.JOURNAL_CREATE,
                         Permissions.JOURNAL_READ,
                         Permissions.JOURNAL_POST,
+                        Permissions.FISCAL_CREATE,
+                        Permissions.FISCAL_READ,
+                        Permissions.FISCAL_CLOSE,
                     ),
             )
         val member =
@@ -271,6 +283,7 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.JOURNAL_CREATE,
                         Permissions.JOURNAL_READ,
+                        Permissions.FISCAL_READ,
                     ),
             )
         val viewer =
@@ -284,6 +297,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ACCOUNT_READ,
                         Permissions.JOURNAL_READ,
+                        Permissions.FISCAL_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -41,11 +41,12 @@ class FiscalYearServiceTest {
         fiscalYearRepository = mock(FiscalYearRepository::class.java)
         journalEntryRepository = mock(JournalEntryRepository::class.java)
         accountRepository = mock(AccountRepository::class.java)
-        fiscalYearService = FiscalYearService(
-            fiscalYearRepository = fiscalYearRepository,
-            journalEntryRepository = journalEntryRepository,
-            accountRepository = accountRepository,
-        )
+        fiscalYearService =
+            FiscalYearService(
+                fiscalYearRepository = fiscalYearRepository,
+                journalEntryRepository = journalEntryRepository,
+                accountRepository = accountRepository,
+            )
     }
 
     @Test
@@ -53,11 +54,12 @@ class FiscalYearServiceTest {
         `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(emptyList())
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
 
-        val request = CreateFiscalYearRequest(
-            name = "FY 2026",
-            startDate = LocalDate.of(2026, 1, 1),
-            endDate = LocalDate.of(2026, 12, 31),
-        )
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2026",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 12, 31),
+            )
 
         val result = fiscalYearService.createFiscalYear(request, orgId)
 
@@ -81,11 +83,12 @@ class FiscalYearServiceTest {
         `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(emptyList())
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
 
-        val request = CreateFiscalYearRequest(
-            name = "FY 2026-2027",
-            startDate = LocalDate.of(2026, 4, 15),
-            endDate = LocalDate.of(2027, 3, 15),
-        )
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2026-2027",
+                startDate = LocalDate.of(2026, 4, 15),
+                endDate = LocalDate.of(2027, 3, 15),
+            )
 
         val result = fiscalYearService.createFiscalYear(request, orgId)
 
@@ -97,35 +100,40 @@ class FiscalYearServiceTest {
 
     @Test
     fun `create should reject if startDate is not before endDate`() {
-        val request = CreateFiscalYearRequest(
-            name = "FY 2026",
-            startDate = LocalDate.of(2026, 12, 31),
-            endDate = LocalDate.of(2026, 1, 1),
-        )
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2026",
+                startDate = LocalDate.of(2026, 12, 31),
+                endDate = LocalDate.of(2026, 1, 1),
+            )
 
-        val exception = assertThrows<IllegalArgumentException> {
-            fiscalYearService.createFiscalYear(request, orgId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.createFiscalYear(request, orgId)
+            }
         assertThat(exception.message).contains("Start date must be before end date")
     }
 
     @Test
     fun `create should reject if dates overlap existing fiscal year`() {
-        val existing = createFiscalYear(
-            startDate = LocalDate.of(2026, 1, 1),
-            endDate = LocalDate.of(2026, 12, 31),
-        )
+        val existing =
+            createFiscalYear(
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 12, 31),
+            )
         `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(listOf(existing))
 
-        val request = CreateFiscalYearRequest(
-            name = "FY 2026 Overlap",
-            startDate = LocalDate.of(2026, 6, 1),
-            endDate = LocalDate.of(2027, 5, 31),
-        )
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2026 Overlap",
+                startDate = LocalDate.of(2026, 6, 1),
+                endDate = LocalDate.of(2027, 5, 31),
+            )
 
-        val exception = assertThrows<IllegalArgumentException> {
-            fiscalYearService.createFiscalYear(request, orgId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.createFiscalYear(request, orgId)
+            }
         assertThat(exception.message).contains("overlaps")
     }
 
@@ -135,12 +143,13 @@ class FiscalYearServiceTest {
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
 
-        val result = fiscalYearService.closePeriod(
-            "fy-1",
-            fiscalYear.periods[0].id,
-            orgId,
-            userId,
-        )
+        val result =
+            fiscalYearService.closePeriod(
+                "fy-1",
+                fiscalYear.periods[0].id,
+                orgId,
+                userId,
+            )
 
         assertThat(result.periods[0].status).isEqualTo(FiscalPeriodStatus.CLOSED)
         assertThat(result.periods[0].closedBy).isEqualTo(userId)
@@ -149,60 +158,67 @@ class FiscalYearServiceTest {
 
     @Test
     fun `closePeriod should reject if period is already closed`() {
-        val fiscalYear = createFiscalYear(
-            periods = listOf(
-                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
-            ),
-        )
+        val fiscalYear =
+            createFiscalYear(
+                periods =
+                    listOf(
+                        createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+                    ),
+            )
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            fiscalYearService.closePeriod(
-                "fy-1",
-                fiscalYear.periods[0].id,
-                orgId,
-                userId,
-            )
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.closePeriod(
+                    "fy-1",
+                    fiscalYear.periods[0].id,
+                    orgId,
+                    userId,
+                )
+            }
         assertThat(exception.message).contains("already closed")
     }
 
     @Test
     fun `closePeriod should reject if preceding period is still open`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.OPEN),
-            createPeriod(2, status = FiscalPeriodStatus.OPEN),
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.OPEN),
+                createPeriod(2, status = FiscalPeriodStatus.OPEN),
+            )
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            fiscalYearService.closePeriod(
-                "fy-1",
-                fiscalYear.periods[1].id,
-                orgId,
-                userId,
-            )
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.closePeriod(
+                    "fy-1",
+                    fiscalYear.periods[1].id,
+                    orgId,
+                    userId,
+                )
+            }
         assertThat(exception.message).contains("preceding periods must be closed")
     }
 
     @Test
     fun `reopenPeriod should set status to REOPENED`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
-            createPeriod(2, status = FiscalPeriodStatus.CLOSED),
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+                createPeriod(2, status = FiscalPeriodStatus.CLOSED),
+            )
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
 
-        val result = fiscalYearService.reopenPeriod(
-            "fy-1",
-            fiscalYear.periods[1].id,
-            orgId,
-            userId,
-        )
+        val result =
+            fiscalYearService.reopenPeriod(
+                "fy-1",
+                fiscalYear.periods[1].id,
+                orgId,
+                userId,
+            )
 
         assertThat(result.periods[1].status).isEqualTo(FiscalPeriodStatus.REOPENED)
         assertThat(result.periods[1].reopenedBy).isEqualTo(userId)
@@ -211,144 +227,158 @@ class FiscalYearServiceTest {
 
     @Test
     fun `reopenPeriod should reject if subsequent period is open`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
-            createPeriod(2, status = FiscalPeriodStatus.OPEN),
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+                createPeriod(2, status = FiscalPeriodStatus.OPEN),
+            )
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            fiscalYearService.reopenPeriod(
-                "fy-1",
-                fiscalYear.periods[0].id,
-                orgId,
-                userId,
-            )
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.reopenPeriod(
+                    "fy-1",
+                    fiscalYear.periods[0].id,
+                    orgId,
+                    userId,
+                )
+            }
         assertThat(exception.message).contains("subsequent periods must be closed")
     }
 
     @Test
     fun `reopenPeriod should reject if fiscal year is closed`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
-        )
-        val fiscalYear = createFiscalYear(
-            periods = periods,
-            status = FiscalYearStatus.CLOSED,
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            )
+        val fiscalYear =
+            createFiscalYear(
+                periods = periods,
+                status = FiscalYearStatus.CLOSED,
+            )
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            fiscalYearService.reopenPeriod(
-                "fy-1",
-                fiscalYear.periods[0].id,
-                orgId,
-                userId,
-            )
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.reopenPeriod(
+                    "fy-1",
+                    fiscalYear.periods[0].id,
+                    orgId,
+                    userId,
+                )
+            }
         assertThat(exception.message).contains("closed fiscal year")
     }
 
     @Test
     fun `closeYear should reject if any period is not closed`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
-            createPeriod(2, status = FiscalPeriodStatus.OPEN),
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+                createPeriod(2, status = FiscalPeriodStatus.OPEN),
+            )
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            fiscalYearService.closeYear("fy-1", orgId, userId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.closeYear("fy-1", orgId, userId)
+            }
         assertThat(exception.message).contains("All periods must be closed")
     }
 
     @Test
     fun `closeYear should create closing journal entry zeroing revenue and expense`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            )
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
 
-        val revenueAccount = Account(
-            id = "acc-revenue",
-            code = "4000",
-            name = "Sales Revenue",
-            type = AccountType.REVENUE,
-            organizationId = orgId,
-        )
-        val expenseAccount = Account(
-            id = "acc-expense",
-            code = "5000",
-            name = "Cost of Goods Sold",
-            type = AccountType.EXPENSE,
-            organizationId = orgId,
-        )
-        val retainedEarnings = Account(
-            id = "acc-re",
-            code = "3100",
-            name = "Retained Earnings",
-            type = AccountType.EQUITY,
-            organizationId = orgId,
-        )
+        val revenueAccount =
+            Account(
+                id = "acc-revenue",
+                code = "4000",
+                name = "Sales Revenue",
+                type = AccountType.REVENUE,
+                organizationId = orgId,
+            )
+        val expenseAccount =
+            Account(
+                id = "acc-expense",
+                code = "5000",
+                name = "Cost of Goods Sold",
+                type = AccountType.EXPENSE,
+                organizationId = orgId,
+            )
+        val retainedEarnings =
+            Account(
+                id = "acc-re",
+                code = "3100",
+                name = "Retained Earnings",
+                type = AccountType.EQUITY,
+                organizationId = orgId,
+            )
 
-        val entries = listOf(
-            JournalEntry(
-                id = "entry-1",
-                entryNumber = "JE-0001",
-                date = LocalDate.of(2026, 1, 15),
-                description = "Sale",
-                organizationId = orgId,
-                status = JournalEntryStatus.POSTED,
-                lines = listOf(
-                    JournalEntryLine(
-                        accountId = "acc-cash",
-                        accountCode = "1000",
-                        accountName = "Cash",
-                        debit = BigDecimal("1000.00"),
-                        credit = BigDecimal.ZERO,
-                    ),
-                    JournalEntryLine(
-                        accountId = "acc-revenue",
-                        accountCode = "4000",
-                        accountName = "Sales Revenue",
-                        debit = BigDecimal.ZERO,
-                        credit = BigDecimal("1000.00"),
-                    ),
+        val entries =
+            listOf(
+                JournalEntry(
+                    id = "entry-1",
+                    entryNumber = "JE-0001",
+                    date = LocalDate.of(2026, 1, 15),
+                    description = "Sale",
+                    organizationId = orgId,
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-cash",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal("1000.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-revenue",
+                                accountCode = "4000",
+                                accountName = "Sales Revenue",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("1000.00"),
+                            ),
+                        ),
+                    createdBy = userId,
                 ),
-                createdBy = userId,
-            ),
-            JournalEntry(
-                id = "entry-2",
-                entryNumber = "JE-0002",
-                date = LocalDate.of(2026, 1, 20),
-                description = "Purchase",
-                organizationId = orgId,
-                status = JournalEntryStatus.POSTED,
-                lines = listOf(
-                    JournalEntryLine(
-                        accountId = "acc-expense",
-                        accountCode = "5000",
-                        accountName = "Cost of Goods Sold",
-                        debit = BigDecimal("300.00"),
-                        credit = BigDecimal.ZERO,
-                    ),
-                    JournalEntryLine(
-                        accountId = "acc-cash",
-                        accountCode = "1000",
-                        accountName = "Cash",
-                        debit = BigDecimal.ZERO,
-                        credit = BigDecimal("300.00"),
-                    ),
+                JournalEntry(
+                    id = "entry-2",
+                    entryNumber = "JE-0002",
+                    date = LocalDate.of(2026, 1, 20),
+                    description = "Purchase",
+                    organizationId = orgId,
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-expense",
+                                accountCode = "5000",
+                                accountName = "Cost of Goods Sold",
+                                debit = BigDecimal("300.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-cash",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("300.00"),
+                            ),
+                        ),
+                    createdBy = userId,
                 ),
-                createdBy = userId,
-            ),
-        )
+            )
 
         `when`(
             journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
@@ -398,55 +428,60 @@ class FiscalYearServiceTest {
 
     @Test
     fun `closeYear should handle net loss correctly`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            )
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
 
-        val expenseAccount = Account(
-            id = "acc-expense",
-            code = "5000",
-            name = "Cost of Goods Sold",
-            type = AccountType.EXPENSE,
-            organizationId = orgId,
-        )
-        val retainedEarnings = Account(
-            id = "acc-re",
-            code = "3100",
-            name = "Retained Earnings",
-            type = AccountType.EQUITY,
-            organizationId = orgId,
-        )
-
-        val entries = listOf(
-            JournalEntry(
-                id = "entry-1",
-                entryNumber = "JE-0001",
-                date = LocalDate.of(2026, 1, 15),
-                description = "Expense only",
+        val expenseAccount =
+            Account(
+                id = "acc-expense",
+                code = "5000",
+                name = "Cost of Goods Sold",
+                type = AccountType.EXPENSE,
                 organizationId = orgId,
-                status = JournalEntryStatus.POSTED,
-                lines = listOf(
-                    JournalEntryLine(
-                        accountId = "acc-expense",
-                        accountCode = "5000",
-                        accountName = "Cost of Goods Sold",
-                        debit = BigDecimal("500.00"),
-                        credit = BigDecimal.ZERO,
-                    ),
-                    JournalEntryLine(
-                        accountId = "acc-cash",
-                        accountCode = "1000",
-                        accountName = "Cash",
-                        debit = BigDecimal.ZERO,
-                        credit = BigDecimal("500.00"),
-                    ),
+            )
+        val retainedEarnings =
+            Account(
+                id = "acc-re",
+                code = "3100",
+                name = "Retained Earnings",
+                type = AccountType.EQUITY,
+                organizationId = orgId,
+            )
+
+        val entries =
+            listOf(
+                JournalEntry(
+                    id = "entry-1",
+                    entryNumber = "JE-0001",
+                    date = LocalDate.of(2026, 1, 15),
+                    description = "Expense only",
+                    organizationId = orgId,
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-expense",
+                                accountCode = "5000",
+                                accountName = "Cost of Goods Sold",
+                                debit = BigDecimal("500.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-cash",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("500.00"),
+                            ),
+                        ),
+                    createdBy = userId,
                 ),
-                createdBy = userId,
-            ),
-        )
+            )
 
         `when`(
             journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
@@ -482,9 +517,10 @@ class FiscalYearServiceTest {
 
     @Test
     fun `closeYear should skip closing entry when no revenue or expense activity`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            )
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
@@ -518,10 +554,11 @@ class FiscalYearServiceTest {
             ),
         ).thenReturn(listOf(fiscalYear))
 
-        val result = fiscalYearService.findOpenPeriodForDate(
-            orgId,
-            LocalDate.of(2026, 1, 15),
-        )
+        val result =
+            fiscalYearService.findOpenPeriodForDate(
+                orgId,
+                LocalDate.of(2026, 1, 15),
+            )
 
         assertThat(result).isNotNull
         assertThat(result!!.status).isEqualTo(FiscalPeriodStatus.OPEN)
@@ -536,10 +573,11 @@ class FiscalYearServiceTest {
             ),
         ).thenReturn(emptyList())
 
-        val result = fiscalYearService.findOpenPeriodForDate(
-            orgId,
-            LocalDate.of(2026, 1, 15),
-        )
+        val result =
+            fiscalYearService.findOpenPeriodForDate(
+                orgId,
+                LocalDate.of(2026, 1, 15),
+            )
 
         assertThat(result).isNull()
     }
@@ -554,19 +592,21 @@ class FiscalYearServiceTest {
             ),
         ).thenReturn(listOf(fiscalYear))
 
-        val result = fiscalYearService.findOpenPeriodForDate(
-            orgId,
-            LocalDate.of(2025, 6, 15),
-        )
+        val result =
+            fiscalYearService.findOpenPeriodForDate(
+                orgId,
+                LocalDate.of(2025, 6, 15),
+            )
 
         assertThat(result).isNull()
     }
 
     @Test
     fun `findOpenPeriodForDate should return reopened period`() {
-        val periods = listOf(
-            createPeriod(1, status = FiscalPeriodStatus.REOPENED),
-        )
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.REOPENED),
+            )
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(
             fiscalYearRepository.findByOrganizationIdAndStatus(
@@ -575,10 +615,11 @@ class FiscalYearServiceTest {
             ),
         ).thenReturn(listOf(fiscalYear))
 
-        val result = fiscalYearService.findOpenPeriodForDate(
-            orgId,
-            LocalDate.of(2026, 1, 15),
-        )
+        val result =
+            fiscalYearService.findOpenPeriodForDate(
+                orgId,
+                LocalDate.of(2026, 1, 15),
+            )
 
         assertThat(result).isNotNull
         assertThat(result!!.status).isEqualTo(FiscalPeriodStatus.REOPENED)
@@ -591,26 +632,29 @@ class FiscalYearServiceTest {
         endDate: LocalDate = LocalDate.of(2026, 12, 31),
         status: FiscalYearStatus = FiscalYearStatus.ACTIVE,
         periods: List<FiscalPeriod>? = null,
-    ): FiscalYear = FiscalYear(
-        id = id,
-        name = name,
-        startDate = startDate,
-        endDate = endDate,
-        status = status,
-        organizationId = orgId,
-        periods = periods ?: listOf(
-            createPeriod(1),
-        ),
-    )
+    ): FiscalYear =
+        FiscalYear(
+            id = id,
+            name = name,
+            startDate = startDate,
+            endDate = endDate,
+            status = status,
+            organizationId = orgId,
+            periods =
+                periods ?: listOf(
+                    createPeriod(1),
+                ),
+        )
 
     private fun createPeriod(
         number: Int,
         status: FiscalPeriodStatus = FiscalPeriodStatus.OPEN,
-    ): FiscalPeriod = FiscalPeriod(
-        periodNumber = number,
-        name = "January 2026",
-        startDate = LocalDate.of(2026, 1, 1),
-        endDate = LocalDate.of(2026, 1, 31),
-        status = status,
-    )
+    ): FiscalPeriod =
+        FiscalPeriod(
+            periodNumber = number,
+            name = "January 2026",
+            startDate = LocalDate.of(2026, 1, 1),
+            endDate = LocalDate.of(2026, 1, 31),
+            status = status,
+        )
 }

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -419,9 +419,9 @@ class FiscalYearServiceTest {
             )
 
         `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
                 orgId,
-                JournalEntryStatus.POSTED,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
                 fiscalYear.startDate,
                 fiscalYear.endDate,
             ),
@@ -532,9 +532,9 @@ class FiscalYearServiceTest {
             )
 
         `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
                 orgId,
-                JournalEntryStatus.POSTED,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
                 fiscalYear.startDate,
                 fiscalYear.endDate,
             ),
@@ -576,9 +576,9 @@ class FiscalYearServiceTest {
             .thenReturn(false)
 
         `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
                 orgId,
-                JournalEntryStatus.POSTED,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
                 fiscalYear.startDate,
                 fiscalYear.endDate,
             ),

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -32,6 +32,7 @@ class FiscalYearServiceTest {
     private lateinit var fiscalYearRepository: FiscalYearRepository
     private lateinit var journalEntryRepository: JournalEntryRepository
     private lateinit var accountRepository: AccountRepository
+    private lateinit var entryNumberGenerator: JournalEntryNumberGenerator
 
     private val orgId = "org-123"
     private val userId = "user-1"
@@ -41,11 +42,13 @@ class FiscalYearServiceTest {
         fiscalYearRepository = mock(FiscalYearRepository::class.java)
         journalEntryRepository = mock(JournalEntryRepository::class.java)
         accountRepository = mock(AccountRepository::class.java)
+        entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
         fiscalYearService =
             FiscalYearService(
                 fiscalYearRepository = fiscalYearRepository,
                 journalEntryRepository = journalEntryRepository,
                 accountRepository = accountRepository,
+                entryNumberGenerator = entryNumberGenerator,
             )
     }
 
@@ -603,12 +606,13 @@ class FiscalYearServiceTest {
                 LocalDate.of(2026, 1, 15),
             )
 
-        assertThat(result).isNotNull
-        assertThat(result!!.status).isEqualTo(FiscalPeriodStatus.OPEN)
+        assertThat(result).isInstanceOf(FiscalYearService.PeriodLookupResult.Found::class.java)
+        val found = result as FiscalYearService.PeriodLookupResult.Found
+        assertThat(found.period.status).isEqualTo(FiscalPeriodStatus.OPEN)
     }
 
     @Test
-    fun `findPeriodForDate should return null when no fiscal year exists`() {
+    fun `findPeriodForDate should return NoFiscalYears when no fiscal year exists`() {
         `when`(fiscalYearRepository.findByOrganizationId(orgId))
             .thenReturn(emptyList())
 
@@ -618,11 +622,11 @@ class FiscalYearServiceTest {
                 LocalDate.of(2026, 1, 15),
             )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(FiscalYearService.PeriodLookupResult.NoFiscalYears)
     }
 
     @Test
-    fun `findPeriodForDate should return null when date is outside fiscal year`() {
+    fun `findPeriodForDate should return NotFound when date is outside fiscal year`() {
         val fiscalYear = createFiscalYear()
         `when`(fiscalYearRepository.findByOrganizationId(orgId))
             .thenReturn(listOf(fiscalYear))
@@ -633,7 +637,7 @@ class FiscalYearServiceTest {
                 LocalDate.of(2025, 6, 15),
             )
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo(FiscalYearService.PeriodLookupResult.NotFound)
     }
 
     @Test
@@ -652,8 +656,9 @@ class FiscalYearServiceTest {
                 LocalDate.of(2026, 1, 15),
             )
 
-        assertThat(result).isNotNull
-        assertThat(result!!.status).isEqualTo(FiscalPeriodStatus.REOPENED)
+        assertThat(result).isInstanceOf(FiscalYearService.PeriodLookupResult.Found::class.java)
+        val found = result as FiscalYearService.PeriodLookupResult.Found
+        assertThat(found.period.status).isEqualTo(FiscalPeriodStatus.REOPENED)
     }
 
     private fun createFiscalYear(

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -326,6 +326,14 @@ class FiscalYearServiceTest {
         `when`(journalEntryRepository.existsByOrganizationIdAndSourceReference(orgId, "YEAR-END-CLOSE-fy-1"))
             .thenReturn(false)
 
+        val cashAccount =
+            Account(
+                id = "acc-cash",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                organizationId = orgId,
+            )
         val revenueAccount =
             Account(
                 id = "acc-revenue",
@@ -417,7 +425,7 @@ class FiscalYearServiceTest {
         ).thenReturn(entries)
 
         `when`(accountRepository.findAllById(any<Iterable<String>>()))
-            .thenReturn(listOf(revenueAccount, expenseAccount, retainedEarnings))
+            .thenReturn(listOf(cashAccount, revenueAccount, expenseAccount, retainedEarnings))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "3100"))
             .thenReturn(Optional.of(retainedEarnings))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(2L)
@@ -465,6 +473,14 @@ class FiscalYearServiceTest {
         `when`(journalEntryRepository.existsByOrganizationIdAndSourceReference(orgId, "YEAR-END-CLOSE-fy-1"))
             .thenReturn(false)
 
+        val cashAccount =
+            Account(
+                id = "acc-cash",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                organizationId = orgId,
+            )
         val expenseAccount =
             Account(
                 id = "acc-expense",
@@ -522,7 +538,7 @@ class FiscalYearServiceTest {
         ).thenReturn(entries)
 
         `when`(accountRepository.findAllById(any<Iterable<String>>()))
-            .thenReturn(listOf(expenseAccount, retainedEarnings))
+            .thenReturn(listOf(cashAccount, expenseAccount, retainedEarnings))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "3100"))
             .thenReturn(Optional.of(retainedEarnings))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
@@ -578,12 +594,8 @@ class FiscalYearServiceTest {
     @Test
     fun `findPeriodForDate should return matching open period`() {
         val fiscalYear = createFiscalYear()
-        `when`(
-            fiscalYearRepository.findByOrganizationIdAndStatus(
-                orgId,
-                FiscalYearStatus.ACTIVE,
-            ),
-        ).thenReturn(listOf(fiscalYear))
+        `when`(fiscalYearRepository.findByOrganizationId(orgId))
+            .thenReturn(listOf(fiscalYear))
 
         val result =
             fiscalYearService.findPeriodForDate(
@@ -597,12 +609,8 @@ class FiscalYearServiceTest {
 
     @Test
     fun `findPeriodForDate should return null when no fiscal year exists`() {
-        `when`(
-            fiscalYearRepository.findByOrganizationIdAndStatus(
-                orgId,
-                FiscalYearStatus.ACTIVE,
-            ),
-        ).thenReturn(emptyList())
+        `when`(fiscalYearRepository.findByOrganizationId(orgId))
+            .thenReturn(emptyList())
 
         val result =
             fiscalYearService.findPeriodForDate(
@@ -616,12 +624,8 @@ class FiscalYearServiceTest {
     @Test
     fun `findPeriodForDate should return null when date is outside fiscal year`() {
         val fiscalYear = createFiscalYear()
-        `when`(
-            fiscalYearRepository.findByOrganizationIdAndStatus(
-                orgId,
-                FiscalYearStatus.ACTIVE,
-            ),
-        ).thenReturn(listOf(fiscalYear))
+        `when`(fiscalYearRepository.findByOrganizationId(orgId))
+            .thenReturn(listOf(fiscalYear))
 
         val result =
             fiscalYearService.findPeriodForDate(
@@ -639,12 +643,8 @@ class FiscalYearServiceTest {
                 createPeriod(1, status = FiscalPeriodStatus.REOPENED),
             )
         val fiscalYear = createFiscalYear(periods = periods)
-        `when`(
-            fiscalYearRepository.findByOrganizationIdAndStatus(
-                orgId,
-                FiscalYearStatus.ACTIVE,
-            ),
-        ).thenReturn(listOf(fiscalYear))
+        `when`(fiscalYearRepository.findByOrganizationId(orgId))
+            .thenReturn(listOf(fiscalYear))
 
         val result =
             fiscalYearService.findPeriodForDate(

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -1,0 +1,616 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateFiscalYearRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.FiscalPeriod
+import com.froilan.synectix.model.FiscalPeriodStatus
+import com.froilan.synectix.model.FiscalYear
+import com.froilan.synectix.model.FiscalYearStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.FiscalYearRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class FiscalYearServiceTest {
+    private lateinit var fiscalYearService: FiscalYearService
+    private lateinit var fiscalYearRepository: FiscalYearRepository
+    private lateinit var journalEntryRepository: JournalEntryRepository
+    private lateinit var accountRepository: AccountRepository
+
+    private val orgId = "org-123"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        fiscalYearRepository = mock(FiscalYearRepository::class.java)
+        journalEntryRepository = mock(JournalEntryRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        fiscalYearService = FiscalYearService(
+            fiscalYearRepository = fiscalYearRepository,
+            journalEntryRepository = journalEntryRepository,
+            accountRepository = accountRepository,
+        )
+    }
+
+    @Test
+    fun `create should auto-generate 12 monthly periods for calendar year`() {
+        `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(emptyList())
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val request = CreateFiscalYearRequest(
+            name = "FY 2026",
+            startDate = LocalDate.of(2026, 1, 1),
+            endDate = LocalDate.of(2026, 12, 31),
+        )
+
+        val result = fiscalYearService.createFiscalYear(request, orgId)
+
+        assertThat(result.name).isEqualTo("FY 2026")
+        assertThat(result.status).isEqualTo(FiscalYearStatus.ACTIVE)
+        assertThat(result.periods).hasSize(12)
+        assertThat(result.periods[0].name).isEqualTo("January 2026")
+        assertThat(result.periods[0].startDate).isEqualTo(LocalDate.of(2026, 1, 1))
+        assertThat(result.periods[0].endDate).isEqualTo(LocalDate.of(2026, 1, 31))
+        assertThat(result.periods[11].name).isEqualTo("December 2026")
+        assertThat(result.periods[11].startDate).isEqualTo(LocalDate.of(2026, 12, 1))
+        assertThat(result.periods[11].endDate).isEqualTo(LocalDate.of(2026, 12, 31))
+
+        result.periods.forEach { period ->
+            assertThat(period.status).isEqualTo(FiscalPeriodStatus.OPEN)
+        }
+    }
+
+    @Test
+    fun `create should handle partial months at boundaries`() {
+        `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(emptyList())
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val request = CreateFiscalYearRequest(
+            name = "FY 2026-2027",
+            startDate = LocalDate.of(2026, 4, 15),
+            endDate = LocalDate.of(2027, 3, 15),
+        )
+
+        val result = fiscalYearService.createFiscalYear(request, orgId)
+
+        assertThat(result.periods).hasSize(12)
+        assertThat(result.periods[0].startDate).isEqualTo(LocalDate.of(2026, 4, 15))
+        assertThat(result.periods[0].endDate).isEqualTo(LocalDate.of(2026, 4, 30))
+        assertThat(result.periods.last().endDate).isEqualTo(LocalDate.of(2027, 3, 15))
+    }
+
+    @Test
+    fun `create should reject if startDate is not before endDate`() {
+        val request = CreateFiscalYearRequest(
+            name = "FY 2026",
+            startDate = LocalDate.of(2026, 12, 31),
+            endDate = LocalDate.of(2026, 1, 1),
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            fiscalYearService.createFiscalYear(request, orgId)
+        }
+        assertThat(exception.message).contains("Start date must be before end date")
+    }
+
+    @Test
+    fun `create should reject if dates overlap existing fiscal year`() {
+        val existing = createFiscalYear(
+            startDate = LocalDate.of(2026, 1, 1),
+            endDate = LocalDate.of(2026, 12, 31),
+        )
+        `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(listOf(existing))
+
+        val request = CreateFiscalYearRequest(
+            name = "FY 2026 Overlap",
+            startDate = LocalDate.of(2026, 6, 1),
+            endDate = LocalDate.of(2027, 5, 31),
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            fiscalYearService.createFiscalYear(request, orgId)
+        }
+        assertThat(exception.message).contains("overlaps")
+    }
+
+    @Test
+    fun `closePeriod should update period status to CLOSED`() {
+        val fiscalYear = createFiscalYear()
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val result = fiscalYearService.closePeriod(
+            "fy-1",
+            fiscalYear.periods[0].id,
+            orgId,
+            userId,
+        )
+
+        assertThat(result.periods[0].status).isEqualTo(FiscalPeriodStatus.CLOSED)
+        assertThat(result.periods[0].closedBy).isEqualTo(userId)
+        assertThat(result.periods[0].closedAt).isNotNull()
+    }
+
+    @Test
+    fun `closePeriod should reject if period is already closed`() {
+        val fiscalYear = createFiscalYear(
+            periods = listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            ),
+        )
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            fiscalYearService.closePeriod(
+                "fy-1",
+                fiscalYear.periods[0].id,
+                orgId,
+                userId,
+            )
+        }
+        assertThat(exception.message).contains("already closed")
+    }
+
+    @Test
+    fun `closePeriod should reject if preceding period is still open`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.OPEN),
+            createPeriod(2, status = FiscalPeriodStatus.OPEN),
+        )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            fiscalYearService.closePeriod(
+                "fy-1",
+                fiscalYear.periods[1].id,
+                orgId,
+                userId,
+            )
+        }
+        assertThat(exception.message).contains("preceding periods must be closed")
+    }
+
+    @Test
+    fun `reopenPeriod should set status to REOPENED`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            createPeriod(2, status = FiscalPeriodStatus.CLOSED),
+        )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val result = fiscalYearService.reopenPeriod(
+            "fy-1",
+            fiscalYear.periods[1].id,
+            orgId,
+            userId,
+        )
+
+        assertThat(result.periods[1].status).isEqualTo(FiscalPeriodStatus.REOPENED)
+        assertThat(result.periods[1].reopenedBy).isEqualTo(userId)
+        assertThat(result.periods[1].reopenedAt).isNotNull()
+    }
+
+    @Test
+    fun `reopenPeriod should reject if subsequent period is open`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            createPeriod(2, status = FiscalPeriodStatus.OPEN),
+        )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            fiscalYearService.reopenPeriod(
+                "fy-1",
+                fiscalYear.periods[0].id,
+                orgId,
+                userId,
+            )
+        }
+        assertThat(exception.message).contains("subsequent periods must be closed")
+    }
+
+    @Test
+    fun `reopenPeriod should reject if fiscal year is closed`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+        )
+        val fiscalYear = createFiscalYear(
+            periods = periods,
+            status = FiscalYearStatus.CLOSED,
+        )
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            fiscalYearService.reopenPeriod(
+                "fy-1",
+                fiscalYear.periods[0].id,
+                orgId,
+                userId,
+            )
+        }
+        assertThat(exception.message).contains("closed fiscal year")
+    }
+
+    @Test
+    fun `closeYear should reject if any period is not closed`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            createPeriod(2, status = FiscalPeriodStatus.OPEN),
+        )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            fiscalYearService.closeYear("fy-1", orgId, userId)
+        }
+        assertThat(exception.message).contains("All periods must be closed")
+    }
+
+    @Test
+    fun `closeYear should create closing journal entry zeroing revenue and expense`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+        )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val revenueAccount = Account(
+            id = "acc-revenue",
+            code = "4000",
+            name = "Sales Revenue",
+            type = AccountType.REVENUE,
+            organizationId = orgId,
+        )
+        val expenseAccount = Account(
+            id = "acc-expense",
+            code = "5000",
+            name = "Cost of Goods Sold",
+            type = AccountType.EXPENSE,
+            organizationId = orgId,
+        )
+        val retainedEarnings = Account(
+            id = "acc-re",
+            code = "3100",
+            name = "Retained Earnings",
+            type = AccountType.EQUITY,
+            organizationId = orgId,
+        )
+
+        val entries = listOf(
+            JournalEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                date = LocalDate.of(2026, 1, 15),
+                description = "Sale",
+                organizationId = orgId,
+                status = JournalEntryStatus.POSTED,
+                lines = listOf(
+                    JournalEntryLine(
+                        accountId = "acc-cash",
+                        accountCode = "1000",
+                        accountName = "Cash",
+                        debit = BigDecimal("1000.00"),
+                        credit = BigDecimal.ZERO,
+                    ),
+                    JournalEntryLine(
+                        accountId = "acc-revenue",
+                        accountCode = "4000",
+                        accountName = "Sales Revenue",
+                        debit = BigDecimal.ZERO,
+                        credit = BigDecimal("1000.00"),
+                    ),
+                ),
+                createdBy = userId,
+            ),
+            JournalEntry(
+                id = "entry-2",
+                entryNumber = "JE-0002",
+                date = LocalDate.of(2026, 1, 20),
+                description = "Purchase",
+                organizationId = orgId,
+                status = JournalEntryStatus.POSTED,
+                lines = listOf(
+                    JournalEntryLine(
+                        accountId = "acc-expense",
+                        accountCode = "5000",
+                        accountName = "Cost of Goods Sold",
+                        debit = BigDecimal("300.00"),
+                        credit = BigDecimal.ZERO,
+                    ),
+                    JournalEntryLine(
+                        accountId = "acc-cash",
+                        accountCode = "1000",
+                        accountName = "Cash",
+                        debit = BigDecimal.ZERO,
+                        credit = BigDecimal("300.00"),
+                    ),
+                ),
+                createdBy = userId,
+            ),
+        )
+
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+                orgId,
+                JournalEntryStatus.POSTED,
+                fiscalYear.startDate,
+                fiscalYear.endDate,
+            ),
+        ).thenReturn(entries)
+
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(listOf(revenueAccount, expenseAccount, retainedEarnings))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "3100"))
+            .thenReturn(Optional.of(retainedEarnings))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(2L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val result = fiscalYearService.closeYear("fy-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(FiscalYearStatus.CLOSED)
+        assertThat(result.closedBy).isEqualTo(userId)
+        assertThat(result.closedAt).isNotNull()
+        assertThat(result.closingEntryId).isNotNull()
+
+        val entryCaptor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(entryCaptor.capture())
+
+        val closingEntry = entryCaptor.firstValue
+        assertThat(closingEntry.description).contains("Year-end closing entry")
+        assertThat(closingEntry.status).isEqualTo(JournalEntryStatus.POSTED)
+
+        // Revenue (1000 credit balance) should be debited to zero it
+        val revenueLine = closingEntry.lines.find { it.accountId == "acc-revenue" }
+        assertThat(revenueLine).isNotNull
+        assertThat(revenueLine!!.debit).isEqualByComparingTo(BigDecimal("1000.00"))
+
+        // Expense (300 debit balance) should be credited to zero it
+        val expenseLine = closingEntry.lines.find { it.accountId == "acc-expense" }
+        assertThat(expenseLine).isNotNull
+        assertThat(expenseLine!!.credit).isEqualByComparingTo(BigDecimal("300.00"))
+
+        // Net income = 1000 - 300 = 700, credited to Retained Earnings
+        val reLine = closingEntry.lines.find { it.accountId == "acc-re" }
+        assertThat(reLine).isNotNull
+        assertThat(reLine!!.credit).isEqualByComparingTo(BigDecimal("700.00"))
+    }
+
+    @Test
+    fun `closeYear should handle net loss correctly`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+        )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val expenseAccount = Account(
+            id = "acc-expense",
+            code = "5000",
+            name = "Cost of Goods Sold",
+            type = AccountType.EXPENSE,
+            organizationId = orgId,
+        )
+        val retainedEarnings = Account(
+            id = "acc-re",
+            code = "3100",
+            name = "Retained Earnings",
+            type = AccountType.EQUITY,
+            organizationId = orgId,
+        )
+
+        val entries = listOf(
+            JournalEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                date = LocalDate.of(2026, 1, 15),
+                description = "Expense only",
+                organizationId = orgId,
+                status = JournalEntryStatus.POSTED,
+                lines = listOf(
+                    JournalEntryLine(
+                        accountId = "acc-expense",
+                        accountCode = "5000",
+                        accountName = "Cost of Goods Sold",
+                        debit = BigDecimal("500.00"),
+                        credit = BigDecimal.ZERO,
+                    ),
+                    JournalEntryLine(
+                        accountId = "acc-cash",
+                        accountCode = "1000",
+                        accountName = "Cash",
+                        debit = BigDecimal.ZERO,
+                        credit = BigDecimal("500.00"),
+                    ),
+                ),
+                createdBy = userId,
+            ),
+        )
+
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+                orgId,
+                JournalEntryStatus.POSTED,
+                fiscalYear.startDate,
+                fiscalYear.endDate,
+            ),
+        ).thenReturn(entries)
+
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(listOf(expenseAccount, retainedEarnings))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "3100"))
+            .thenReturn(Optional.of(retainedEarnings))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val result = fiscalYearService.closeYear("fy-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(FiscalYearStatus.CLOSED)
+
+        val entryCaptor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(entryCaptor.capture())
+
+        val closingEntry = entryCaptor.firstValue
+        // Net loss: 0 revenue - 500 expense = -500
+        // Retained Earnings should be debited (reducing equity)
+        val reLine = closingEntry.lines.find { it.accountId == "acc-re" }
+        assertThat(reLine).isNotNull
+        assertThat(reLine!!.debit).isEqualByComparingTo(BigDecimal("500.00"))
+        assertThat(reLine.credit).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `closeYear should skip closing entry when no revenue or expense activity`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+        )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
+                orgId,
+                JournalEntryStatus.POSTED,
+                fiscalYear.startDate,
+                fiscalYear.endDate,
+            ),
+        ).thenReturn(emptyList())
+
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(emptyList())
+
+        val result = fiscalYearService.closeYear("fy-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(FiscalYearStatus.CLOSED)
+        assertThat(result.closingEntryId).isNull()
+        verify(journalEntryRepository, never()).save(any<JournalEntry>())
+    }
+
+    @Test
+    fun `findOpenPeriodForDate should return matching open period`() {
+        val fiscalYear = createFiscalYear()
+        `when`(
+            fiscalYearRepository.findByOrganizationIdAndStatus(
+                orgId,
+                FiscalYearStatus.ACTIVE,
+            ),
+        ).thenReturn(listOf(fiscalYear))
+
+        val result = fiscalYearService.findOpenPeriodForDate(
+            orgId,
+            LocalDate.of(2026, 1, 15),
+        )
+
+        assertThat(result).isNotNull
+        assertThat(result!!.status).isEqualTo(FiscalPeriodStatus.OPEN)
+    }
+
+    @Test
+    fun `findOpenPeriodForDate should return null when no fiscal year exists`() {
+        `when`(
+            fiscalYearRepository.findByOrganizationIdAndStatus(
+                orgId,
+                FiscalYearStatus.ACTIVE,
+            ),
+        ).thenReturn(emptyList())
+
+        val result = fiscalYearService.findOpenPeriodForDate(
+            orgId,
+            LocalDate.of(2026, 1, 15),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `findOpenPeriodForDate should return null when date is outside fiscal year`() {
+        val fiscalYear = createFiscalYear()
+        `when`(
+            fiscalYearRepository.findByOrganizationIdAndStatus(
+                orgId,
+                FiscalYearStatus.ACTIVE,
+            ),
+        ).thenReturn(listOf(fiscalYear))
+
+        val result = fiscalYearService.findOpenPeriodForDate(
+            orgId,
+            LocalDate.of(2025, 6, 15),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `findOpenPeriodForDate should return reopened period`() {
+        val periods = listOf(
+            createPeriod(1, status = FiscalPeriodStatus.REOPENED),
+        )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(
+            fiscalYearRepository.findByOrganizationIdAndStatus(
+                orgId,
+                FiscalYearStatus.ACTIVE,
+            ),
+        ).thenReturn(listOf(fiscalYear))
+
+        val result = fiscalYearService.findOpenPeriodForDate(
+            orgId,
+            LocalDate.of(2026, 1, 15),
+        )
+
+        assertThat(result).isNotNull
+        assertThat(result!!.status).isEqualTo(FiscalPeriodStatus.REOPENED)
+    }
+
+    private fun createFiscalYear(
+        id: String = "fy-1",
+        name: String = "FY 2026",
+        startDate: LocalDate = LocalDate.of(2026, 1, 1),
+        endDate: LocalDate = LocalDate.of(2026, 12, 31),
+        status: FiscalYearStatus = FiscalYearStatus.ACTIVE,
+        periods: List<FiscalPeriod>? = null,
+    ): FiscalYear = FiscalYear(
+        id = id,
+        name = name,
+        startDate = startDate,
+        endDate = endDate,
+        status = status,
+        organizationId = orgId,
+        periods = periods ?: listOf(
+            createPeriod(1),
+        ),
+    )
+
+    private fun createPeriod(
+        number: Int,
+        status: FiscalPeriodStatus = FiscalPeriodStatus.OPEN,
+    ): FiscalPeriod = FiscalPeriod(
+        periodNumber = number,
+        name = "January 2026",
+        startDate = LocalDate.of(2026, 1, 1),
+        endDate = LocalDate.of(2026, 1, 31),
+        status = status,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -115,11 +115,36 @@ class FiscalYearServiceTest {
     }
 
     @Test
+    fun `create should reject if active fiscal year already exists`() {
+        val existing =
+            createFiscalYear(
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 12, 31),
+                status = FiscalYearStatus.ACTIVE,
+            )
+        `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(listOf(existing))
+
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2027",
+                startDate = LocalDate.of(2027, 1, 1),
+                endDate = LocalDate.of(2027, 12, 31),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.createFiscalYear(request, orgId)
+            }
+        assertThat(exception.message).contains("active fiscal year")
+    }
+
+    @Test
     fun `create should reject if dates overlap existing fiscal year`() {
         val existing =
             createFiscalYear(
                 startDate = LocalDate.of(2026, 1, 1),
                 endDate = LocalDate.of(2026, 12, 31),
+                status = FiscalYearStatus.CLOSED,
             )
         `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(listOf(existing))
 
@@ -298,6 +323,8 @@ class FiscalYearServiceTest {
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryRepository.existsByOrganizationIdAndSourceReference(orgId, "YEAR-END-CLOSE-fy-1"))
+            .thenReturn(false)
 
         val revenueAccount =
             Account(
@@ -389,7 +416,7 @@ class FiscalYearServiceTest {
             ),
         ).thenReturn(entries)
 
-        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+        `when`(accountRepository.findAllById(any<Iterable<String>>()))
             .thenReturn(listOf(revenueAccount, expenseAccount, retainedEarnings))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "3100"))
             .thenReturn(Optional.of(retainedEarnings))
@@ -435,6 +462,8 @@ class FiscalYearServiceTest {
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryRepository.existsByOrganizationIdAndSourceReference(orgId, "YEAR-END-CLOSE-fy-1"))
+            .thenReturn(false)
 
         val expenseAccount =
             Account(
@@ -492,7 +521,7 @@ class FiscalYearServiceTest {
             ),
         ).thenReturn(entries)
 
-        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+        `when`(accountRepository.findAllById(any<Iterable<String>>()))
             .thenReturn(listOf(expenseAccount, retainedEarnings))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "3100"))
             .thenReturn(Optional.of(retainedEarnings))
@@ -524,6 +553,8 @@ class FiscalYearServiceTest {
         val fiscalYear = createFiscalYear(periods = periods)
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
         `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryRepository.existsByOrganizationIdAndSourceReference(orgId, "YEAR-END-CLOSE-fy-1"))
+            .thenReturn(false)
 
         `when`(
             journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(
@@ -534,7 +565,7 @@ class FiscalYearServiceTest {
             ),
         ).thenReturn(emptyList())
 
-        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+        `when`(accountRepository.findAllById(any<Iterable<String>>()))
             .thenReturn(emptyList())
 
         val result = fiscalYearService.closeYear("fy-1", orgId, userId)
@@ -545,7 +576,7 @@ class FiscalYearServiceTest {
     }
 
     @Test
-    fun `findOpenPeriodForDate should return matching open period`() {
+    fun `findPeriodForDate should return matching open period`() {
         val fiscalYear = createFiscalYear()
         `when`(
             fiscalYearRepository.findByOrganizationIdAndStatus(
@@ -555,7 +586,7 @@ class FiscalYearServiceTest {
         ).thenReturn(listOf(fiscalYear))
 
         val result =
-            fiscalYearService.findOpenPeriodForDate(
+            fiscalYearService.findPeriodForDate(
                 orgId,
                 LocalDate.of(2026, 1, 15),
             )
@@ -565,7 +596,7 @@ class FiscalYearServiceTest {
     }
 
     @Test
-    fun `findOpenPeriodForDate should return null when no fiscal year exists`() {
+    fun `findPeriodForDate should return null when no fiscal year exists`() {
         `when`(
             fiscalYearRepository.findByOrganizationIdAndStatus(
                 orgId,
@@ -574,7 +605,7 @@ class FiscalYearServiceTest {
         ).thenReturn(emptyList())
 
         val result =
-            fiscalYearService.findOpenPeriodForDate(
+            fiscalYearService.findPeriodForDate(
                 orgId,
                 LocalDate.of(2026, 1, 15),
             )
@@ -583,7 +614,7 @@ class FiscalYearServiceTest {
     }
 
     @Test
-    fun `findOpenPeriodForDate should return null when date is outside fiscal year`() {
+    fun `findPeriodForDate should return null when date is outside fiscal year`() {
         val fiscalYear = createFiscalYear()
         `when`(
             fiscalYearRepository.findByOrganizationIdAndStatus(
@@ -593,7 +624,7 @@ class FiscalYearServiceTest {
         ).thenReturn(listOf(fiscalYear))
 
         val result =
-            fiscalYearService.findOpenPeriodForDate(
+            fiscalYearService.findPeriodForDate(
                 orgId,
                 LocalDate.of(2025, 6, 15),
             )
@@ -602,7 +633,7 @@ class FiscalYearServiceTest {
     }
 
     @Test
-    fun `findOpenPeriodForDate should return reopened period`() {
+    fun `findPeriodForDate should return reopened period`() {
         val periods =
             listOf(
                 createPeriod(1, status = FiscalPeriodStatus.REOPENED),
@@ -616,7 +647,7 @@ class FiscalYearServiceTest {
         ).thenReturn(listOf(fiscalYear))
 
         val result =
-            fiscalYearService.findOpenPeriodForDate(
+            fiscalYearService.findPeriodForDate(
                 orgId,
                 LocalDate.of(2026, 1, 15),
             )

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -4,12 +4,12 @@ import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.JournalEntryLineRequest
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.FiscalPeriod
+import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
-import com.froilan.synectix.model.FiscalPeriod
-import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -568,20 +568,22 @@ class JournalEntryServiceTest {
 
     @Test
     fun `create should succeed when no fiscal year exists`() {
-        val cashAccount = createMockAccount(
-            id = "acc-1",
-            code = "1000",
-            name = "Cash",
-            type = AccountType.ASSET,
-            orgId = orgId,
-        )
-        val revenueAccount = createMockAccount(
-            id = "acc-2",
-            code = "4000",
-            name = "Revenue",
-            type = AccountType.REVENUE,
-            orgId = orgId,
-        )
+        val cashAccount =
+            createMockAccount(
+                id = "acc-1",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                orgId = orgId,
+            )
+        val revenueAccount =
+            createMockAccount(
+                id = "acc-2",
+                code = "4000",
+                name = "Revenue",
+                type = AccountType.REVENUE,
+                orgId = orgId,
+            )
 
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
@@ -589,22 +591,24 @@ class JournalEntryServiceTest {
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
         `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(false)
 
-        val request = CreateJournalEntryRequest(
-            date = LocalDate.of(2026, 1, 15),
-            description = "Test entry",
-            lines = listOf(
-                JournalEntryLineRequest(
-                    accountId = "acc-1",
-                    debit = BigDecimal("100.00"),
-                    credit = BigDecimal.ZERO,
-                ),
-                JournalEntryLineRequest(
-                    accountId = "acc-2",
-                    debit = BigDecimal.ZERO,
-                    credit = BigDecimal("100.00"),
-                ),
-            ),
-        )
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Test entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(
+                            accountId = "acc-1",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLineRequest(
+                            accountId = "acc-2",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+            )
 
         val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
         assertThat(result.status).isEqualTo(JournalEntryStatus.DRAFT)
@@ -612,20 +616,22 @@ class JournalEntryServiceTest {
 
     @Test
     fun `create should reject when fiscal period is closed`() {
-        val cashAccount = createMockAccount(
-            id = "acc-1",
-            code = "1000",
-            name = "Cash",
-            type = AccountType.ASSET,
-            orgId = orgId,
-        )
-        val revenueAccount = createMockAccount(
-            id = "acc-2",
-            code = "4000",
-            name = "Revenue",
-            type = AccountType.REVENUE,
-            orgId = orgId,
-        )
+        val cashAccount =
+            createMockAccount(
+                id = "acc-1",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                orgId = orgId,
+            )
+        val revenueAccount =
+            createMockAccount(
+                id = "acc-2",
+                code = "4000",
+                name = "Revenue",
+                type = AccountType.REVENUE,
+                orgId = orgId,
+            )
 
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
@@ -633,52 +639,58 @@ class JournalEntryServiceTest {
         `when`(fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
             .thenReturn(null)
 
-        val request = CreateJournalEntryRequest(
-            date = LocalDate.of(2026, 1, 15),
-            description = "Test entry",
-            lines = listOf(
-                JournalEntryLineRequest(
-                    accountId = "acc-1",
-                    debit = BigDecimal("100.00"),
-                    credit = BigDecimal.ZERO,
-                ),
-                JournalEntryLineRequest(
-                    accountId = "acc-2",
-                    debit = BigDecimal.ZERO,
-                    credit = BigDecimal("100.00"),
-                ),
-            ),
-        )
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Test entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(
+                            accountId = "acc-1",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLineRequest(
+                            accountId = "acc-2",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+            )
 
-        val exception = assertThrows<IllegalArgumentException> {
-            journalEntryService.createJournalEntry(request, orgId, createdBy)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
         assertThat(exception.message).contains("No open fiscal period")
     }
 
     @Test
     fun `create should succeed when fiscal period is open`() {
-        val cashAccount = createMockAccount(
-            id = "acc-1",
-            code = "1000",
-            name = "Cash",
-            type = AccountType.ASSET,
-            orgId = orgId,
-        )
-        val revenueAccount = createMockAccount(
-            id = "acc-2",
-            code = "4000",
-            name = "Revenue",
-            type = AccountType.REVENUE,
-            orgId = orgId,
-        )
-        val openPeriod = FiscalPeriod(
-            periodNumber = 1,
-            name = "January 2026",
-            startDate = LocalDate.of(2026, 1, 1),
-            endDate = LocalDate.of(2026, 1, 31),
-            status = FiscalPeriodStatus.OPEN,
-        )
+        val cashAccount =
+            createMockAccount(
+                id = "acc-1",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                orgId = orgId,
+            )
+        val revenueAccount =
+            createMockAccount(
+                id = "acc-2",
+                code = "4000",
+                name = "Revenue",
+                type = AccountType.REVENUE,
+                orgId = orgId,
+            )
+        val openPeriod =
+            FiscalPeriod(
+                periodNumber = 1,
+                name = "January 2026",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 31),
+                status = FiscalPeriodStatus.OPEN,
+            )
 
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
@@ -688,22 +700,24 @@ class JournalEntryServiceTest {
         `when`(fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
             .thenReturn(openPeriod)
 
-        val request = CreateJournalEntryRequest(
-            date = LocalDate.of(2026, 1, 15),
-            description = "Test entry",
-            lines = listOf(
-                JournalEntryLineRequest(
-                    accountId = "acc-1",
-                    debit = BigDecimal("100.00"),
-                    credit = BigDecimal.ZERO,
-                ),
-                JournalEntryLineRequest(
-                    accountId = "acc-2",
-                    debit = BigDecimal.ZERO,
-                    credit = BigDecimal("100.00"),
-                ),
-            ),
-        )
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Test entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(
+                            accountId = "acc-1",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLineRequest(
+                            accountId = "acc-2",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+            )
 
         val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
         assertThat(result.status).isEqualTo(JournalEntryStatus.DRAFT)
@@ -711,28 +725,30 @@ class JournalEntryServiceTest {
 
     @Test
     fun `post should reject when fiscal period is closed`() {
-        val entry = createMockEntry(
-            id = "entry-1",
-            entryNumber = "JE-0001",
-            status = JournalEntryStatus.DRAFT,
-            lines = listOf(
-                JournalEntryLine(
-                    accountId = "acc-1",
-                    accountCode = "1000",
-                    accountName = "Cash",
-                    debit = BigDecimal("100.00"),
-                    credit = BigDecimal.ZERO,
-                ),
-                JournalEntryLine(
-                    accountId = "acc-2",
-                    accountCode = "4000",
-                    accountName = "Revenue",
-                    debit = BigDecimal.ZERO,
-                    credit = BigDecimal("100.00"),
-                ),
-            ),
-            orgId = orgId,
-        )
+        val entry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.DRAFT,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
 
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
         `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
@@ -740,9 +756,10 @@ class JournalEntryServiceTest {
             fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
         ).thenReturn(null)
 
-        val exception = assertThrows<IllegalArgumentException> {
-            journalEntryService.postJournalEntry("entry-1", orgId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.postJournalEntry("entry-1", orgId)
+            }
         assertThat(exception.message).contains("No open fiscal period")
     }
 

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -589,7 +589,7 @@ class JournalEntryServiceTest {
             .thenReturn(listOf(cashAccount, revenueAccount))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
-        `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(false)
+        `when`(fiscalYearService.hasFiscalYears(orgId)).thenReturn(false)
 
         val request =
             CreateJournalEntryRequest(
@@ -644,7 +644,7 @@ class JournalEntryServiceTest {
                 status = FiscalPeriodStatus.CLOSED,
             )
 
-        `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
+        `when`(fiscalYearService.hasFiscalYears(orgId)).thenReturn(true)
         `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
             .thenReturn(closedPeriod)
 
@@ -705,7 +705,7 @@ class JournalEntryServiceTest {
             .thenReturn(listOf(cashAccount, revenueAccount))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
-        `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
+        `when`(fiscalYearService.hasFiscalYears(orgId)).thenReturn(true)
         `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
             .thenReturn(openPeriod)
 
@@ -769,7 +769,7 @@ class JournalEntryServiceTest {
             )
 
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
-        `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
+        `when`(fiscalYearService.hasFiscalYears(orgId)).thenReturn(true)
         `when`(
             fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
         ).thenReturn(closedPeriod)

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -635,9 +635,18 @@ class JournalEntryServiceTest {
 
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
+        val closedPeriod =
+            FiscalPeriod(
+                periodNumber = 1,
+                name = "January 2026",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 31),
+                status = FiscalPeriodStatus.CLOSED,
+            )
+
         `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
-        `when`(fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(null)
+        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
+            .thenReturn(closedPeriod)
 
         val request =
             CreateJournalEntryRequest(
@@ -662,7 +671,7 @@ class JournalEntryServiceTest {
             assertThrows<IllegalArgumentException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
-        assertThat(exception.message).contains("No open fiscal period")
+        assertThat(exception.message).contains("closed")
     }
 
     @Test
@@ -697,7 +706,7 @@ class JournalEntryServiceTest {
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
         `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
-        `when`(fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
+        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
             .thenReturn(openPeriod)
 
         val request =
@@ -750,17 +759,26 @@ class JournalEntryServiceTest {
                 orgId = orgId,
             )
 
+        val closedPeriod =
+            FiscalPeriod(
+                periodNumber = 1,
+                name = "January 2026",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 31),
+                status = FiscalPeriodStatus.CLOSED,
+            )
+
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
         `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
         `when`(
-            fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
-        ).thenReturn(null)
+            fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
+        ).thenReturn(closedPeriod)
 
         val exception =
             assertThrows<IllegalArgumentException> {
                 journalEntryService.postJournalEntry("entry-1", orgId)
             }
-        assertThat(exception.message).contains("No open fiscal period")
+        assertThat(exception.message).contains("closed")
     }
 
     private fun createMockAccount(

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -31,6 +31,7 @@ class JournalEntryServiceTest {
     private lateinit var journalEntryRepository: JournalEntryRepository
     private lateinit var accountRepository: AccountRepository
     private lateinit var fiscalYearService: FiscalYearService
+    private lateinit var entryNumberGenerator: JournalEntryNumberGenerator
 
     private val orgId = "org-123"
     private val createdBy = "user-1"
@@ -40,11 +41,15 @@ class JournalEntryServiceTest {
         journalEntryRepository = mock(JournalEntryRepository::class.java)
         accountRepository = mock(AccountRepository::class.java)
         fiscalYearService = mock(FiscalYearService::class.java)
+        entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
+        `when`(fiscalYearService.findPeriodForDate(any(), any()))
+            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
         journalEntryService =
             JournalEntryService(
                 journalEntryRepository = journalEntryRepository,
                 accountRepository = accountRepository,
                 fiscalYearService = fiscalYearService,
+                entryNumberGenerator = entryNumberGenerator,
             )
     }
 
@@ -589,7 +594,8 @@ class JournalEntryServiceTest {
             .thenReturn(listOf(cashAccount, revenueAccount))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
-        `when`(fiscalYearService.hasFiscalYears(orgId)).thenReturn(false)
+        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
+            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
 
         val request =
             CreateJournalEntryRequest(
@@ -644,9 +650,8 @@ class JournalEntryServiceTest {
                 status = FiscalPeriodStatus.CLOSED,
             )
 
-        `when`(fiscalYearService.hasFiscalYears(orgId)).thenReturn(true)
         `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(closedPeriod)
+            .thenReturn(FiscalYearService.PeriodLookupResult.Found(closedPeriod))
 
         val request =
             CreateJournalEntryRequest(
@@ -705,9 +710,8 @@ class JournalEntryServiceTest {
             .thenReturn(listOf(cashAccount, revenueAccount))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
-        `when`(fiscalYearService.hasFiscalYears(orgId)).thenReturn(true)
         `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(openPeriod)
+            .thenReturn(FiscalYearService.PeriodLookupResult.Found(openPeriod))
 
         val request =
             CreateJournalEntryRequest(
@@ -769,10 +773,9 @@ class JournalEntryServiceTest {
             )
 
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
-        `when`(fiscalYearService.hasFiscalYears(orgId)).thenReturn(true)
         `when`(
             fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
-        ).thenReturn(closedPeriod)
+        ).thenReturn(FiscalYearService.PeriodLookupResult.Found(closedPeriod))
 
         val exception =
             assertThrows<IllegalArgumentException> {

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -8,6 +8,8 @@ import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.FiscalPeriod
+import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -28,6 +30,7 @@ class JournalEntryServiceTest {
     private lateinit var journalEntryService: JournalEntryService
     private lateinit var journalEntryRepository: JournalEntryRepository
     private lateinit var accountRepository: AccountRepository
+    private lateinit var fiscalYearService: FiscalYearService
 
     private val orgId = "org-123"
     private val createdBy = "user-1"
@@ -36,10 +39,12 @@ class JournalEntryServiceTest {
     fun setup() {
         journalEntryRepository = mock(JournalEntryRepository::class.java)
         accountRepository = mock(AccountRepository::class.java)
+        fiscalYearService = mock(FiscalYearService::class.java)
         journalEntryService =
             JournalEntryService(
                 journalEntryRepository = journalEntryRepository,
                 accountRepository = accountRepository,
+                fiscalYearService = fiscalYearService,
             )
     }
 
@@ -559,6 +564,186 @@ class JournalEntryServiceTest {
         assertThat(revenueBalance!!.totalCredits).isEqualByComparingTo(BigDecimal("300.00"))
         // REVENUE: balance = credits - debits
         assertThat(revenueBalance.balance).isEqualByComparingTo(BigDecimal("300.00"))
+    }
+
+    @Test
+    fun `create should succeed when no fiscal year exists`() {
+        val cashAccount = createMockAccount(
+            id = "acc-1",
+            code = "1000",
+            name = "Cash",
+            type = AccountType.ASSET,
+            orgId = orgId,
+        )
+        val revenueAccount = createMockAccount(
+            id = "acc-2",
+            code = "4000",
+            name = "Revenue",
+            type = AccountType.REVENUE,
+            orgId = orgId,
+        )
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
+            .thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(false)
+
+        val request = CreateJournalEntryRequest(
+            date = LocalDate.of(2026, 1, 15),
+            description = "Test entry",
+            lines = listOf(
+                JournalEntryLineRequest(
+                    accountId = "acc-1",
+                    debit = BigDecimal("100.00"),
+                    credit = BigDecimal.ZERO,
+                ),
+                JournalEntryLineRequest(
+                    accountId = "acc-2",
+                    debit = BigDecimal.ZERO,
+                    credit = BigDecimal("100.00"),
+                ),
+            ),
+        )
+
+        val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
+        assertThat(result.status).isEqualTo(JournalEntryStatus.DRAFT)
+    }
+
+    @Test
+    fun `create should reject when fiscal period is closed`() {
+        val cashAccount = createMockAccount(
+            id = "acc-1",
+            code = "1000",
+            name = "Cash",
+            type = AccountType.ASSET,
+            orgId = orgId,
+        )
+        val revenueAccount = createMockAccount(
+            id = "acc-2",
+            code = "4000",
+            name = "Revenue",
+            type = AccountType.REVENUE,
+            orgId = orgId,
+        )
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
+            .thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
+        `when`(fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
+            .thenReturn(null)
+
+        val request = CreateJournalEntryRequest(
+            date = LocalDate.of(2026, 1, 15),
+            description = "Test entry",
+            lines = listOf(
+                JournalEntryLineRequest(
+                    accountId = "acc-1",
+                    debit = BigDecimal("100.00"),
+                    credit = BigDecimal.ZERO,
+                ),
+                JournalEntryLineRequest(
+                    accountId = "acc-2",
+                    debit = BigDecimal.ZERO,
+                    credit = BigDecimal("100.00"),
+                ),
+            ),
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            journalEntryService.createJournalEntry(request, orgId, createdBy)
+        }
+        assertThat(exception.message).contains("No open fiscal period")
+    }
+
+    @Test
+    fun `create should succeed when fiscal period is open`() {
+        val cashAccount = createMockAccount(
+            id = "acc-1",
+            code = "1000",
+            name = "Cash",
+            type = AccountType.ASSET,
+            orgId = orgId,
+        )
+        val revenueAccount = createMockAccount(
+            id = "acc-2",
+            code = "4000",
+            name = "Revenue",
+            type = AccountType.REVENUE,
+            orgId = orgId,
+        )
+        val openPeriod = FiscalPeriod(
+            periodNumber = 1,
+            name = "January 2026",
+            startDate = LocalDate.of(2026, 1, 1),
+            endDate = LocalDate.of(2026, 1, 31),
+            status = FiscalPeriodStatus.OPEN,
+        )
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
+            .thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
+        `when`(fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
+            .thenReturn(openPeriod)
+
+        val request = CreateJournalEntryRequest(
+            date = LocalDate.of(2026, 1, 15),
+            description = "Test entry",
+            lines = listOf(
+                JournalEntryLineRequest(
+                    accountId = "acc-1",
+                    debit = BigDecimal("100.00"),
+                    credit = BigDecimal.ZERO,
+                ),
+                JournalEntryLineRequest(
+                    accountId = "acc-2",
+                    debit = BigDecimal.ZERO,
+                    credit = BigDecimal("100.00"),
+                ),
+            ),
+        )
+
+        val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
+        assertThat(result.status).isEqualTo(JournalEntryStatus.DRAFT)
+    }
+
+    @Test
+    fun `post should reject when fiscal period is closed`() {
+        val entry = createMockEntry(
+            id = "entry-1",
+            entryNumber = "JE-0001",
+            status = JournalEntryStatus.DRAFT,
+            lines = listOf(
+                JournalEntryLine(
+                    accountId = "acc-1",
+                    accountCode = "1000",
+                    accountName = "Cash",
+                    debit = BigDecimal("100.00"),
+                    credit = BigDecimal.ZERO,
+                ),
+                JournalEntryLine(
+                    accountId = "acc-2",
+                    accountCode = "4000",
+                    accountName = "Revenue",
+                    debit = BigDecimal.ZERO,
+                    credit = BigDecimal("100.00"),
+                ),
+            ),
+            orgId = orgId,
+        )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
+        `when`(fiscalYearService.hasActiveFiscalYear(orgId)).thenReturn(true)
+        `when`(
+            fiscalYearService.findOpenPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
+        ).thenReturn(null)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            journalEntryService.postJournalEntry("entry-1", orgId)
+        }
+        assertThat(exception.message).contains("No open fiscal period")
     }
 
     private fun createMockAccount(


### PR DESCRIPTION
## Summary
- Add fiscal year management with auto-generated monthly periods
- Implement period lifecycle: OPEN → CLOSED → REOPENED with sequential enforcement
- Year-end close generates closing journal entries that zero out revenue/expense into Retained Earnings (3100)
- Add fiscal period validation hook to JournalEntryService — blocks create/post when period is closed
- Add fiscal:create, fiscal:read, fiscal:close permissions with role seeding

## API Endpoints
- `POST /finance/fiscal` — create fiscal year with auto-generated periods
- `GET /finance/fiscal` — list fiscal years (summary)
- `GET /finance/fiscal/{id}` — get fiscal year with periods
- `POST /finance/fiscal/{id}/periods/{periodId}/close` — close a period
- `POST /finance/fiscal/{id}/periods/{periodId}/reopen` — reopen a period
- `POST /finance/fiscal/{id}/close` — year-end close

## Test plan
- [x] 18 FiscalYearServiceTest cases (create, close/reopen period, year-end close with net income/loss, findOpenPeriodForDate)
- [x] 4 new JournalEntryServiceTest cases for fiscal period validation hook
- [x] RoleSeederTest updated with fiscal permissions
- [x] ktlintCheck passes
- [x] 222/223 tests pass (1 pre-existing MongoDB context load failure)

Closes #30