### PR TITLE
Accounts Payable (AP) module (#26)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -56,6 +56,11 @@ class RoleSeeder(
                             Permissions.FISCAL_CREATE,
                             Permissions.FISCAL_READ,
                             Permissions.FISCAL_CLOSE,
+                            Permissions.AP_CREATE,
+                            Permissions.AP_READ,
+                            Permissions.AP_APPROVE,
+                            Permissions.AP_PAY,
+                            Permissions.AP_VOID,
                         ),
                 ),
                 Role(
@@ -82,6 +87,10 @@ class RoleSeeder(
                             Permissions.FISCAL_CREATE,
                             Permissions.FISCAL_READ,
                             Permissions.FISCAL_CLOSE,
+                            Permissions.AP_CREATE,
+                            Permissions.AP_READ,
+                            Permissions.AP_APPROVE,
+                            Permissions.AP_PAY,
                         ),
                 ),
                 Role(
@@ -99,6 +108,8 @@ class RoleSeeder(
                             Permissions.JOURNAL_CREATE,
                             Permissions.JOURNAL_READ,
                             Permissions.FISCAL_READ,
+                            Permissions.AP_CREATE,
+                            Permissions.AP_READ,
                         ),
                 ),
                 Role(
@@ -112,6 +123,7 @@ class RoleSeeder(
                             Permissions.ACCOUNT_READ,
                             Permissions.JOURNAL_READ,
                             Permissions.FISCAL_READ,
+                            Permissions.AP_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -17,6 +17,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 
 @Component
@@ -59,7 +60,7 @@ class TokenAuthenticationFilter(
 
             if (sessionTokenOpt.isPresent) {
                 val sessionToken = sessionTokenOpt.get()
-                if (sessionToken.expiryAt.isAfter(LocalDateTime.now())) {
+                if (sessionToken.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
                     val userOpt = userRepository.findById(sessionToken.userId)
                     if (userOpt.isPresent && userOpt.get().isActive) {
                         val user = userOpt.get()

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -1,0 +1,268 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.BillLineResponse
+import com.froilan.synectix.dto.BillPaymentResponse
+import com.froilan.synectix.dto.BillResponse
+import com.froilan.synectix.dto.BillSummaryResponse
+import com.froilan.synectix.dto.CreateBillRequest
+import com.froilan.synectix.dto.RecordPaymentRequest
+import com.froilan.synectix.dto.VoidBillRequest
+import com.froilan.synectix.model.Bill
+import com.froilan.synectix.model.BillPayment
+import com.froilan.synectix.model.BillStatus
+import com.froilan.synectix.model.User
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.BillService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.util.Locale
+
+@RestController
+@RequestMapping("/finance/ap/bills")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class BillController(
+    private val billService: BillService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('ap:create')")
+    fun createBill(
+        @Valid @RequestBody request: CreateBillRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val createdBy = extractUserId() ?: "api-key"
+
+        return try {
+            val bill = billService.createBill(request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(bill.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest()
+                .body(mapOf("error" to (e.message ?: "Failed to create bill")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun listBills(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) vendorId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        val billStatus =
+            if (status != null) {
+                try {
+                    BillStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest()
+                        .body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+
+        val bills = billService.listBills(orgId, billStatus, vendorId)
+        return ResponseEntity.ok(bills.map { it.toSummaryResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun getBill(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val bill = billService.getBill(id, orgId)
+            ResponseEntity.ok(bill.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Bill not found")))
+        }
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('ap:approve')")
+    fun approveBill(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val bill = billService.approveBill(id, orgId, userId)
+            ResponseEntity.ok(bill.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
+        }
+    }
+
+    @PostMapping("/{id}/void")
+    @PreAuthorize("hasAuthority('ap:void')")
+    fun voidBill(
+        @PathVariable id: String,
+        @Valid @RequestBody request: VoidBillRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val bill = billService.voidBill(id, orgId, request.reason, userId)
+            ResponseEntity.ok(bill.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to void bill")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to void bill")))
+        }
+    }
+
+    @PostMapping("/{id}/payments")
+    @PreAuthorize("hasAuthority('ap:pay')")
+    fun recordPayment(
+        @PathVariable id: String,
+        @Valid @RequestBody request: RecordPaymentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val createdBy = extractUserId() ?: "api-key"
+
+        return try {
+            val payment = billService.recordPayment(id, request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(payment.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to record payment")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to record payment")))
+        }
+    }
+
+    @GetMapping("/{id}/payments")
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun listPayments(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val payments = billService.getPayments(id, orgId)
+            ResponseEntity.ok(payments.map { it.toResponse() })
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Bill not found")))
+        }
+    }
+
+    @GetMapping("/aging")
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun getAgingReport(
+        @RequestParam(required = false) asOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now())
+        return ResponseEntity.ok(report)
+    }
+
+    private fun Bill.toResponse() =
+        BillResponse(
+            id = id,
+            billNumber = billNumber,
+            vendorId = vendorId,
+            vendorName = vendorName,
+            date = date.toString(),
+            dueDate = dueDate.toString(),
+            referenceNumber = referenceNumber,
+            organizationId = organizationId,
+            status = status.name,
+            lines =
+                lines.map { line ->
+                    BillLineResponse(
+                        accountId = line.accountId,
+                        accountCode = line.accountCode,
+                        accountName = line.accountName,
+                        amount = line.amount,
+                        description = line.description,
+                    )
+                },
+            totalAmount = totalAmount,
+            amountPaid = amountPaid,
+            journalEntryId = journalEntryId,
+            createdBy = createdBy,
+            approvedAt = approvedAt?.toString(),
+            approvedBy = approvedBy,
+            paidAt = paidAt?.toString(),
+            voidedAt = voidedAt?.toString(),
+            voidReason = voidReason,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun Bill.toSummaryResponse() =
+        BillSummaryResponse(
+            id = id,
+            billNumber = billNumber,
+            vendorName = vendorName,
+            date = date.toString(),
+            dueDate = dueDate.toString(),
+            status = status.name,
+            totalAmount = totalAmount,
+            amountPaid = amountPaid,
+        )
+
+    private fun BillPayment.toResponse() =
+        BillPaymentResponse(
+            id = id,
+            billId = billId,
+            paymentDate = paymentDate.toString(),
+            amount = amount,
+            paymentMethod = paymentMethod.name,
+            referenceNumber = referenceNumber,
+            journalEntryId = journalEntryId,
+            createdBy = createdBy,
+            createdAt = createdAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun extractUserId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return (authentication.principal as? User)?.uuid
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.Locale
 
 @RestController
@@ -194,7 +195,7 @@ class BillController(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
         val orgId = extractOrganizationId() ?: return unauthorized()
-        val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now())
+        val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
         return ResponseEntity.ok(report)
     }
 

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -49,7 +49,8 @@ class BillController(
             val bill = billService.createBill(request, orgId, createdBy)
             ResponseEntity.status(HttpStatus.CREATED).body(bill.toResponse())
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest()
+            ResponseEntity
+                .badRequest()
                 .body(mapOf("error" to (e.message ?: "Failed to create bill")))
         }
     }
@@ -67,7 +68,8 @@ class BillController(
                 try {
                     BillStatus.valueOf(status.uppercase(Locale.ROOT))
                 } catch (e: IllegalArgumentException) {
-                    return ResponseEntity.badRequest()
+                    return ResponseEntity
+                        .badRequest()
                         .body(mapOf("error" to "Invalid status '$status'"))
                 }
             } else {
@@ -89,7 +91,8 @@ class BillController(
             val bill = billService.getBill(id, orgId)
             ResponseEntity.ok(bill.toResponse())
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND)
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(mapOf("error" to (e.message ?: "Bill not found")))
         }
     }
@@ -108,10 +111,12 @@ class BillController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
         } catch (e: IllegalStateException) {
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
         }
     }
@@ -131,10 +136,12 @@ class BillController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to void bill")))
         } catch (e: IllegalStateException) {
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(mapOf("error" to (e.message ?: "Failed to void bill")))
         }
     }
@@ -154,10 +161,12 @@ class BillController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to record payment")))
         } catch (e: IllegalStateException) {
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(mapOf("error" to (e.message ?: "Failed to record payment")))
         }
     }
@@ -173,7 +182,8 @@ class BillController(
             val payments = billService.getPayments(id, orgId)
             ResponseEntity.ok(payments.map { it.toResponse() })
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND)
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(mapOf("error" to (e.message ?: "Bill not found")))
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @RestController
 @RequestMapping("/health")
@@ -25,7 +26,7 @@ class HealthController(
         val healthData =
             mutableMapOf<String, Any>(
                 "status" to "UP",
-                "timestamp" to LocalDateTime.now(),
+                "timestamp" to LocalDateTime.now(ZoneOffset.UTC),
                 "application" to "Synectix ERP System",
                 "version" to "0.0.1-SNAPSHOT",
             )
@@ -56,7 +57,7 @@ class HealthController(
         val detailedHealth =
             mutableMapOf<String, Any>(
                 "status" to "UP",
-                "timestamp" to LocalDateTime.now(),
+                "timestamp" to LocalDateTime.now(ZoneOffset.UTC),
                 "application" to
                     mapOf(
                         "name" to "Synectix ERP System",

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -1,0 +1,137 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateVendorRequest
+import com.froilan.synectix.dto.UpdateVendorRequest
+import com.froilan.synectix.dto.VendorResponse
+import com.froilan.synectix.model.User
+import com.froilan.synectix.model.Vendor
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.VendorService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/finance/ap/vendors")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class VendorController(
+    private val vendorService: VendorService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('ap:create')")
+    fun createVendor(
+        @Valid @RequestBody request: CreateVendorRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val vendor = vendorService.createVendor(request, orgId)
+            ResponseEntity.status(HttpStatus.CREATED).body(vendor.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create vendor")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun listVendors(): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val vendors = vendorService.listVendors(orgId)
+        return ResponseEntity.ok(vendors.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun getVendor(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val vendor = vendorService.getVendor(id, orgId)
+            ResponseEntity.ok(vendor.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Vendor not found")))
+        }
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('ap:create')")
+    fun updateVendor(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateVendorRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val vendor = vendorService.updateVendor(id, request, orgId)
+            ResponseEntity.ok(vendor.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Vendor not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to update vendor")))
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('ap:void')")
+    fun deleteVendor(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val vendor = vendorService.deleteVendor(id, orgId)
+            ResponseEntity.ok(vendor.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Vendor not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to delete vendor")))
+        }
+    }
+
+    private fun Vendor.toResponse() =
+        VendorResponse(
+            id = id,
+            name = name,
+            contactName = contactName,
+            contactEmail = contactEmail,
+            contactPhone = contactPhone,
+            paymentTermDays = paymentTermDays,
+            defaultExpenseAccountId = defaultExpenseAccountId,
+            organizationId = organizationId,
+            isActive = isActive,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -5,7 +5,6 @@ import com.froilan.synectix.annotation.Loggable
 import com.froilan.synectix.dto.CreateVendorRequest
 import com.froilan.synectix.dto.UpdateVendorRequest
 import com.froilan.synectix.dto.VendorResponse
-import com.froilan.synectix.model.User
 import com.froilan.synectix.model.Vendor
 import com.froilan.synectix.security.ApiKeyContext
 import com.froilan.synectix.security.SessionContext
@@ -64,7 +63,8 @@ class VendorController(
             val vendor = vendorService.getVendor(id, orgId)
             ResponseEntity.ok(vendor.toResponse())
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND)
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(mapOf("error" to (e.message ?: "Vendor not found")))
         }
     }
@@ -83,7 +83,8 @@ class VendorController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Vendor not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to update vendor")))
         }
     }
@@ -101,7 +102,8 @@ class VendorController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Vendor not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to delete vendor")))
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -90,7 +90,7 @@ class VendorController(
     }
 
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAuthority('ap:void')")
+    @PreAuthorize("hasAuthority('ap:create')")
     fun deleteVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {

--- a/src/main/kotlin/com/froilan/synectix/dto/BillDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/BillDtos.kt
@@ -1,0 +1,117 @@
+package com.froilan.synectix.dto
+
+import com.froilan.synectix.model.PaymentMethod
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class BillLineRequest(
+    @field:NotBlank(message = "Account ID is required")
+    val accountId: String,
+    @field:Positive(message = "Amount must be positive")
+    val amount: BigDecimal,
+    val description: String? = null,
+)
+
+data class CreateBillRequest(
+    @field:NotBlank(message = "Vendor ID is required")
+    val vendorId: String,
+    val date: LocalDate,
+    val dueDate: LocalDate,
+    val referenceNumber: String? = null,
+    @field:NotEmpty(message = "At least one line item is required")
+    @field:Valid
+    val lines: List<BillLineRequest>,
+)
+
+data class VoidBillRequest(
+    @field:NotBlank(message = "Void reason is required")
+    val reason: String,
+)
+
+data class RecordPaymentRequest(
+    val paymentDate: LocalDate,
+    @field:Positive(message = "Payment amount must be positive")
+    val amount: BigDecimal,
+    val paymentMethod: PaymentMethod,
+    val referenceNumber: String? = null,
+)
+
+data class BillLineResponse(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val amount: BigDecimal,
+    val description: String?,
+)
+
+data class BillResponse(
+    val id: String,
+    val billNumber: String,
+    val vendorId: String,
+    val vendorName: String,
+    val date: String,
+    val dueDate: String,
+    val referenceNumber: String?,
+    val organizationId: String,
+    val status: String,
+    val lines: List<BillLineResponse>,
+    val totalAmount: BigDecimal,
+    val amountPaid: BigDecimal,
+    val journalEntryId: String?,
+    val createdBy: String,
+    val approvedAt: String?,
+    val approvedBy: String?,
+    val paidAt: String?,
+    val voidedAt: String?,
+    val voidReason: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class BillSummaryResponse(
+    val id: String,
+    val billNumber: String,
+    val vendorName: String,
+    val date: String,
+    val dueDate: String,
+    val status: String,
+    val totalAmount: BigDecimal,
+    val amountPaid: BigDecimal,
+)
+
+data class BillPaymentResponse(
+    val id: String,
+    val billId: String,
+    val paymentDate: String,
+    val amount: BigDecimal,
+    val paymentMethod: String,
+    val referenceNumber: String?,
+    val journalEntryId: String?,
+    val createdBy: String,
+    val createdAt: String?,
+)
+
+data class AgingBucket(
+    val current: BigDecimal,
+    val days1to30: BigDecimal,
+    val days31to60: BigDecimal,
+    val days61to90: BigDecimal,
+    val days90plus: BigDecimal,
+    val total: BigDecimal,
+)
+
+data class VendorAgingResponse(
+    val vendorId: String,
+    val vendorName: String,
+    val aging: AgingBucket,
+)
+
+data class ApAgingReportResponse(
+    val asOfDate: String,
+    val vendors: List<VendorAgingResponse>,
+    val totals: AgingBucket,
+)

--- a/src/main/kotlin/com/froilan/synectix/dto/VendorDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/VendorDtos.kt
@@ -1,0 +1,36 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreateVendorRequest(
+    @field:NotBlank(message = "Vendor name is required")
+    val name: String,
+    val contactName: String? = null,
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    val paymentTermDays: Int = 30,
+    val defaultExpenseAccountId: String? = null,
+)
+
+data class UpdateVendorRequest(
+    val name: String? = null,
+    val contactName: String? = null,
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    val paymentTermDays: Int? = null,
+    val defaultExpenseAccountId: String? = null,
+)
+
+data class VendorResponse(
+    val id: String,
+    val name: String,
+    val contactName: String?,
+    val contactEmail: String?,
+    val contactPhone: String?,
+    val paymentTermDays: Int,
+    val defaultExpenseAccountId: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/dto/VendorDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/VendorDtos.kt
@@ -1,5 +1,6 @@
 package com.froilan.synectix.dto
 
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 
 data class CreateVendorRequest(
@@ -8,6 +9,7 @@ data class CreateVendorRequest(
     val contactName: String? = null,
     val contactEmail: String? = null,
     val contactPhone: String? = null,
+    @field:Min(value = 0, message = "Payment term days must be zero or positive")
     val paymentTermDays: Int = 30,
     val defaultExpenseAccountId: String? = null,
 )
@@ -17,6 +19,7 @@ data class UpdateVendorRequest(
     val contactName: String? = null,
     val contactEmail: String? = null,
     val contactPhone: String? = null,
+    @field:Min(value = 0, message = "Payment term days must be zero or positive")
     val paymentTermDays: Int? = null,
     val defaultExpenseAccountId: String? = null,
 )

--- a/src/main/kotlin/com/froilan/synectix/dto/VendorDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/VendorDtos.kt
@@ -1,5 +1,6 @@
 package com.froilan.synectix.dto
 
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 
@@ -7,6 +8,7 @@ data class CreateVendorRequest(
     @field:NotBlank(message = "Vendor name is required")
     val name: String,
     val contactName: String? = null,
+    @field:Email(message = "Invalid email format")
     val contactEmail: String? = null,
     val contactPhone: String? = null,
     @field:Min(value = 0, message = "Payment term days must be zero or positive")
@@ -17,6 +19,7 @@ data class CreateVendorRequest(
 data class UpdateVendorRequest(
     val name: String? = null,
     val contactName: String? = null,
+    @field:Email(message = "Invalid email format")
     val contactEmail: String? = null,
     val contactPhone: String? = null,
     @field:Min(value = 0, message = "Payment term days must be zero or positive")

--- a/src/main/kotlin/com/froilan/synectix/model/Bill.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Bill.kt
@@ -41,6 +41,8 @@ data class BillLine(
     def = "{'organizationId': 1, 'billNumber': 1}",
     unique = true,
 )
+@CompoundIndex(name = "org_status", def = "{'organizationId': 1, 'status': 1}")
+@CompoundIndex(name = "org_vendor", def = "{'organizationId': 1, 'vendorId': 1}")
 data class Bill(
     @Id
     val id: String = UUID.randomUUID().toString(),

--- a/src/main/kotlin/com/froilan/synectix/model/Bill.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Bill.kt
@@ -1,0 +1,70 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class BillStatus {
+    DRAFT,
+    APPROVED,
+    PARTIALLY_PAID,
+    PAID,
+    VOID,
+}
+
+enum class PaymentMethod {
+    CASH,
+    CHECK,
+    BANK_TRANSFER,
+    CREDIT_CARD,
+    OTHER,
+}
+
+data class BillLine(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val amount: BigDecimal,
+    val description: String? = null,
+)
+
+@Document(collection = "bills")
+@CompoundIndex(
+    name = "unique_bill_number_per_org",
+    def = "{'organizationId': 1, 'billNumber': 1}",
+    unique = true,
+)
+data class Bill(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val billNumber: String,
+    val vendorId: String,
+    val vendorName: String,
+    val date: LocalDate,
+    val dueDate: LocalDate,
+    val referenceNumber: String? = null,
+    @Indexed
+    val organizationId: String,
+    val status: BillStatus = BillStatus.DRAFT,
+    val lines: List<BillLine>,
+    val totalAmount: BigDecimal,
+    val amountPaid: BigDecimal = BigDecimal.ZERO,
+    val journalEntryId: String? = null,
+    val createdBy: String,
+    val approvedAt: LocalDateTime? = null,
+    val approvedBy: String? = null,
+    val paidAt: LocalDateTime? = null,
+    val voidedAt: LocalDateTime? = null,
+    val voidReason: String? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/BillPayment.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/BillPayment.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.model
 
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.math.BigDecimal
@@ -10,6 +11,10 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 @Document(collection = "bill_payments")
+@CompoundIndex(
+    name = "org_bill_payment",
+    def = "{'organizationId': 1, 'billId': 1}",
+)
 data class BillPayment(
     @Id
     val id: String = UUID.randomUUID().toString(),

--- a/src/main/kotlin/com/froilan/synectix/model/BillPayment.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/BillPayment.kt
@@ -1,0 +1,28 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "bill_payments")
+data class BillPayment(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    @Indexed
+    val billId: String,
+    val paymentDate: LocalDate,
+    val amount: BigDecimal,
+    val paymentMethod: PaymentMethod,
+    val referenceNumber: String? = null,
+    val journalEntryId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val createdBy: String,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Organizations.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Organizations.kt
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Document(collection = "organizations")
@@ -21,6 +22,6 @@ data class Organizations(
     val fiscalYearStart: LocalDateTime,
     val timezone: String,
     val status: String = "ACTIVE",
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
     val isActive: Boolean = true,
 )

--- a/src/main/kotlin/com/froilan/synectix/model/PasswordResetToken.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/PasswordResetToken.kt
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Document(collection = "password_reset_tokens")
@@ -15,5 +16,5 @@ data class PasswordResetToken(
     val userId: String,
     @Indexed(expireAfterSeconds = 0)
     val expiryAt: LocalDateTime,
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
 )

--- a/src/main/kotlin/com/froilan/synectix/model/RefreshToken.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/RefreshToken.kt
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Document(collection = "refresh_tokens")
@@ -16,5 +17,5 @@ data class RefreshToken(
     val sessionTokenId: String,
     @Indexed(expireAfterSeconds = 0)
     val expiryAt: LocalDateTime,
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
 )

--- a/src/main/kotlin/com/froilan/synectix/model/SessionToken.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/SessionToken.kt
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Document(collection = "session_tokens")
@@ -18,5 +19,5 @@ data class SessionToken(
     val expiryAt: LocalDateTime,
     val ipAddress: String? = null,
     val userAgent: String? = null,
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
 )

--- a/src/main/kotlin/com/froilan/synectix/model/Vendor.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Vendor.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "vendors")
+@CompoundIndex(
+    name = "unique_name_per_org",
+    def = "{'organizationId': 1, 'name': 1}",
+    unique = true,
+)
+data class Vendor(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val contactName: String? = null,
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    val paymentTermDays: Int = 30,
+    val defaultExpenseAccountId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/BillPaymentRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/BillPaymentRepository.kt
@@ -1,0 +1,12 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.BillPayment
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface BillPaymentRepository : MongoRepository<BillPayment, String> {
+    fun findByBillId(billId: String): List<BillPayment>
+
+    fun findByOrganizationId(organizationId: String): List<BillPayment>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/BillPaymentRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/BillPaymentRepository.kt
@@ -6,7 +6,10 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface BillPaymentRepository : MongoRepository<BillPayment, String> {
-    fun findByBillId(billId: String): List<BillPayment>
+    fun findByBillIdAndOrganizationId(
+        billId: String,
+        organizationId: String,
+    ): List<BillPayment>
 
     fun findByOrganizationId(organizationId: String): List<BillPayment>
 }

--- a/src/main/kotlin/com/froilan/synectix/repository/BillRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/BillRepository.kt
@@ -1,0 +1,35 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Bill
+import com.froilan.synectix.model.BillStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+interface BillRepository : MongoRepository<Bill, String> {
+    fun findByOrganizationId(organizationId: String): List<Bill>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: BillStatus,
+    ): List<Bill>
+
+    fun findByOrganizationIdAndVendorId(
+        organizationId: String,
+        vendorId: String,
+    ): List<Bill>
+
+    fun findByOrganizationIdAndStatusIn(
+        organizationId: String,
+        statuses: List<BillStatus>,
+    ): List<Bill>
+
+    fun findByOrganizationIdAndDateBetween(
+        organizationId: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<Bill>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/BillRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/BillRepository.kt
@@ -20,6 +20,12 @@ interface BillRepository : MongoRepository<Bill, String> {
         vendorId: String,
     ): List<Bill>
 
+    fun findByOrganizationIdAndStatusAndVendorId(
+        organizationId: String,
+        status: BillStatus,
+        vendorId: String,
+    ): List<Bill>
+
     fun findByOrganizationIdAndStatusIn(
         organizationId: String,
         statuses: List<BillStatus>,

--- a/src/main/kotlin/com/froilan/synectix/repository/VendorRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/VendorRepository.kt
@@ -1,0 +1,13 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Vendor
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface VendorRepository : MongoRepository<Vendor, String> {
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Vendor>
+}

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -33,6 +33,12 @@ object Permissions {
     const val FISCAL_READ = "fiscal:read"
     const val FISCAL_CLOSE = "fiscal:close"
 
+    const val AP_CREATE = "ap:create"
+    const val AP_READ = "ap:read"
+    const val AP_APPROVE = "ap:approve"
+    const val AP_PAY = "ap:pay"
+    const val AP_VOID = "ap:void"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -58,5 +64,10 @@ object Permissions {
             FISCAL_CREATE,
             FISCAL_READ,
             FISCAL_CLOSE,
+            AP_CREATE,
+            AP_READ,
+            AP_APPROVE,
+            AP_PAY,
+            AP_VOID,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
@@ -56,7 +56,7 @@ class AccountService(
         return try {
             accountRepository.save(account)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException("Account code '${request.code}' already exists in this organization")
+            throw IllegalArgumentException("Account code '${request.code}' already exists in this organization", e)
         }
     }
 

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Update
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @Service
 class ApiKeyService(
@@ -81,11 +82,11 @@ class ApiKeyService(
         val apiKey = apiKeyRepository.findByKeyHash(keyHash).orElse(null) ?: return null
 
         if (!apiKey.isActive) return null
-        if (apiKey.expiresAt != null && !apiKey.expiresAt.isAfter(LocalDateTime.now())) return null
+        if (apiKey.expiresAt != null && !apiKey.expiresAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) return null
 
         mongoTemplate.updateFirst(
             Query.query(Criteria.where("_id").`is`(apiKey.id)),
-            Update.update("lastUsedAt", LocalDateTime.now()),
+            Update.update("lastUsedAt", LocalDateTime.now(ZoneOffset.UTC)),
             ApiKey::class.java,
         )
 

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -84,15 +84,15 @@ class AuthService(
             val errorMessage = e.message ?: ""
             when {
                 errorMessage.contains("username", ignoreCase = true) ->
-                    throw IllegalArgumentException("Username already exists")
+                    throw IllegalArgumentException("Username already exists", e)
                 errorMessage.contains("email", ignoreCase = true) ->
-                    throw IllegalArgumentException("Email already exists")
+                    throw IllegalArgumentException("Email already exists", e)
                 errorMessage.contains("orgSlug", ignoreCase = true) ->
-                    throw IllegalArgumentException("Organization slug already exists")
+                    throw IllegalArgumentException("Organization slug already exists", e)
                 errorMessage.contains("name", ignoreCase = true) ->
-                    throw IllegalArgumentException("Organization name already exists")
+                    throw IllegalArgumentException("Organization name already exists", e)
                 else ->
-                    throw IllegalArgumentException("Registration failed due to a conflict")
+                    throw IllegalArgumentException("Registration failed due to a conflict", e)
             }
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -27,6 +27,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.Locale
 
@@ -116,7 +117,7 @@ class AuthService(
         }
 
         val accessTokenStr = generateToken()
-        val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
+        val expiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(tokenValidityMs, ChronoUnit.MILLIS)
 
         val orgId = user.organizationId
         val sessionToken =
@@ -131,7 +132,7 @@ class AuthService(
         val savedSession = sessionTokenRepository.save(sessionToken)
 
         val refreshTokenStr = generateToken()
-        val refreshExpiryAt = LocalDateTime.now().plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+        val refreshExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
 
         val refreshToken =
             RefreshToken(
@@ -162,7 +163,7 @@ class AuthService(
                 .findByTokenHash(refreshTokenHash)
                 .orElseThrow { IllegalArgumentException("Invalid or expired refresh token") }
 
-        if (!existing.expiryAt.isAfter(LocalDateTime.now())) {
+        if (!existing.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
             throw IllegalArgumentException("Invalid or expired refresh token")
         }
 
@@ -179,7 +180,7 @@ class AuthService(
         val orgId = oldSession?.organizationId ?: user.organizationId
 
         val accessTokenStr = generateToken()
-        val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
+        val expiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(tokenValidityMs, ChronoUnit.MILLIS)
 
         val sessionToken =
             SessionToken(
@@ -192,7 +193,7 @@ class AuthService(
 
         val refreshTokenStr = generateToken()
         val newRefreshTokenHash = tokenHasher.hash(refreshTokenStr)
-        val refreshExpiryAt = LocalDateTime.now().plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+        val refreshExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
 
         val newRefreshToken =
             RefreshToken(
@@ -263,7 +264,7 @@ class AuthService(
             PasswordResetToken(
                 tokenHash = tokenHasher.hash(rawToken),
                 userId = user.uuid,
-                expiryAt = LocalDateTime.now().plusMinutes(resetTokenExpiryMinutes),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(resetTokenExpiryMinutes),
             )
         passwordResetTokenRepository.save(resetToken)
 
@@ -282,7 +283,7 @@ class AuthService(
                 .findByTokenHash(tokenHash)
                 .orElseThrow { IllegalArgumentException("Invalid or expired reset token") }
 
-        if (!existing.expiryAt.isAfter(LocalDateTime.now())) {
+        if (!existing.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
             passwordResetTokenRepository.deleteById(existing.id)
             throw IllegalArgumentException("Invalid or expired reset token")
         }
@@ -306,7 +307,8 @@ class AuthService(
         refreshTokenRepository.deleteByUserId(user.uuid)
     }
 
-    fun listSessions(userId: String): List<SessionToken> = sessionTokenRepository.findByUserIdAndExpiryAtAfter(userId, LocalDateTime.now())
+    fun listSessions(userId: String): List<SessionToken> =
+        sessionTokenRepository.findByUserIdAndExpiryAtAfter(userId, LocalDateTime.now(ZoneOffset.UTC))
 
     @Transactional
     fun revokeSession(
@@ -362,7 +364,7 @@ class AuthService(
         }
 
         val accessTokenStr = generateToken()
-        val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
+        val expiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(tokenValidityMs, ChronoUnit.MILLIS)
 
         val sessionToken =
             SessionToken(
@@ -376,7 +378,7 @@ class AuthService(
         val savedSession = sessionTokenRepository.save(sessionToken)
 
         val refreshTokenStr = generateToken()
-        val refreshExpiryAt = LocalDateTime.now().plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+        val refreshExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
 
         val refreshToken =
             RefreshToken(

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
@@ -60,7 +61,7 @@ class BillService(
 
         accounts.values.forEach { account ->
             if (account.organizationId != organizationId) {
-                throw IllegalArgumentException("Account '${account.code}' does not belong to this organization")
+                throw IllegalArgumentException("Account '${account.id}' not found")
             }
             if (!account.isActive) {
                 throw IllegalArgumentException("Account '${account.code}' is inactive")
@@ -175,6 +176,8 @@ class BillService(
             ),
         )
 
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+
         val journalEntry =
             entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
                 JournalEntry(
@@ -187,7 +190,7 @@ class BillService(
                     sourceReference = "BILL-APPROVE-${bill.id}",
                     lines = journalLines,
                     createdBy = approvedBy,
-                    postedAt = LocalDateTime.now(),
+                    postedAt = now,
                 )
             }
 
@@ -195,7 +198,7 @@ class BillService(
             bill.copy(
                 status = BillStatus.APPROVED,
                 journalEntryId = journalEntry.id,
-                approvedAt = LocalDateTime.now(),
+                approvedAt = now,
                 approvedBy = approvedBy,
             ),
         )
@@ -213,11 +216,13 @@ class BillService(
         if (bill.status == BillStatus.VOID) {
             throw IllegalArgumentException("Bill is already voided")
         }
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+
         if (bill.status == BillStatus.DRAFT) {
             return billRepository.save(
                 bill.copy(
                     status = BillStatus.VOID,
-                    voidedAt = LocalDateTime.now(),
+                    voidedAt = now,
                     voidReason = reason,
                 ),
             )
@@ -274,14 +279,14 @@ class BillService(
                 sourceReference = "BILL-VOID-${bill.id}",
                 lines = reversingLines,
                 createdBy = voidedBy,
-                postedAt = LocalDateTime.now(),
+                postedAt = now,
             )
         }
 
         return billRepository.save(
             bill.copy(
                 status = BillStatus.VOID,
-                voidedAt = LocalDateTime.now(),
+                voidedAt = now,
                 voidReason = reason,
             ),
         )
@@ -356,7 +361,7 @@ class BillService(
                             ),
                         ),
                     createdBy = createdBy,
-                    postedAt = LocalDateTime.now(),
+                    postedAt = LocalDateTime.now(ZoneOffset.UTC),
                 )
             }
 
@@ -383,7 +388,7 @@ class BillService(
             bill.copy(
                 amountPaid = newAmountPaid,
                 status = newStatus,
-                paidAt = if (fullyPaid) LocalDateTime.now() else null,
+                paidAt = if (fullyPaid) LocalDateTime.now(ZoneOffset.UTC) else null,
             ),
         )
 
@@ -488,7 +493,7 @@ class BillService(
                 return billRepository.save(buildBill(billNumber))
             } catch (e: DuplicateKeyException) {
                 if (it == maxRetries - 1) {
-                    throw IllegalStateException("Failed to generate unique bill number")
+                    throw IllegalStateException("Failed to generate unique bill number: $billNumber", e)
                 }
             }
         }

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -233,6 +233,9 @@ class BillService(
             accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
                 IllegalStateException("Accounts Payable account (2000) not found")
             }
+        if (!apAccount.isActive) {
+            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
+        }
 
         val reversingLines = mutableListOf<JournalEntryLine>()
 

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -9,6 +9,7 @@ import com.froilan.synectix.model.Bill
 import com.froilan.synectix.model.BillLine
 import com.froilan.synectix.model.BillPayment
 import com.froilan.synectix.model.BillStatus
+import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
@@ -31,6 +32,7 @@ class BillService(
     private val accountRepository: AccountRepository,
     private val vendorService: VendorService,
     private val entryNumberGenerator: JournalEntryNumberGenerator,
+    private val fiscalYearService: FiscalYearService,
 ) {
     @Transactional
     fun createBill(
@@ -112,15 +114,17 @@ class BillService(
         organizationId: String,
         status: BillStatus? = null,
         vendorId: String? = null,
-    ): List<Bill> {
-        val bills =
-            when {
-                status != null -> billRepository.findByOrganizationIdAndStatus(organizationId, status)
-                vendorId != null -> billRepository.findByOrganizationIdAndVendorId(organizationId, vendorId)
-                else -> billRepository.findByOrganizationId(organizationId)
-            }
-        return bills
-    }
+    ): List<Bill> =
+        when {
+            status != null && vendorId != null ->
+                billRepository.findByOrganizationIdAndStatusAndVendorId(organizationId, status, vendorId)
+            status != null ->
+                billRepository.findByOrganizationIdAndStatus(organizationId, status)
+            vendorId != null ->
+                billRepository.findByOrganizationIdAndVendorId(organizationId, vendorId)
+            else ->
+                billRepository.findByOrganizationId(organizationId)
+        }
 
     @Transactional
     fun approveBill(
@@ -134,10 +138,15 @@ class BillService(
             throw IllegalArgumentException("Only draft bills can be approved")
         }
 
+        validateFiscalPeriodOpen(organizationId, bill.date)
+
         val apAccount =
             accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
                 IllegalStateException("Accounts Payable account (2000) not found")
             }
+        if (!apAccount.isActive) {
+            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
+        }
 
         val journalLines = mutableListOf<JournalEntryLine>()
 
@@ -216,6 +225,9 @@ class BillService(
             throw IllegalArgumentException("Cannot void a bill with recorded payments")
         }
 
+        val voidDate = LocalDate.now()
+        validateFiscalPeriodOpen(organizationId, voidDate)
+
         val apAccount =
             accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
                 IllegalStateException("Accounts Payable account (2000) not found")
@@ -250,7 +262,7 @@ class BillService(
         entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
             JournalEntry(
                 entryNumber = entryNumber,
-                date = bill.date,
+                date = voidDate,
                 description = "Void bill ${bill.billNumber} - ${bill.vendorName}",
                 organizationId = organizationId,
                 status = JournalEntryStatus.POSTED,
@@ -291,14 +303,22 @@ class BillService(
             )
         }
 
+        validateFiscalPeriodOpen(organizationId, request.paymentDate)
+
         val apAccount =
             accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
                 IllegalStateException("Accounts Payable account (2000) not found")
             }
+        if (!apAccount.isActive) {
+            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
+        }
         val cashAccount =
             accountRepository.findByOrganizationIdAndCode(organizationId, "1000").orElseThrow {
                 IllegalStateException("Cash account (1000) not found")
             }
+        if (!cashAccount.isActive) {
+            throw IllegalArgumentException("Cash account (1000) is inactive")
+        }
 
         val journalEntry =
             entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
@@ -368,7 +388,7 @@ class BillService(
         organizationId: String,
     ): List<BillPayment> {
         getBill(billId, organizationId)
-        return billPaymentRepository.findByBillId(billId)
+        return billPaymentRepository.findByBillIdAndOrganizationId(billId, organizationId)
     }
 
     fun getAgingReport(
@@ -464,5 +484,21 @@ class BillService(
             }
         }
         throw IllegalStateException("Failed to generate unique bill number")
+    }
+
+    private fun validateFiscalPeriodOpen(
+        organizationId: String,
+        date: LocalDate,
+    ) {
+        when (val result = fiscalYearService.findPeriodForDate(organizationId, date)) {
+            is FiscalYearService.PeriodLookupResult.NoFiscalYears -> return
+            is FiscalYearService.PeriodLookupResult.NotFound ->
+                throw IllegalArgumentException("No fiscal period covers the date $date")
+            is FiscalYearService.PeriodLookupResult.Found -> {
+                if (result.period.status == FiscalPeriodStatus.CLOSED) {
+                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
+                }
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -433,7 +433,12 @@ class BillService(
             }
         }
 
-        val total = current.add(days1to30).add(days31to60).add(days61to90).add(days90plus)
+        val total =
+            current
+                .add(days1to30)
+                .add(days31to60)
+                .add(days61to90)
+                .add(days90plus)
         return AgingBucket(
             current = current,
             days1to30 = days1to30,

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -218,6 +218,7 @@ class BillService(
         }
         val now = LocalDateTime.now(ZoneOffset.UTC)
 
+        // Draft voids skip fiscal validation — no GL entries are posted
         if (bill.status == BillStatus.DRAFT) {
             return billRepository.save(
                 bill.copy(

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -24,6 +24,7 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
+import java.util.UUID
 
 @Service
 class BillService(
@@ -320,6 +321,8 @@ class BillService(
             throw IllegalArgumentException("Cash account (1000) is inactive")
         }
 
+        val paymentId = UUID.randomUUID().toString()
+
         val journalEntry =
             entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
                 JournalEntry(
@@ -329,7 +332,7 @@ class BillService(
                     organizationId = organizationId,
                     status = JournalEntryStatus.POSTED,
                     source = JournalEntrySource.SYSTEM,
-                    sourceReference = "BILL-PAYMENT-${bill.id}",
+                    sourceReference = "BILL-PAYMENT-$paymentId",
                     lines =
                         listOf(
                             JournalEntryLine(
@@ -357,6 +360,7 @@ class BillService(
         val payment =
             billPaymentRepository.save(
                 BillPayment(
+                    id = paymentId,
                     billId = bill.id,
                     paymentDate = request.paymentDate,
                     amount = request.amount,
@@ -480,7 +484,9 @@ class BillService(
             try {
                 return billRepository.save(buildBill(billNumber))
             } catch (e: DuplicateKeyException) {
-                if (it == maxRetries - 1) throw e
+                if (it == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique bill number")
+                }
             }
         }
         throw IllegalStateException("Failed to generate unique bill number")

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -1,0 +1,463 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AgingBucket
+import com.froilan.synectix.dto.ApAgingReportResponse
+import com.froilan.synectix.dto.CreateBillRequest
+import com.froilan.synectix.dto.RecordPaymentRequest
+import com.froilan.synectix.dto.VendorAgingResponse
+import com.froilan.synectix.model.Bill
+import com.froilan.synectix.model.BillLine
+import com.froilan.synectix.model.BillPayment
+import com.froilan.synectix.model.BillStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.BillPaymentRepository
+import com.froilan.synectix.repository.BillRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+@Service
+class BillService(
+    private val billRepository: BillRepository,
+    private val billPaymentRepository: BillPaymentRepository,
+    private val accountRepository: AccountRepository,
+    private val vendorService: VendorService,
+    private val entryNumberGenerator: JournalEntryNumberGenerator,
+) {
+    @Transactional
+    fun createBill(
+        request: CreateBillRequest,
+        organizationId: String,
+        createdBy: String,
+    ): Bill {
+        val vendor = vendorService.getVendor(request.vendorId, organizationId)
+        if (!vendor.isActive) {
+            throw IllegalArgumentException("Cannot create bill for inactive vendor")
+        }
+
+        if (!request.date.isBefore(request.dueDate) && request.date != request.dueDate) {
+            throw IllegalArgumentException("Due date must be on or after bill date")
+        }
+
+        val accountIds = request.lines.map { it.accountId }
+        val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
+
+        val missingAccounts = accountIds.filter { it !in accounts }
+        if (missingAccounts.isNotEmpty()) {
+            throw IllegalArgumentException("Accounts not found: ${missingAccounts.joinToString(", ")}")
+        }
+
+        accounts.values.forEach { account ->
+            if (account.organizationId != organizationId) {
+                throw IllegalArgumentException("Account '${account.code}' does not belong to this organization")
+            }
+            if (!account.isActive) {
+                throw IllegalArgumentException("Account '${account.code}' is inactive")
+            }
+        }
+
+        val lines =
+            request.lines.map { lineReq ->
+                val account = accounts.getValue(lineReq.accountId)
+                BillLine(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    amount = lineReq.amount,
+                    description = lineReq.description,
+                )
+            }
+
+        val totalAmount = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.amount) }
+
+        return saveBillWithRetry(organizationId) { billNumber ->
+            Bill(
+                billNumber = billNumber,
+                vendorId = vendor.id,
+                vendorName = vendor.name,
+                date = request.date,
+                dueDate = request.dueDate,
+                referenceNumber = request.referenceNumber,
+                organizationId = organizationId,
+                lines = lines,
+                totalAmount = totalAmount,
+                createdBy = createdBy,
+            )
+        }
+    }
+
+    fun getBill(
+        billId: String,
+        organizationId: String,
+    ): Bill {
+        val bill =
+            billRepository.findById(billId).orElseThrow {
+                IllegalArgumentException("Bill not found")
+            }
+        if (bill.organizationId != organizationId) {
+            throw IllegalArgumentException("Bill not found")
+        }
+        return bill
+    }
+
+    fun listBills(
+        organizationId: String,
+        status: BillStatus? = null,
+        vendorId: String? = null,
+    ): List<Bill> {
+        val bills =
+            when {
+                status != null -> billRepository.findByOrganizationIdAndStatus(organizationId, status)
+                vendorId != null -> billRepository.findByOrganizationIdAndVendorId(organizationId, vendorId)
+                else -> billRepository.findByOrganizationId(organizationId)
+            }
+        return bills
+    }
+
+    @Transactional
+    fun approveBill(
+        billId: String,
+        organizationId: String,
+        approvedBy: String,
+    ): Bill {
+        val bill = getBill(billId, organizationId)
+
+        if (bill.status != BillStatus.DRAFT) {
+            throw IllegalArgumentException("Only draft bills can be approved")
+        }
+
+        val apAccount =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
+                IllegalStateException("Accounts Payable account (2000) not found")
+            }
+
+        val journalLines = mutableListOf<JournalEntryLine>()
+
+        bill.lines.forEach { line ->
+            journalLines.add(
+                JournalEntryLine(
+                    accountId = line.accountId,
+                    accountCode = line.accountCode,
+                    accountName = line.accountName,
+                    debit = line.amount,
+                    credit = BigDecimal.ZERO,
+                    description = line.description,
+                ),
+            )
+        }
+
+        journalLines.add(
+            JournalEntryLine(
+                accountId = apAccount.id,
+                accountCode = apAccount.code,
+                accountName = apAccount.name,
+                debit = BigDecimal.ZERO,
+                credit = bill.totalAmount,
+                description = "AP - ${bill.vendorName} - ${bill.billNumber}",
+            ),
+        )
+
+        val journalEntry =
+            entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
+                JournalEntry(
+                    entryNumber = entryNumber,
+                    date = bill.date,
+                    description = "Bill ${bill.billNumber} - ${bill.vendorName}",
+                    organizationId = organizationId,
+                    status = JournalEntryStatus.POSTED,
+                    source = JournalEntrySource.SYSTEM,
+                    sourceReference = "BILL-APPROVE-${bill.id}",
+                    lines = journalLines,
+                    createdBy = approvedBy,
+                    postedAt = LocalDateTime.now(),
+                )
+            }
+
+        return billRepository.save(
+            bill.copy(
+                status = BillStatus.APPROVED,
+                journalEntryId = journalEntry.id,
+                approvedAt = LocalDateTime.now(),
+                approvedBy = approvedBy,
+            ),
+        )
+    }
+
+    @Transactional
+    fun voidBill(
+        billId: String,
+        organizationId: String,
+        reason: String,
+        voidedBy: String,
+    ): Bill {
+        val bill = getBill(billId, organizationId)
+
+        if (bill.status == BillStatus.VOID) {
+            throw IllegalArgumentException("Bill is already voided")
+        }
+        if (bill.status == BillStatus.DRAFT) {
+            return billRepository.save(
+                bill.copy(
+                    status = BillStatus.VOID,
+                    voidedAt = LocalDateTime.now(),
+                    voidReason = reason,
+                ),
+            )
+        }
+        if (bill.amountPaid.compareTo(BigDecimal.ZERO) != 0) {
+            throw IllegalArgumentException("Cannot void a bill with recorded payments")
+        }
+
+        val apAccount =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
+                IllegalStateException("Accounts Payable account (2000) not found")
+            }
+
+        val reversingLines = mutableListOf<JournalEntryLine>()
+
+        bill.lines.forEach { line ->
+            reversingLines.add(
+                JournalEntryLine(
+                    accountId = line.accountId,
+                    accountCode = line.accountCode,
+                    accountName = line.accountName,
+                    debit = BigDecimal.ZERO,
+                    credit = line.amount,
+                    description = "Void: ${line.description ?: ""}".trim(),
+                ),
+            )
+        }
+
+        reversingLines.add(
+            JournalEntryLine(
+                accountId = apAccount.id,
+                accountCode = apAccount.code,
+                accountName = apAccount.name,
+                debit = bill.totalAmount,
+                credit = BigDecimal.ZERO,
+                description = "Void AP - ${bill.vendorName} - ${bill.billNumber}",
+            ),
+        )
+
+        entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
+            JournalEntry(
+                entryNumber = entryNumber,
+                date = bill.date,
+                description = "Void bill ${bill.billNumber} - ${bill.vendorName}",
+                organizationId = organizationId,
+                status = JournalEntryStatus.POSTED,
+                source = JournalEntrySource.SYSTEM,
+                sourceReference = "BILL-VOID-${bill.id}",
+                lines = reversingLines,
+                createdBy = voidedBy,
+                postedAt = LocalDateTime.now(),
+            )
+        }
+
+        return billRepository.save(
+            bill.copy(
+                status = BillStatus.VOID,
+                voidedAt = LocalDateTime.now(),
+                voidReason = reason,
+            ),
+        )
+    }
+
+    @Transactional
+    fun recordPayment(
+        billId: String,
+        request: RecordPaymentRequest,
+        organizationId: String,
+        createdBy: String,
+    ): BillPayment {
+        val bill = getBill(billId, organizationId)
+
+        if (bill.status != BillStatus.APPROVED && bill.status != BillStatus.PARTIALLY_PAID) {
+            throw IllegalArgumentException("Bill must be approved or partially paid to record payment")
+        }
+
+        val remaining = bill.totalAmount.subtract(bill.amountPaid)
+        if (request.amount.compareTo(remaining) > 0) {
+            throw IllegalArgumentException(
+                "Payment amount exceeds remaining balance of $remaining",
+            )
+        }
+
+        val apAccount =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
+                IllegalStateException("Accounts Payable account (2000) not found")
+            }
+        val cashAccount =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "1000").orElseThrow {
+                IllegalStateException("Cash account (1000) not found")
+            }
+
+        val journalEntry =
+            entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
+                JournalEntry(
+                    entryNumber = entryNumber,
+                    date = request.paymentDate,
+                    description = "Payment for bill ${bill.billNumber} - ${bill.vendorName}",
+                    organizationId = organizationId,
+                    status = JournalEntryStatus.POSTED,
+                    source = JournalEntrySource.SYSTEM,
+                    sourceReference = "BILL-PAYMENT-${bill.id}",
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = apAccount.id,
+                                accountCode = apAccount.code,
+                                accountName = apAccount.name,
+                                debit = request.amount,
+                                credit = BigDecimal.ZERO,
+                                description = "Payment - ${bill.vendorName}",
+                            ),
+                            JournalEntryLine(
+                                accountId = cashAccount.id,
+                                accountCode = cashAccount.code,
+                                accountName = cashAccount.name,
+                                debit = BigDecimal.ZERO,
+                                credit = request.amount,
+                                description = "Payment - ${bill.vendorName}",
+                            ),
+                        ),
+                    createdBy = createdBy,
+                    postedAt = LocalDateTime.now(),
+                )
+            }
+
+        val payment =
+            billPaymentRepository.save(
+                BillPayment(
+                    billId = bill.id,
+                    paymentDate = request.paymentDate,
+                    amount = request.amount,
+                    paymentMethod = request.paymentMethod,
+                    referenceNumber = request.referenceNumber,
+                    journalEntryId = journalEntry.id,
+                    organizationId = organizationId,
+                    createdBy = createdBy,
+                ),
+            )
+
+        val newAmountPaid = bill.amountPaid.add(request.amount)
+        val fullyPaid = newAmountPaid.compareTo(bill.totalAmount) >= 0
+        val newStatus = if (fullyPaid) BillStatus.PAID else BillStatus.PARTIALLY_PAID
+
+        billRepository.save(
+            bill.copy(
+                amountPaid = newAmountPaid,
+                status = newStatus,
+                paidAt = if (fullyPaid) LocalDateTime.now() else null,
+            ),
+        )
+
+        return payment
+    }
+
+    fun getPayments(
+        billId: String,
+        organizationId: String,
+    ): List<BillPayment> {
+        getBill(billId, organizationId)
+        return billPaymentRepository.findByBillId(billId)
+    }
+
+    fun getAgingReport(
+        organizationId: String,
+        asOfDate: LocalDate = LocalDate.now(),
+    ): ApAgingReportResponse {
+        val outstandingStatuses =
+            listOf(BillStatus.APPROVED, BillStatus.PARTIALLY_PAID)
+        val bills = billRepository.findByOrganizationIdAndStatusIn(organizationId, outstandingStatuses)
+
+        val vendorBills = bills.groupBy { it.vendorId }
+
+        val vendorAgingList =
+            vendorBills.map { (_, vendorBillList) ->
+                val vendorName = vendorBillList.first().vendorName
+                val vendorId = vendorBillList.first().vendorId
+                val bucket = calculateAgingBucket(vendorBillList, asOfDate)
+                VendorAgingResponse(
+                    vendorId = vendorId,
+                    vendorName = vendorName,
+                    aging = bucket,
+                )
+            }
+
+        val totals =
+            AgingBucket(
+                current = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.current) },
+                days1to30 = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.days1to30) },
+                days31to60 = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.days31to60) },
+                days61to90 = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.days61to90) },
+                days90plus = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.days90plus) },
+                total = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.total) },
+            )
+
+        return ApAgingReportResponse(
+            asOfDate = asOfDate.toString(),
+            vendors = vendorAgingList,
+            totals = totals,
+        )
+    }
+
+    private fun calculateAgingBucket(
+        bills: List<Bill>,
+        asOfDate: LocalDate,
+    ): AgingBucket {
+        var current = BigDecimal.ZERO
+        var days1to30 = BigDecimal.ZERO
+        var days31to60 = BigDecimal.ZERO
+        var days61to90 = BigDecimal.ZERO
+        var days90plus = BigDecimal.ZERO
+
+        bills.forEach { bill ->
+            val outstanding = bill.totalAmount.subtract(bill.amountPaid)
+            val daysOverdue = ChronoUnit.DAYS.between(bill.dueDate, asOfDate)
+
+            when {
+                daysOverdue <= 0 -> current = current.add(outstanding)
+                daysOverdue <= 30 -> days1to30 = days1to30.add(outstanding)
+                daysOverdue <= 60 -> days31to60 = days31to60.add(outstanding)
+                daysOverdue <= 90 -> days61to90 = days61to90.add(outstanding)
+                else -> days90plus = days90plus.add(outstanding)
+            }
+        }
+
+        val total = current.add(days1to30).add(days31to60).add(days61to90).add(days90plus)
+        return AgingBucket(
+            current = current,
+            days1to30 = days1to30,
+            days31to60 = days31to60,
+            days61to90 = days61to90,
+            days90plus = days90plus,
+            total = total,
+        )
+    }
+
+    private fun saveBillWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildBill: (String) -> Bill,
+    ): Bill {
+        repeat(maxRetries) {
+            val count = billRepository.countByOrganizationId(organizationId)
+            val billNumber = "BILL-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return billRepository.save(buildBill(billNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) throw e
+            }
+        }
+        throw IllegalStateException("Failed to generate unique bill number")
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -5,15 +5,12 @@ import com.froilan.synectix.dto.ApAgingReportResponse
 import com.froilan.synectix.dto.CreateBillRequest
 import com.froilan.synectix.dto.RecordPaymentRequest
 import com.froilan.synectix.dto.VendorAgingResponse
+import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.Bill
 import com.froilan.synectix.model.BillLine
 import com.froilan.synectix.model.BillPayment
 import com.froilan.synectix.model.BillStatus
-import com.froilan.synectix.model.FiscalPeriodStatus
-import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
-import com.froilan.synectix.model.JournalEntrySource
-import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.BillPaymentRepository
 import com.froilan.synectix.repository.BillRepository
@@ -33,8 +30,7 @@ class BillService(
     private val billPaymentRepository: BillPaymentRepository,
     private val accountRepository: AccountRepository,
     private val vendorService: VendorService,
-    private val entryNumberGenerator: JournalEntryNumberGenerator,
-    private val fiscalYearService: FiscalYearService,
+    private val journalEntryService: JournalEntryService,
 ) {
     @Transactional
     fun createBill(
@@ -47,7 +43,7 @@ class BillService(
             throw IllegalArgumentException("Cannot create bill for inactive vendor")
         }
 
-        if (!request.date.isBefore(request.dueDate) && request.date != request.dueDate) {
+        if (request.date.isAfter(request.dueDate)) {
             throw IllegalArgumentException("Due date must be on or after bill date")
         }
 
@@ -61,7 +57,7 @@ class BillService(
             }
         }
 
-        val accountIds = request.lines.map { it.accountId }
+        val accountIds = request.lines.map { it.accountId }.distinct()
         val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
 
         val missingAccounts = accountIds.filter { it !in accounts }
@@ -150,20 +146,10 @@ class BillService(
             throw IllegalArgumentException("Only draft bills can be approved")
         }
 
-        validateFiscalPeriodOpen(organizationId, bill.date)
+        val apAccount = getApAccount(organizationId)
 
-        val apAccount =
-            accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
-                IllegalStateException("Accounts Payable account (2000) not found")
-            }
-        if (!apAccount.isActive) {
-            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
-        }
-
-        val journalLines = mutableListOf<JournalEntryLine>()
-
-        bill.lines.forEach { line ->
-            journalLines.add(
+        val journalLines =
+            bill.lines.map { line ->
                 JournalEntryLine(
                     accountId = line.accountId,
                     accountCode = line.accountCode,
@@ -171,39 +157,28 @@ class BillService(
                     debit = line.amount,
                     credit = BigDecimal.ZERO,
                     description = line.description,
-                ),
-            )
-        }
-
-        journalLines.add(
-            JournalEntryLine(
-                accountId = apAccount.id,
-                accountCode = apAccount.code,
-                accountName = apAccount.name,
-                debit = BigDecimal.ZERO,
-                credit = bill.totalAmount,
-                description = "AP - ${bill.vendorName} - ${bill.billNumber}",
-            ),
-        )
-
-        val now = LocalDateTime.now(ZoneOffset.UTC)
+                )
+            } +
+                JournalEntryLine(
+                    accountId = apAccount.id,
+                    accountCode = apAccount.code,
+                    accountName = apAccount.name,
+                    debit = BigDecimal.ZERO,
+                    credit = bill.totalAmount,
+                    description = "AP - ${bill.vendorName} - ${bill.billNumber}",
+                )
 
         val journalEntry =
-            entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
-                JournalEntry(
-                    entryNumber = entryNumber,
-                    date = bill.date,
-                    description = "Bill ${bill.billNumber} - ${bill.vendorName}",
-                    organizationId = organizationId,
-                    status = JournalEntryStatus.POSTED,
-                    source = JournalEntrySource.SYSTEM,
-                    sourceReference = "BILL-APPROVE-${bill.id}",
-                    lines = journalLines,
-                    createdBy = approvedBy,
-                    postedAt = now,
-                )
-            }
+            journalEntryService.createSystemEntry(
+                date = bill.date,
+                description = "Bill ${bill.billNumber} - ${bill.vendorName}",
+                organizationId = organizationId,
+                lines = journalLines,
+                sourceReference = "BILL-APPROVE-${bill.id}",
+                createdBy = approvedBy,
+            )
 
+        val now = LocalDateTime.now(ZoneOffset.UTC)
         return billRepository.save(
             bill.copy(
                 status = BillStatus.APPROVED,
@@ -242,55 +217,11 @@ class BillService(
             throw IllegalArgumentException("Cannot void a bill with recorded payments")
         }
 
-        val voidDate = LocalDate.now(ZoneOffset.UTC)
-        validateFiscalPeriodOpen(organizationId, voidDate)
-
-        val apAccount =
-            accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
-                IllegalStateException("Accounts Payable account (2000) not found")
-            }
-        if (!apAccount.isActive) {
-            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
-        }
-
-        val reversingLines = mutableListOf<JournalEntryLine>()
-
-        bill.lines.forEach { line ->
-            reversingLines.add(
-                JournalEntryLine(
-                    accountId = line.accountId,
-                    accountCode = line.accountCode,
-                    accountName = line.accountName,
-                    debit = BigDecimal.ZERO,
-                    credit = line.amount,
-                    description = "Void: ${line.description ?: ""}".trim(),
-                ),
-            )
-        }
-
-        reversingLines.add(
-            JournalEntryLine(
-                accountId = apAccount.id,
-                accountCode = apAccount.code,
-                accountName = apAccount.name,
-                debit = bill.totalAmount,
-                credit = BigDecimal.ZERO,
-                description = "Void AP - ${bill.vendorName} - ${bill.billNumber}",
-            ),
-        )
-
-        entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
-            JournalEntry(
-                entryNumber = entryNumber,
-                date = voidDate,
-                description = "Void bill ${bill.billNumber} - ${bill.vendorName}",
-                organizationId = organizationId,
-                status = JournalEntryStatus.POSTED,
-                source = JournalEntrySource.SYSTEM,
-                sourceReference = "BILL-VOID-${bill.id}",
-                lines = reversingLines,
-                createdBy = voidedBy,
-                postedAt = now,
+        if (bill.journalEntryId != null) {
+            journalEntryService.voidJournalEntry(
+                bill.journalEntryId,
+                organizationId,
+                reason,
             )
         }
 
@@ -327,58 +258,38 @@ class BillService(
             )
         }
 
-        validateFiscalPeriodOpen(organizationId, request.paymentDate)
-
-        val apAccount =
-            accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
-                IllegalStateException("Accounts Payable account (2000) not found")
-            }
-        if (!apAccount.isActive) {
-            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
-        }
-        val cashAccount =
-            accountRepository.findByOrganizationIdAndCode(organizationId, "1000").orElseThrow {
-                IllegalStateException("Cash account (1000) not found")
-            }
-        if (!cashAccount.isActive) {
-            throw IllegalArgumentException("Cash account (1000) is inactive")
-        }
+        val apAccount = getApAccount(organizationId)
+        val cashAccount = getCashAccount(organizationId)
 
         val paymentId = UUID.randomUUID().toString()
 
         val journalEntry =
-            entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
-                JournalEntry(
-                    entryNumber = entryNumber,
-                    date = request.paymentDate,
-                    description = "Payment for bill ${bill.billNumber} - ${bill.vendorName}",
-                    organizationId = organizationId,
-                    status = JournalEntryStatus.POSTED,
-                    source = JournalEntrySource.SYSTEM,
-                    sourceReference = "BILL-PAYMENT-$paymentId",
-                    lines =
-                        listOf(
-                            JournalEntryLine(
-                                accountId = apAccount.id,
-                                accountCode = apAccount.code,
-                                accountName = apAccount.name,
-                                debit = request.amount,
-                                credit = BigDecimal.ZERO,
-                                description = "Payment - ${bill.vendorName}",
-                            ),
-                            JournalEntryLine(
-                                accountId = cashAccount.id,
-                                accountCode = cashAccount.code,
-                                accountName = cashAccount.name,
-                                debit = BigDecimal.ZERO,
-                                credit = request.amount,
-                                description = "Payment - ${bill.vendorName}",
-                            ),
+            journalEntryService.createSystemEntry(
+                date = request.paymentDate,
+                description = "Payment for bill ${bill.billNumber} - ${bill.vendorName}",
+                organizationId = organizationId,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = apAccount.id,
+                            accountCode = apAccount.code,
+                            accountName = apAccount.name,
+                            debit = request.amount,
+                            credit = BigDecimal.ZERO,
+                            description = "Payment - ${bill.vendorName}",
                         ),
-                    createdBy = createdBy,
-                    postedAt = LocalDateTime.now(ZoneOffset.UTC),
-                )
-            }
+                        JournalEntryLine(
+                            accountId = cashAccount.id,
+                            accountCode = cashAccount.code,
+                            accountName = cashAccount.name,
+                            debit = BigDecimal.ZERO,
+                            credit = request.amount,
+                            description = "Payment - ${bill.vendorName}",
+                        ),
+                    ),
+                sourceReference = "BILL-PAYMENT-$paymentId",
+                createdBy = createdBy,
+            )
 
         val payment =
             billPaymentRepository.save(
@@ -515,19 +426,25 @@ class BillService(
         throw IllegalStateException("Failed to generate unique bill number")
     }
 
-    private fun validateFiscalPeriodOpen(
-        organizationId: String,
-        date: LocalDate,
-    ) {
-        when (val result = fiscalYearService.findPeriodForDate(organizationId, date)) {
-            is FiscalYearService.PeriodLookupResult.NoFiscalYears -> return
-            is FiscalYearService.PeriodLookupResult.NotFound ->
-                throw IllegalArgumentException("No fiscal period covers the date $date")
-            is FiscalYearService.PeriodLookupResult.Found -> {
-                if (result.period.status == FiscalPeriodStatus.CLOSED) {
-                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
-                }
+    private fun getApAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
+                IllegalStateException("Accounts Payable account (2000) not found")
             }
+        if (!account.isActive) {
+            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
         }
+        return account
+    }
+
+    private fun getCashAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "1000").orElseThrow {
+                IllegalStateException("Cash account (1000) not found")
+            }
+        if (!account.isActive) {
+            throw IllegalArgumentException("Cash account (1000) is inactive")
+        }
+        return account
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -51,6 +51,16 @@ class BillService(
             throw IllegalArgumentException("Due date must be on or after bill date")
         }
 
+        if (request.lines.isEmpty()) {
+            throw IllegalArgumentException("At least one line item is required")
+        }
+
+        request.lines.forEach { line ->
+            if (line.amount <= BigDecimal.ZERO) {
+                throw IllegalArgumentException("Line item amounts must be positive")
+            }
+        }
+
         val accountIds = request.lines.map { it.accountId }
         val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
 
@@ -232,7 +242,7 @@ class BillService(
             throw IllegalArgumentException("Cannot void a bill with recorded payments")
         }
 
-        val voidDate = LocalDate.now()
+        val voidDate = LocalDate.now(ZoneOffset.UTC)
         validateFiscalPeriodOpen(organizationId, voidDate)
 
         val apAccount =
@@ -304,6 +314,10 @@ class BillService(
 
         if (bill.status != BillStatus.APPROVED && bill.status != BillStatus.PARTIALLY_PAID) {
             throw IllegalArgumentException("Bill must be approved or partially paid to record payment")
+        }
+
+        if (request.amount <= BigDecimal.ZERO) {
+            throw IllegalArgumentException("Payment amount must be positive")
         }
 
         val remaining = bill.totalAmount.subtract(bill.amountPaid)
@@ -406,7 +420,7 @@ class BillService(
 
     fun getAgingReport(
         organizationId: String,
-        asOfDate: LocalDate = LocalDate.now(),
+        asOfDate: LocalDate = LocalDate.now(ZoneOffset.UTC),
     ): ApAgingReportResponse {
         val outstandingStatuses =
             listOf(BillStatus.APPROVED, BillStatus.PARTIALLY_PAID)

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -72,6 +72,7 @@ class FiscalYearService(
         } catch (e: DuplicateKeyException) {
             throw IllegalArgumentException(
                 "Fiscal year '${request.name}' already exists in this organization",
+                e,
             )
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.format.TextStyle
 import java.util.Locale
 
@@ -117,7 +118,7 @@ class FiscalYearService(
         updatedPeriods[periodIndex] =
             period.copy(
                 status = FiscalPeriodStatus.CLOSED,
-                closedAt = LocalDateTime.now(),
+                closedAt = LocalDateTime.now(ZoneOffset.UTC),
                 closedBy = closedBy,
             )
 
@@ -161,7 +162,7 @@ class FiscalYearService(
         updatedPeriods[periodIndex] =
             period.copy(
                 status = FiscalPeriodStatus.REOPENED,
-                reopenedAt = LocalDateTime.now(),
+                reopenedAt = LocalDateTime.now(ZoneOffset.UTC),
                 reopenedBy = reopenedBy,
             )
 
@@ -192,7 +193,7 @@ class FiscalYearService(
         return fiscalYearRepository.save(
             fiscalYear.copy(
                 status = FiscalYearStatus.CLOSED,
-                closedAt = LocalDateTime.now(),
+                closedAt = LocalDateTime.now(ZoneOffset.UTC),
                 closedBy = closedBy,
                 closingEntryId = closingEntry?.id,
             ),
@@ -344,7 +345,7 @@ class FiscalYearService(
                 sourceReference = sourceRef,
                 lines = closingLines,
                 createdBy = closedBy,
-                postedAt = LocalDateTime.now(),
+                postedAt = LocalDateTime.now(ZoneOffset.UTC),
             )
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -218,6 +218,22 @@ class FiscalYearService(
         return PeriodLookupResult.NotFound
     }
 
+    fun validatePeriodOpen(
+        organizationId: String,
+        date: LocalDate,
+    ) {
+        when (val result = findPeriodForDate(organizationId, date)) {
+            is PeriodLookupResult.NoFiscalYears -> return
+            is PeriodLookupResult.NotFound ->
+                throw IllegalArgumentException("No fiscal period covers the date $date")
+            is PeriodLookupResult.Found -> {
+                if (result.period.status == FiscalPeriodStatus.CLOSED) {
+                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
+                }
+            }
+        }
+    }
+
     sealed class PeriodLookupResult {
         data object NoFiscalYears : PeriodLookupResult()
 

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -80,7 +80,7 @@ class InvitationService(
         try {
             invitationRepository.save(invitation)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException("An invitation has already been sent to this email")
+            throw IllegalArgumentException("An invitation has already been sent to this email", e)
         }
 
         return rawToken
@@ -176,11 +176,11 @@ class InvitationService(
             val errorMessage = e.message ?: ""
             when {
                 errorMessage.contains("username", ignoreCase = true) ->
-                    throw IllegalArgumentException("Username already exists")
+                    throw IllegalArgumentException("Username already exists", e)
                 errorMessage.contains("email", ignoreCase = true) ->
-                    throw IllegalArgumentException("Email already exists")
+                    throw IllegalArgumentException("Email already exists", e)
                 else ->
-                    throw IllegalArgumentException("Account could not be created")
+                    throw IllegalArgumentException("Account could not be created", e)
             }
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -23,6 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Locale
 
 @Service
@@ -60,7 +61,7 @@ class InvitationService(
             )
         if (existing.isPresent) {
             val pendingInvitation = existing.get()
-            if (pendingInvitation.expiryAt.isAfter(LocalDateTime.now())) {
+            if (pendingInvitation.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
                 throw IllegalArgumentException("An invitation has already been sent to this email")
             }
             invitationRepository.save(pendingInvitation.copy(status = InvitationStatus.EXPIRED))
@@ -74,7 +75,7 @@ class InvitationService(
                 role = role.name,
                 tokenHash = tokenHasher.hash(rawToken),
                 invitedBy = inviter.uuid,
-                expiryAt = LocalDateTime.now().plusHours(invitationExpiryHours),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(invitationExpiryHours),
             )
         try {
             invitationRepository.save(invitation)
@@ -91,7 +92,7 @@ class InvitationService(
             invitationRepository.findByTokenHash(tokenHash).orElseThrow {
                 IllegalArgumentException("Invalid or expired invitation token")
             }
-        if (invitation.status != InvitationStatus.PENDING || !invitation.expiryAt.isAfter(LocalDateTime.now())) {
+        if (invitation.status != InvitationStatus.PENDING || !invitation.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
             throw IllegalArgumentException("Invalid or expired invitation token")
         }
         val existingUser = userRepository.findByEmail(invitation.email).isPresent
@@ -116,7 +117,7 @@ class InvitationService(
                         .and("status")
                         .`is`(InvitationStatus.PENDING)
                         .and("expiryAt")
-                        .gt(LocalDateTime.now()),
+                        .gt(LocalDateTime.now(ZoneOffset.UTC)),
                 ),
                 Update.update("status", InvitationStatus.ACCEPTED),
                 FindAndModifyOptions.options().returnNew(true),
@@ -206,6 +207,6 @@ class InvitationService(
         invitationRepository.findByOrganizationIdAndStatusAndExpiryAtAfter(
             organizationId,
             InvitationStatus.PENDING,
-            LocalDateTime.now(),
+            LocalDateTime.now(ZoneOffset.UTC),
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
@@ -20,7 +20,9 @@ class JournalEntryNumberGenerator(
             try {
                 return journalEntryRepository.save(buildEntry(entryNumber))
             } catch (e: DuplicateKeyException) {
-                if (it == maxRetries - 1) throw e
+                if (it == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique entry number")
+                }
             }
         }
         throw IllegalStateException("Failed to generate unique entry number")

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
@@ -21,7 +21,7 @@ class JournalEntryNumberGenerator(
                 return journalEntryRepository.save(buildEntry(entryNumber))
             } catch (e: DuplicateKeyException) {
                 if (it == maxRetries - 1) {
-                    throw IllegalStateException("Failed to generate unique entry number")
+                    throw IllegalStateException("Failed to generate unique entry number: $entryNumber", e)
                 }
             }
         }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @Service
 class JournalEntryService(
@@ -116,7 +117,7 @@ class JournalEntryService(
         return journalEntryRepository.save(
             entry.copy(
                 status = JournalEntryStatus.POSTED,
-                postedAt = LocalDateTime.now(),
+                postedAt = LocalDateTime.now(ZoneOffset.UTC),
             ),
         )
     }
@@ -136,7 +137,7 @@ class JournalEntryService(
             journalEntryRepository.save(
                 entry.copy(
                     status = JournalEntryStatus.VOIDED,
-                    voidedAt = LocalDateTime.now(),
+                    voidedAt = LocalDateTime.now(ZoneOffset.UTC),
                     voidReason = reason,
                 ),
             )
@@ -157,7 +158,7 @@ class JournalEntryService(
                 sourceReference = "VOID-${entry.id}",
                 lines = reversedLines,
                 createdBy = entry.createdBy,
-                postedAt = LocalDateTime.now(),
+                postedAt = LocalDateTime.now(ZoneOffset.UTC),
             )
         }
 

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -150,7 +150,7 @@ class JournalEntryService(
         entryNumberGenerator.saveWithRetry(organizationId) { reversingNumber ->
             JournalEntry(
                 entryNumber = reversingNumber,
-                date = LocalDate.now(),
+                date = LocalDate.now(ZoneOffset.UTC),
                 description = "Reversal of ${entry.entryNumber}: $reason",
                 organizationId = organizationId,
                 status = JournalEntryStatus.POSTED,

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -4,7 +4,6 @@ import com.froilan.synectix.dto.AccountBalanceResponse
 import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.TrialBalanceResponse
 import com.froilan.synectix.model.AccountType
-import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
@@ -92,6 +91,40 @@ class JournalEntryService(
                 lines = lines,
                 createdBy = createdBy,
                 sourceReference = request.sourceReference,
+            )
+        }
+    }
+
+    @Transactional
+    fun createSystemEntry(
+        date: LocalDate,
+        description: String,
+        organizationId: String,
+        lines: List<JournalEntryLine>,
+        sourceReference: String,
+        createdBy: String,
+    ): JournalEntry {
+        val totalDebits = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
+        val totalCredits = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
+        if (totalDebits.compareTo(totalCredits) != 0) {
+            throw IllegalArgumentException("System journal entry is not balanced")
+        }
+
+        validateFiscalPeriodOpen(organizationId, date)
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        return entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
+            JournalEntry(
+                entryNumber = entryNumber,
+                date = date,
+                description = description,
+                organizationId = organizationId,
+                status = JournalEntryStatus.POSTED,
+                source = JournalEntrySource.SYSTEM,
+                sourceReference = sourceReference,
+                lines = lines,
+                createdBy = createdBy,
+                postedAt = now,
             )
         }
     }
@@ -327,16 +360,5 @@ class JournalEntryService(
     private fun validateFiscalPeriodOpen(
         organizationId: String,
         date: LocalDate,
-    ) {
-        when (val result = fiscalYearService.findPeriodForDate(organizationId, date)) {
-            is FiscalYearService.PeriodLookupResult.NoFiscalYears -> return
-            is FiscalYearService.PeriodLookupResult.NotFound ->
-                throw IllegalArgumentException("No fiscal period covers the date $date")
-            is FiscalYearService.PeriodLookupResult.Found -> {
-                if (result.period.status == FiscalPeriodStatus.CLOSED) {
-                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
-                }
-            }
-        }
-    }
+    ) = fiscalYearService.validatePeriodOpen(organizationId, date)
 }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -175,6 +175,9 @@ class JournalEntryService(
                 ),
             )
 
+        val reversalDate = LocalDate.now(ZoneOffset.UTC)
+        validateFiscalPeriodOpen(organizationId, reversalDate)
+
         val reversedLines =
             entry.lines.map { line ->
                 line.copy(debit = line.credit, credit = line.debit)
@@ -183,7 +186,7 @@ class JournalEntryService(
         entryNumberGenerator.saveWithRetry(organizationId) { reversingNumber ->
             JournalEntry(
                 entryNumber = reversingNumber,
-                date = LocalDate.now(ZoneOffset.UTC),
+                date = reversalDate,
                 description = "Reversal of ${entry.entryNumber}: $reason",
                 organizationId = organizationId,
                 status = JournalEntryStatus.POSTED,

--- a/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
@@ -33,6 +33,7 @@ class VendorService(
         } catch (e: DuplicateKeyException) {
             throw IllegalArgumentException(
                 "Vendor '${request.name}' already exists in this organization",
+                e,
             )
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
@@ -65,6 +65,10 @@ class VendorService(
             throw IllegalArgumentException("Cannot update inactive vendor")
         }
 
+        if (request.name != null && request.name.isBlank()) {
+            throw IllegalArgumentException("Vendor name cannot be blank")
+        }
+
         val updated =
             vendor.copy(
                 name = request.name ?: vendor.name,

--- a/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
@@ -85,6 +85,7 @@ class VendorService(
         } catch (e: DuplicateKeyException) {
             throw IllegalArgumentException(
                 "Vendor '${updated.name}' already exists in this organization",
+                e,
             )
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
@@ -51,8 +51,7 @@ class VendorService(
         return vendor
     }
 
-    fun listVendors(organizationId: String): List<Vendor> =
-        vendorRepository.findByOrganizationIdAndIsActive(organizationId, true)
+    fun listVendors(organizationId: String): List<Vendor> = vendorRepository.findByOrganizationIdAndIsActive(organizationId, true)
 
     @Transactional
     fun updateVendor(

--- a/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
@@ -1,0 +1,101 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateVendorRequest
+import com.froilan.synectix.dto.UpdateVendorRequest
+import com.froilan.synectix.model.Vendor
+import com.froilan.synectix.repository.VendorRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class VendorService(
+    private val vendorRepository: VendorRepository,
+) {
+    @Transactional
+    fun createVendor(
+        request: CreateVendorRequest,
+        organizationId: String,
+    ): Vendor {
+        val vendor =
+            Vendor(
+                name = request.name,
+                contactName = request.contactName,
+                contactEmail = request.contactEmail,
+                contactPhone = request.contactPhone,
+                paymentTermDays = request.paymentTermDays,
+                defaultExpenseAccountId = request.defaultExpenseAccountId,
+                organizationId = organizationId,
+            )
+
+        return try {
+            vendorRepository.save(vendor)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Vendor '${request.name}' already exists in this organization",
+            )
+        }
+    }
+
+    fun getVendor(
+        vendorId: String,
+        organizationId: String,
+    ): Vendor {
+        val vendor =
+            vendorRepository.findById(vendorId).orElseThrow {
+                IllegalArgumentException("Vendor not found")
+            }
+        if (vendor.organizationId != organizationId) {
+            throw IllegalArgumentException("Vendor not found")
+        }
+        return vendor
+    }
+
+    fun listVendors(organizationId: String): List<Vendor> =
+        vendorRepository.findByOrganizationIdAndIsActive(organizationId, true)
+
+    @Transactional
+    fun updateVendor(
+        vendorId: String,
+        request: UpdateVendorRequest,
+        organizationId: String,
+    ): Vendor {
+        val vendor = getVendor(vendorId, organizationId)
+
+        if (!vendor.isActive) {
+            throw IllegalArgumentException("Cannot update inactive vendor")
+        }
+
+        val updated =
+            vendor.copy(
+                name = request.name ?: vendor.name,
+                contactName = request.contactName ?: vendor.contactName,
+                contactEmail = request.contactEmail ?: vendor.contactEmail,
+                contactPhone = request.contactPhone ?: vendor.contactPhone,
+                paymentTermDays = request.paymentTermDays ?: vendor.paymentTermDays,
+                defaultExpenseAccountId = request.defaultExpenseAccountId ?: vendor.defaultExpenseAccountId,
+            )
+
+        return try {
+            vendorRepository.save(updated)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Vendor '${updated.name}' already exists in this organization",
+            )
+        }
+    }
+
+    @Transactional
+    fun deleteVendor(
+        vendorId: String,
+        organizationId: String,
+    ): Vendor {
+        val vendor = getVendor(vendorId, organizationId)
+
+        if (!vendor.isActive) {
+            throw IllegalArgumentException("Vendor is already inactive")
+        }
+
+        return vendorRepository.save(vendor.copy(isActive = false))
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -76,6 +76,11 @@ class RoleSeederTest {
                         Permissions.FISCAL_CREATE,
                         Permissions.FISCAL_READ,
                         Permissions.FISCAL_CLOSE,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
+                        Permissions.AP_APPROVE,
+                        Permissions.AP_PAY,
+                        Permissions.AP_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -144,6 +149,11 @@ class RoleSeederTest {
                         Permissions.FISCAL_CREATE,
                         Permissions.FISCAL_READ,
                         Permissions.FISCAL_CLOSE,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
+                        Permissions.AP_APPROVE,
+                        Permissions.AP_PAY,
+                        Permissions.AP_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -239,6 +249,11 @@ class RoleSeederTest {
                         Permissions.FISCAL_CREATE,
                         Permissions.FISCAL_READ,
                         Permissions.FISCAL_CLOSE,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
+                        Permissions.AP_APPROVE,
+                        Permissions.AP_PAY,
+                        Permissions.AP_VOID,
                     ),
             )
         val admin =
@@ -266,6 +281,10 @@ class RoleSeederTest {
                         Permissions.FISCAL_CREATE,
                         Permissions.FISCAL_READ,
                         Permissions.FISCAL_CLOSE,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
+                        Permissions.AP_APPROVE,
+                        Permissions.AP_PAY,
                     ),
             )
         val member =
@@ -284,6 +303,8 @@ class RoleSeederTest {
                         Permissions.JOURNAL_CREATE,
                         Permissions.JOURNAL_READ,
                         Permissions.FISCAL_READ,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
                     ),
             )
         val viewer =
@@ -298,6 +319,7 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.JOURNAL_READ,
                         Permissions.FISCAL_READ,
+                        Permissions.AP_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -41,6 +41,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @WebMvcTest(controllers = [AuthController::class])
 @Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
@@ -288,8 +289,8 @@ class AuthControllerTest {
                 username = "testuser",
                 roles = listOf("OWNER"),
                 organizationId = "org-123",
-                expiresAt = LocalDateTime.now().plusHours(24).toString(),
-                refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(24).toString(),
+                refreshTokenExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30).toString(),
             )
 
         `when`(authService.login(any<LoginRequest>(), anyOrNull(), anyOrNull())).thenReturn(authResponse)
@@ -402,8 +403,8 @@ class AuthControllerTest {
                 username = "testuser",
                 roles = listOf("OWNER"),
                 organizationId = "org-123",
-                expiresAt = LocalDateTime.now().plusHours(24).toString(),
-                refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(24).toString(),
+                refreshTokenExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30).toString(),
             )
 
         `when`(authService.refresh(any<String>())).thenReturn(authResponse)
@@ -700,8 +701,8 @@ class AuthControllerTest {
                 username = "testuser",
                 roles = listOf("MEMBER"),
                 organizationId = "org-456",
-                expiresAt = LocalDateTime.now().plusHours(24).toString(),
-                refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(24).toString(),
+                refreshTokenExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30).toString(),
             )
         `when`(authService.switchOrganization(any(), any(), anyOrNull(), anyOrNull())).thenReturn(switchResponse)
 

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -38,6 +38,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @WebMvcTest(controllers = [InvitationController::class])
 @Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
@@ -160,7 +161,7 @@ class InvitationControllerTest {
                     role = "MEMBER",
                     tokenHash = "hash1",
                     invitedBy = "user-123",
-                    expiryAt = LocalDateTime.now().plusHours(72),
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(72),
                 ),
             )
         `when`(invitationService.listInvitations("org-123")).thenReturn(invitations)

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @WebMvcTest(controllers = [SessionController::class])
 @Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
@@ -106,7 +107,7 @@ class SessionControllerTest {
                     id = "s1",
                     token = currentToken,
                     userId = testUser.uuid,
-                    expiryAt = LocalDateTime.now().plusHours(12),
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12),
                     ipAddress = "127.0.0.1",
                     userAgent = "Mozilla/5.0",
                 ),
@@ -114,7 +115,7 @@ class SessionControllerTest {
                     id = "s2",
                     token = "other-token",
                     userId = testUser.uuid,
-                    expiryAt = LocalDateTime.now().plusHours(6),
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(6),
                     ipAddress = "192.168.1.1",
                     userAgent = "Chrome",
                 ),

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.springframework.data.mongodb.core.MongoTemplate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Optional
 
 class ApiKeyServiceTest {
@@ -132,7 +133,7 @@ class ApiKeyServiceTest {
 
     @Test
     fun `authenticateByApiKey should return null for expired key`() {
-        val apiKey = createMockApiKey(expiresAt = LocalDateTime.now().minusHours(1))
+        val apiKey = createMockApiKey(expiresAt = LocalDateTime.now(ZoneOffset.UTC).minusHours(1))
         `when`(apiKeyRepository.findByKeyHash("hashed-expired-key")).thenReturn(Optional.of(apiKey))
 
         val result = apiKeyService.authenticateByApiKey("expired-key")

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -31,6 +31,7 @@ import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Optional
 import java.util.UUID
 
@@ -255,7 +256,7 @@ class AuthServiceTest {
         assertThat(result.accessToken).isNotNull().isNotEmpty()
         assertThat(result.refreshToken).isNotNull().isNotEmpty()
 
-        val expectedRefreshExpiry = LocalDateTime.now().plusDays(30)
+        val expectedRefreshExpiry = LocalDateTime.now(ZoneOffset.UTC).plusDays(30)
         val actualRefreshExpiry = LocalDateTime.parse(result.refreshTokenExpiresAt)
         assertThat(actualRefreshExpiry).isAfter(expectedRefreshExpiry.minusMinutes(1))
         assertThat(actualRefreshExpiry).isBefore(expectedRefreshExpiry.plusMinutes(1))
@@ -306,7 +307,7 @@ class AuthServiceTest {
         val capturedToken = tokenCaptor.firstValue
         assertThat(capturedToken.userId).isEqualTo(user.uuid)
 
-        val expectedExpiry = LocalDateTime.now().plusHours(24)
+        val expectedExpiry = LocalDateTime.now(ZoneOffset.UTC).plusHours(24)
         val actualExpiry = capturedToken.expiryAt
         assertThat(actualExpiry).isAfter(expectedExpiry.minusMinutes(1))
         assertThat(actualExpiry).isBefore(expectedExpiry.plusMinutes(1))
@@ -355,7 +356,7 @@ class AuthServiceTest {
                 tokenHash = oldRefreshTokenHash,
                 userId = user.uuid,
                 sessionTokenId = oldSessionToken.id,
-                expiryAt = LocalDateTime.now().plusDays(30),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30),
             )
 
         `when`(refreshTokenRepository.findByTokenHash(oldRefreshTokenHash)).thenReturn(Optional.of(existingRefreshToken))
@@ -383,7 +384,7 @@ class AuthServiceTest {
                 tokenHash = expiredTokenHash,
                 userId = "user-123",
                 sessionTokenId = "session-123",
-                expiryAt = LocalDateTime.now().minusHours(1),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).minusHours(1),
             )
 
         `when`(refreshTokenRepository.findByTokenHash(expiredTokenHash)).thenReturn(Optional.of(expiredRefreshToken))
@@ -419,7 +420,7 @@ class AuthServiceTest {
                 tokenHash = refreshTokenHash,
                 userId = inactiveUser.uuid,
                 sessionTokenId = "session-123",
-                expiryAt = LocalDateTime.now().plusDays(30),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30),
             )
 
         `when`(refreshTokenRepository.findByTokenHash(refreshTokenHash)).thenReturn(Optional.of(existingRefreshToken))
@@ -461,7 +462,8 @@ class AuthServiceTest {
     @Test
     fun `listSessions should return only non-expired sessions`() {
         val userId = "user-123"
-        val activeSession = SessionToken(id = "s1", token = "t1", userId = userId, expiryAt = LocalDateTime.now().plusHours(12))
+        val activeSession =
+            SessionToken(id = "s1", token = "t1", userId = userId, expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12))
         `when`(sessionTokenRepository.findByUserIdAndExpiryAtAfter(eq(userId), any())).thenReturn(listOf(activeSession))
 
         val result = authService.listSessions(userId)
@@ -473,7 +475,7 @@ class AuthServiceTest {
     @Test
     fun `revokeSession should delete session and its refresh token`() {
         val userId = "user-123"
-        val session = SessionToken(id = "s1", token = "t1", userId = userId, expiryAt = LocalDateTime.now().plusHours(12))
+        val session = SessionToken(id = "s1", token = "t1", userId = userId, expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12))
 
         `when`(sessionTokenRepository.findById("s1")).thenReturn(Optional.of(session))
 
@@ -485,7 +487,8 @@ class AuthServiceTest {
 
     @Test
     fun `revokeSession should throw when session belongs to different user`() {
-        val session = SessionToken(id = "s1", token = "t1", userId = "other-user", expiryAt = LocalDateTime.now().plusHours(12))
+        val session =
+            SessionToken(id = "s1", token = "t1", userId = "other-user", expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12))
 
         `when`(sessionTokenRepository.findById("s1")).thenReturn(Optional.of(session))
 
@@ -500,7 +503,8 @@ class AuthServiceTest {
     fun `revokeSession should throw when attempting to revoke the current session`() {
         val userId = "user-123"
         val currentToken = "current-token"
-        val session = SessionToken(id = "s1", token = currentToken, userId = userId, expiryAt = LocalDateTime.now().plusHours(12))
+        val session =
+            SessionToken(id = "s1", token = currentToken, userId = userId, expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12))
 
         `when`(sessionTokenRepository.findById("s1")).thenReturn(Optional.of(session))
 
@@ -517,7 +521,7 @@ class AuthServiceTest {
         val currentToken = "current-token"
         val otherSessions =
             listOf(
-                SessionToken(id = "s2", token = "other-token", userId = userId, expiryAt = LocalDateTime.now().plusHours(12)),
+                SessionToken(id = "s2", token = "other-token", userId = userId, expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12)),
             )
         `when`(sessionTokenRepository.findByUserIdAndTokenNot(userId, currentToken)).thenReturn(otherSessions)
 
@@ -608,7 +612,7 @@ class AuthServiceTest {
             PasswordResetToken(
                 tokenHash = "hashed-valid-token",
                 userId = user.uuid,
-                expiryAt = LocalDateTime.now().plusMinutes(30),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(30),
             )
 
         `when`(passwordResetTokenRepository.findByTokenHash("hashed-valid-token")).thenReturn(Optional.of(resetToken))
@@ -641,7 +645,7 @@ class AuthServiceTest {
             PasswordResetToken(
                 tokenHash = "hashed-expired-token",
                 userId = "user-123",
-                expiryAt = LocalDateTime.now().minusMinutes(10),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).minusMinutes(10),
             )
 
         `when`(passwordResetTokenRepository.findByTokenHash("hashed-expired-token"))
@@ -834,6 +838,6 @@ class AuthServiceTest {
             id = "token-123",
             token = "generated-token",
             userId = "user-123",
-            expiryAt = LocalDateTime.now().plusHours(24),
+            expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(24),
         )
 }

--- a/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
@@ -1,0 +1,409 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.BillLineRequest
+import com.froilan.synectix.dto.CreateBillRequest
+import com.froilan.synectix.dto.RecordPaymentRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.Bill
+import com.froilan.synectix.model.BillLine
+import com.froilan.synectix.model.BillPayment
+import com.froilan.synectix.model.BillStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.PaymentMethod
+import com.froilan.synectix.model.Vendor
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.BillPaymentRepository
+import com.froilan.synectix.repository.BillRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class BillServiceTest {
+    private lateinit var billService: BillService
+    private lateinit var billRepository: BillRepository
+    private lateinit var billPaymentRepository: BillPaymentRepository
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var journalEntryRepository: JournalEntryRepository
+    private lateinit var vendorService: VendorService
+    private lateinit var entryNumberGenerator: JournalEntryNumberGenerator
+
+    private val orgId = "org-123"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        billRepository = mock(BillRepository::class.java)
+        billPaymentRepository = mock(BillPaymentRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        journalEntryRepository = mock(JournalEntryRepository::class.java)
+        vendorService = mock(VendorService::class.java)
+        entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
+        billService = BillService(
+            billRepository = billRepository,
+            billPaymentRepository = billPaymentRepository,
+            accountRepository = accountRepository,
+            vendorService = vendorService,
+            entryNumberGenerator = entryNumberGenerator,
+        )
+    }
+
+    @Test
+    fun `create should save bill as DRAFT with correct total`() {
+        val vendor = createVendor()
+        val expenseAccount = createAccount("acc-1", "5000", "Office Supplies", AccountType.EXPENSE)
+
+        `when`(vendorService.getVendor("v-1", orgId)).thenReturn(vendor)
+        `when`(accountRepository.findAllById(listOf("acc-1")))
+            .thenReturn(listOf(expenseAccount))
+        `when`(billRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val request = CreateBillRequest(
+            vendorId = "v-1",
+            date = LocalDate.of(2026, 3, 1),
+            dueDate = LocalDate.of(2026, 3, 31),
+            lines = listOf(
+                BillLineRequest(accountId = "acc-1", amount = BigDecimal("250.00")),
+            ),
+        )
+
+        val result = billService.createBill(request, orgId, userId)
+
+        assertThat(result.status).isEqualTo(BillStatus.DRAFT)
+        assertThat(result.vendorName).isEqualTo("Acme Corp")
+        assertThat(result.totalAmount).isEqualByComparingTo(BigDecimal("250.00"))
+        assertThat(result.amountPaid).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.billNumber).isEqualTo("BILL-0001")
+        assertThat(result.lines).hasSize(1)
+        assertThat(result.lines[0].accountCode).isEqualTo("5000")
+    }
+
+    @Test
+    fun `create should reject inactive vendor`() {
+        val vendor = createVendor(isActive = false)
+        `when`(vendorService.getVendor("v-1", orgId)).thenReturn(vendor)
+
+        val request = CreateBillRequest(
+            vendorId = "v-1",
+            date = LocalDate.of(2026, 3, 1),
+            dueDate = LocalDate.of(2026, 3, 31),
+            lines = listOf(
+                BillLineRequest(accountId = "acc-1", amount = BigDecimal("100.00")),
+            ),
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            billService.createBill(request, orgId, userId)
+        }
+        assertThat(exception.message).contains("inactive vendor")
+    }
+
+    @Test
+    fun `approve should post journal entry and update status`() {
+        val bill = createBill()
+        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
+            .thenReturn(Optional.of(apAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val result = billService.approveBill("bill-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(BillStatus.APPROVED)
+        assertThat(result.journalEntryId).isNotNull()
+        assertThat(result.approvedBy).isEqualTo(userId)
+
+        val entryCaptor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(entryCaptor.capture())
+        val je = entryCaptor.firstValue
+
+        assertThat(je.status).isEqualTo(JournalEntryStatus.POSTED)
+        assertThat(je.lines).hasSize(2)
+
+        val debitLine = je.lines.find { it.debit > BigDecimal.ZERO }
+        assertThat(debitLine!!.accountCode).isEqualTo("5000")
+        assertThat(debitLine.debit).isEqualByComparingTo(BigDecimal("500.00"))
+
+        val creditLine = je.lines.find { it.credit > BigDecimal.ZERO }
+        assertThat(creditLine!!.accountCode).isEqualTo("2000")
+        assertThat(creditLine.credit).isEqualByComparingTo(BigDecimal("500.00"))
+    }
+
+    @Test
+    fun `approve should reject non-draft bill`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            billService.approveBill("bill-1", orgId, userId)
+        }
+        assertThat(exception.message).contains("Only draft")
+    }
+
+    @Test
+    fun `void should create reversing entry for approved bill`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
+            .thenReturn(Optional.of(apAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val result = billService.voidBill("bill-1", orgId, "Duplicate", userId)
+
+        assertThat(result.status).isEqualTo(BillStatus.VOID)
+        assertThat(result.voidReason).isEqualTo("Duplicate")
+
+        val entryCaptor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(entryCaptor.capture())
+        val je = entryCaptor.firstValue
+
+        val apDebit = je.lines.find { it.accountCode == "2000" }
+        assertThat(apDebit!!.debit).isEqualByComparingTo(BigDecimal("500.00"))
+
+        val expenseCredit = je.lines.find { it.accountCode == "5000" }
+        assertThat(expenseCredit!!.credit).isEqualByComparingTo(BigDecimal("500.00"))
+    }
+
+    @Test
+    fun `void should allow voiding draft without journal entry`() {
+        val bill = createBill(status = BillStatus.DRAFT)
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val result = billService.voidBill("bill-1", orgId, "Not needed", userId)
+
+        assertThat(result.status).isEqualTo(BillStatus.VOID)
+    }
+
+    @Test
+    fun `void should reject bill with payments`() {
+        val bill = createBill(
+            status = BillStatus.PARTIALLY_PAID,
+            amountPaid = BigDecimal("100.00"),
+        )
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            billService.voidBill("bill-1", orgId, "Cancel", userId)
+        }
+        assertThat(exception.message).contains("recorded payments")
+    }
+
+    @Test
+    fun `recordPayment should create payment and update bill status`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+        val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
+            .thenReturn(Optional.of(apAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
+            .thenReturn(Optional.of(cashAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(billPaymentRepository.save(any<BillPayment>())).thenAnswer { it.arguments[0] }
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val request = RecordPaymentRequest(
+            paymentDate = LocalDate.of(2026, 3, 15),
+            amount = BigDecimal("200.00"),
+            paymentMethod = PaymentMethod.BANK_TRANSFER,
+        )
+
+        val payment = billService.recordPayment("bill-1", request, orgId, userId)
+
+        assertThat(payment.amount).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(payment.paymentMethod).isEqualTo(PaymentMethod.BANK_TRANSFER)
+
+        val billCaptor = argumentCaptor<Bill>()
+        verify(billRepository).save(billCaptor.capture())
+        assertThat(billCaptor.firstValue.status).isEqualTo(BillStatus.PARTIALLY_PAID)
+        assertThat(billCaptor.firstValue.amountPaid).isEqualByComparingTo(BigDecimal("200.00"))
+    }
+
+    @Test
+    fun `recordPayment should mark bill as PAID when fully paid`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+        val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
+            .thenReturn(Optional.of(apAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
+            .thenReturn(Optional.of(cashAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(billPaymentRepository.save(any<BillPayment>())).thenAnswer { it.arguments[0] }
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val request = RecordPaymentRequest(
+            paymentDate = LocalDate.of(2026, 3, 15),
+            amount = BigDecimal("500.00"),
+            paymentMethod = PaymentMethod.CHECK,
+        )
+
+        billService.recordPayment("bill-1", request, orgId, userId)
+
+        val billCaptor = argumentCaptor<Bill>()
+        verify(billRepository).save(billCaptor.capture())
+        assertThat(billCaptor.firstValue.status).isEqualTo(BillStatus.PAID)
+        assertThat(billCaptor.firstValue.paidAt).isNotNull()
+    }
+
+    @Test
+    fun `recordPayment should reject overpayment`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+
+        val request = RecordPaymentRequest(
+            paymentDate = LocalDate.of(2026, 3, 15),
+            amount = BigDecimal("999.00"),
+            paymentMethod = PaymentMethod.CASH,
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            billService.recordPayment("bill-1", request, orgId, userId)
+        }
+        assertThat(exception.message).contains("exceeds remaining balance")
+    }
+
+    @Test
+    fun `recordPayment should reject draft bill`() {
+        val bill = createBill(status = BillStatus.DRAFT)
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+
+        val request = RecordPaymentRequest(
+            paymentDate = LocalDate.of(2026, 3, 15),
+            amount = BigDecimal("100.00"),
+            paymentMethod = PaymentMethod.CASH,
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            billService.recordPayment("bill-1", request, orgId, userId)
+        }
+        assertThat(exception.message).contains("approved or partially paid")
+    }
+
+    @Test
+    fun `aging report should bucket bills by overdue days`() {
+        val asOfDate = LocalDate.of(2026, 5, 1)
+        val bills = listOf(
+            createBill(
+                id = "bill-1",
+                vendorId = "v-1",
+                dueDate = LocalDate.of(2026, 5, 15),
+                totalAmount = BigDecimal("100.00"),
+                status = BillStatus.APPROVED,
+            ),
+            createBill(
+                id = "bill-2",
+                vendorId = "v-1",
+                dueDate = LocalDate.of(2026, 4, 15),
+                totalAmount = BigDecimal("200.00"),
+                status = BillStatus.APPROVED,
+            ),
+            createBill(
+                id = "bill-3",
+                vendorId = "v-1",
+                dueDate = LocalDate.of(2026, 2, 1),
+                totalAmount = BigDecimal("300.00"),
+                status = BillStatus.PARTIALLY_PAID,
+                amountPaid = BigDecimal("50.00"),
+            ),
+        )
+
+        val outstandingStatuses = listOf(BillStatus.APPROVED, BillStatus.PARTIALLY_PAID)
+        `when`(billRepository.findByOrganizationIdAndStatusIn(orgId, outstandingStatuses))
+            .thenReturn(bills)
+
+        val report = billService.getAgingReport(orgId, asOfDate)
+
+        assertThat(report.vendors).hasSize(1)
+        val vendorAging = report.vendors[0]
+        assertThat(vendorAging.vendorName).isEqualTo("Acme Corp")
+
+        // bill-1: due May 15, asOf May 1 -> not overdue -> current
+        assertThat(vendorAging.aging.current).isEqualByComparingTo(BigDecimal("100.00"))
+        // bill-2: due Apr 15, asOf May 1 -> 16 days overdue -> 1-30 bucket
+        assertThat(vendorAging.aging.days1to30).isEqualByComparingTo(BigDecimal("200.00"))
+        // bill-3: due Feb 1, asOf May 1 -> 89 days overdue -> 61-90 bucket, outstanding = 250
+        assertThat(vendorAging.aging.days61to90).isEqualByComparingTo(BigDecimal("250.00"))
+
+        assertThat(report.totals.total).isEqualByComparingTo(BigDecimal("550.00"))
+    }
+
+    private fun createVendor(
+        id: String = "v-1",
+        isActive: Boolean = true,
+    ) = Vendor(
+        id = id,
+        name = "Acme Corp",
+        contactName = "John",
+        paymentTermDays = 30,
+        organizationId = orgId,
+        isActive = isActive,
+    )
+
+    private fun createAccount(
+        id: String,
+        code: String,
+        name: String,
+        type: AccountType,
+    ) = Account(
+        id = id,
+        code = code,
+        name = name,
+        type = type,
+        organizationId = orgId,
+    )
+
+    private fun createBill(
+        id: String = "bill-1",
+        vendorId: String = "v-1",
+        status: BillStatus = BillStatus.DRAFT,
+        totalAmount: BigDecimal = BigDecimal("500.00"),
+        amountPaid: BigDecimal = BigDecimal.ZERO,
+        dueDate: LocalDate = LocalDate.of(2026, 3, 31),
+    ) = Bill(
+        id = id,
+        billNumber = "BILL-0001",
+        vendorId = vendorId,
+        vendorName = "Acme Corp",
+        date = LocalDate.of(2026, 3, 1),
+        dueDate = dueDate,
+        organizationId = orgId,
+        status = status,
+        lines = listOf(
+            BillLine(
+                accountId = "acc-1",
+                accountCode = "5000",
+                accountName = "Office Supplies",
+                amount = totalAmount,
+            ),
+        ),
+        totalAmount = totalAmount,
+        amountPaid = amountPaid,
+        createdBy = userId,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
@@ -50,13 +50,14 @@ class BillServiceTest {
         journalEntryRepository = mock(JournalEntryRepository::class.java)
         vendorService = mock(VendorService::class.java)
         entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
-        billService = BillService(
-            billRepository = billRepository,
-            billPaymentRepository = billPaymentRepository,
-            accountRepository = accountRepository,
-            vendorService = vendorService,
-            entryNumberGenerator = entryNumberGenerator,
-        )
+        billService =
+            BillService(
+                billRepository = billRepository,
+                billPaymentRepository = billPaymentRepository,
+                accountRepository = accountRepository,
+                vendorService = vendorService,
+                entryNumberGenerator = entryNumberGenerator,
+            )
     }
 
     @Test
@@ -70,14 +71,16 @@ class BillServiceTest {
         `when`(billRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
 
-        val request = CreateBillRequest(
-            vendorId = "v-1",
-            date = LocalDate.of(2026, 3, 1),
-            dueDate = LocalDate.of(2026, 3, 31),
-            lines = listOf(
-                BillLineRequest(accountId = "acc-1", amount = BigDecimal("250.00")),
-            ),
-        )
+        val request =
+            CreateBillRequest(
+                vendorId = "v-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                lines =
+                    listOf(
+                        BillLineRequest(accountId = "acc-1", amount = BigDecimal("250.00")),
+                    ),
+            )
 
         val result = billService.createBill(request, orgId, userId)
 
@@ -95,18 +98,21 @@ class BillServiceTest {
         val vendor = createVendor(isActive = false)
         `when`(vendorService.getVendor("v-1", orgId)).thenReturn(vendor)
 
-        val request = CreateBillRequest(
-            vendorId = "v-1",
-            date = LocalDate.of(2026, 3, 1),
-            dueDate = LocalDate.of(2026, 3, 31),
-            lines = listOf(
-                BillLineRequest(accountId = "acc-1", amount = BigDecimal("100.00")),
-            ),
-        )
+        val request =
+            CreateBillRequest(
+                vendorId = "v-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                lines =
+                    listOf(
+                        BillLineRequest(accountId = "acc-1", amount = BigDecimal("100.00")),
+                    ),
+            )
 
-        val exception = assertThrows<IllegalArgumentException> {
-            billService.createBill(request, orgId, userId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.createBill(request, orgId, userId)
+            }
         assertThat(exception.message).contains("inactive vendor")
     }
 
@@ -149,9 +155,10 @@ class BillServiceTest {
         val bill = createBill(status = BillStatus.APPROVED)
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            billService.approveBill("bill-1", orgId, userId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.approveBill("bill-1", orgId, userId)
+            }
         assertThat(exception.message).contains("Only draft")
     }
 
@@ -196,15 +203,17 @@ class BillServiceTest {
 
     @Test
     fun `void should reject bill with payments`() {
-        val bill = createBill(
-            status = BillStatus.PARTIALLY_PAID,
-            amountPaid = BigDecimal("100.00"),
-        )
+        val bill =
+            createBill(
+                status = BillStatus.PARTIALLY_PAID,
+                amountPaid = BigDecimal("100.00"),
+            )
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            billService.voidBill("bill-1", orgId, "Cancel", userId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.voidBill("bill-1", orgId, "Cancel", userId)
+            }
         assertThat(exception.message).contains("recorded payments")
     }
 
@@ -224,11 +233,12 @@ class BillServiceTest {
         `when`(billPaymentRepository.save(any<BillPayment>())).thenAnswer { it.arguments[0] }
         `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
 
-        val request = RecordPaymentRequest(
-            paymentDate = LocalDate.of(2026, 3, 15),
-            amount = BigDecimal("200.00"),
-            paymentMethod = PaymentMethod.BANK_TRANSFER,
-        )
+        val request =
+            RecordPaymentRequest(
+                paymentDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("200.00"),
+                paymentMethod = PaymentMethod.BANK_TRANSFER,
+            )
 
         val payment = billService.recordPayment("bill-1", request, orgId, userId)
 
@@ -257,11 +267,12 @@ class BillServiceTest {
         `when`(billPaymentRepository.save(any<BillPayment>())).thenAnswer { it.arguments[0] }
         `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
 
-        val request = RecordPaymentRequest(
-            paymentDate = LocalDate.of(2026, 3, 15),
-            amount = BigDecimal("500.00"),
-            paymentMethod = PaymentMethod.CHECK,
-        )
+        val request =
+            RecordPaymentRequest(
+                paymentDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("500.00"),
+                paymentMethod = PaymentMethod.CHECK,
+            )
 
         billService.recordPayment("bill-1", request, orgId, userId)
 
@@ -276,15 +287,17 @@ class BillServiceTest {
         val bill = createBill(status = BillStatus.APPROVED)
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
 
-        val request = RecordPaymentRequest(
-            paymentDate = LocalDate.of(2026, 3, 15),
-            amount = BigDecimal("999.00"),
-            paymentMethod = PaymentMethod.CASH,
-        )
+        val request =
+            RecordPaymentRequest(
+                paymentDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("999.00"),
+                paymentMethod = PaymentMethod.CASH,
+            )
 
-        val exception = assertThrows<IllegalArgumentException> {
-            billService.recordPayment("bill-1", request, orgId, userId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.recordPayment("bill-1", request, orgId, userId)
+            }
         assertThat(exception.message).contains("exceeds remaining balance")
     }
 
@@ -293,45 +306,48 @@ class BillServiceTest {
         val bill = createBill(status = BillStatus.DRAFT)
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
 
-        val request = RecordPaymentRequest(
-            paymentDate = LocalDate.of(2026, 3, 15),
-            amount = BigDecimal("100.00"),
-            paymentMethod = PaymentMethod.CASH,
-        )
+        val request =
+            RecordPaymentRequest(
+                paymentDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("100.00"),
+                paymentMethod = PaymentMethod.CASH,
+            )
 
-        val exception = assertThrows<IllegalArgumentException> {
-            billService.recordPayment("bill-1", request, orgId, userId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.recordPayment("bill-1", request, orgId, userId)
+            }
         assertThat(exception.message).contains("approved or partially paid")
     }
 
     @Test
     fun `aging report should bucket bills by overdue days`() {
         val asOfDate = LocalDate.of(2026, 5, 1)
-        val bills = listOf(
-            createBill(
-                id = "bill-1",
-                vendorId = "v-1",
-                dueDate = LocalDate.of(2026, 5, 15),
-                totalAmount = BigDecimal("100.00"),
-                status = BillStatus.APPROVED,
-            ),
-            createBill(
-                id = "bill-2",
-                vendorId = "v-1",
-                dueDate = LocalDate.of(2026, 4, 15),
-                totalAmount = BigDecimal("200.00"),
-                status = BillStatus.APPROVED,
-            ),
-            createBill(
-                id = "bill-3",
-                vendorId = "v-1",
-                dueDate = LocalDate.of(2026, 2, 1),
-                totalAmount = BigDecimal("300.00"),
-                status = BillStatus.PARTIALLY_PAID,
-                amountPaid = BigDecimal("50.00"),
-            ),
-        )
+        val bills =
+            listOf(
+                createBill(
+                    id = "bill-1",
+                    vendorId = "v-1",
+                    dueDate = LocalDate.of(2026, 5, 15),
+                    totalAmount = BigDecimal("100.00"),
+                    status = BillStatus.APPROVED,
+                ),
+                createBill(
+                    id = "bill-2",
+                    vendorId = "v-1",
+                    dueDate = LocalDate.of(2026, 4, 15),
+                    totalAmount = BigDecimal("200.00"),
+                    status = BillStatus.APPROVED,
+                ),
+                createBill(
+                    id = "bill-3",
+                    vendorId = "v-1",
+                    dueDate = LocalDate.of(2026, 2, 1),
+                    totalAmount = BigDecimal("300.00"),
+                    status = BillStatus.PARTIALLY_PAID,
+                    amountPaid = BigDecimal("50.00"),
+                ),
+            )
 
         val outstandingStatuses = listOf(BillStatus.APPROVED, BillStatus.PARTIALLY_PAID)
         `when`(billRepository.findByOrganizationIdAndStatusIn(orgId, outstandingStatuses))
@@ -394,14 +410,15 @@ class BillServiceTest {
         dueDate = dueDate,
         organizationId = orgId,
         status = status,
-        lines = listOf(
-            BillLine(
-                accountId = "acc-1",
-                accountCode = "5000",
-                accountName = "Office Supplies",
-                amount = totalAmount,
+        lines =
+            listOf(
+                BillLine(
+                    accountId = "acc-1",
+                    accountCode = "5000",
+                    accountName = "Office Supplies",
+                    amount = totalAmount,
+                ),
             ),
-        ),
         totalAmount = totalAmount,
         amountPaid = amountPaid,
         createdBy = userId,

--- a/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
@@ -38,6 +38,7 @@ class BillServiceTest {
     private lateinit var journalEntryRepository: JournalEntryRepository
     private lateinit var vendorService: VendorService
     private lateinit var entryNumberGenerator: JournalEntryNumberGenerator
+    private lateinit var fiscalYearService: FiscalYearService
 
     private val orgId = "org-123"
     private val userId = "user-1"
@@ -49,7 +50,10 @@ class BillServiceTest {
         accountRepository = mock(AccountRepository::class.java)
         journalEntryRepository = mock(JournalEntryRepository::class.java)
         vendorService = mock(VendorService::class.java)
+        fiscalYearService = mock(FiscalYearService::class.java)
         entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
+        `when`(fiscalYearService.findPeriodForDate(any(), any()))
+            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
         billService =
             BillService(
                 billRepository = billRepository,
@@ -57,6 +61,7 @@ class BillServiceTest {
                 accountRepository = accountRepository,
                 vendorService = vendorService,
                 entryNumberGenerator = entryNumberGenerator,
+                fiscalYearService = fiscalYearService,
             )
     }
 

--- a/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
@@ -16,7 +16,6 @@ import com.froilan.synectix.model.Vendor
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.BillPaymentRepository
 import com.froilan.synectix.repository.BillRepository
-import com.froilan.synectix.repository.JournalEntryRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,10 +34,8 @@ class BillServiceTest {
     private lateinit var billRepository: BillRepository
     private lateinit var billPaymentRepository: BillPaymentRepository
     private lateinit var accountRepository: AccountRepository
-    private lateinit var journalEntryRepository: JournalEntryRepository
     private lateinit var vendorService: VendorService
-    private lateinit var entryNumberGenerator: JournalEntryNumberGenerator
-    private lateinit var fiscalYearService: FiscalYearService
+    private lateinit var journalEntryService: JournalEntryService
 
     private val orgId = "org-123"
     private val userId = "user-1"
@@ -48,20 +45,15 @@ class BillServiceTest {
         billRepository = mock(BillRepository::class.java)
         billPaymentRepository = mock(BillPaymentRepository::class.java)
         accountRepository = mock(AccountRepository::class.java)
-        journalEntryRepository = mock(JournalEntryRepository::class.java)
         vendorService = mock(VendorService::class.java)
-        fiscalYearService = mock(FiscalYearService::class.java)
-        entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
-        `when`(fiscalYearService.findPeriodForDate(any(), any()))
-            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
+        journalEntryService = mock(JournalEntryService::class.java)
         billService =
             BillService(
                 billRepository = billRepository,
                 billPaymentRepository = billPaymentRepository,
                 accountRepository = accountRepository,
                 vendorService = vendorService,
-                entryNumberGenerator = entryNumberGenerator,
-                fiscalYearService = fiscalYearService,
+                journalEntryService = journalEntryService,
             )
     }
 
@@ -125,34 +117,32 @@ class BillServiceTest {
     fun `approve should post journal entry and update status`() {
         val bill = createBill()
         val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+        val mockEntry =
+            JournalEntry(
+                id = "je-1",
+                entryNumber = "JE-0001",
+                date = bill.date,
+                description = "Bill BILL-0001 - Acme Corp",
+                organizationId = orgId,
+                status = JournalEntryStatus.POSTED,
+                lines = emptyList(),
+                createdBy = userId,
+            )
 
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
             .thenReturn(Optional.of(apAccount))
-        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
-        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
         `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
 
         val result = billService.approveBill("bill-1", orgId, userId)
 
         assertThat(result.status).isEqualTo(BillStatus.APPROVED)
-        assertThat(result.journalEntryId).isNotNull()
+        assertThat(result.journalEntryId).isEqualTo("je-1")
         assertThat(result.approvedBy).isEqualTo(userId)
 
-        val entryCaptor = argumentCaptor<JournalEntry>()
-        verify(journalEntryRepository).save(entryCaptor.capture())
-        val je = entryCaptor.firstValue
-
-        assertThat(je.status).isEqualTo(JournalEntryStatus.POSTED)
-        assertThat(je.lines).hasSize(2)
-
-        val debitLine = je.lines.find { it.debit > BigDecimal.ZERO }
-        assertThat(debitLine!!.accountCode).isEqualTo("5000")
-        assertThat(debitLine.debit).isEqualByComparingTo(BigDecimal("500.00"))
-
-        val creditLine = je.lines.find { it.credit > BigDecimal.ZERO }
-        assertThat(creditLine!!.accountCode).isEqualTo("2000")
-        assertThat(creditLine.credit).isEqualByComparingTo(BigDecimal("500.00"))
+        verify(journalEntryService).createSystemEntry(any(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -168,31 +158,30 @@ class BillServiceTest {
     }
 
     @Test
-    fun `void should create reversing entry for approved bill`() {
-        val bill = createBill(status = BillStatus.APPROVED)
-        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+    fun `void should void journal entry for approved bill`() {
+        val bill = createBill(status = BillStatus.APPROVED, journalEntryId = "je-1")
+        val voidedEntry =
+            JournalEntry(
+                id = "je-1",
+                entryNumber = "JE-0001",
+                date = bill.date,
+                description = "Bill BILL-0001",
+                organizationId = orgId,
+                status = JournalEntryStatus.VOIDED,
+                lines = emptyList(),
+                createdBy = userId,
+            )
 
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
-        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
-            .thenReturn(Optional.of(apAccount))
-        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
-        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryService.voidJournalEntry("je-1", orgId, "Duplicate"))
+            .thenReturn(voidedEntry)
         `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
 
         val result = billService.voidBill("bill-1", orgId, "Duplicate", userId)
 
         assertThat(result.status).isEqualTo(BillStatus.VOID)
         assertThat(result.voidReason).isEqualTo("Duplicate")
-
-        val entryCaptor = argumentCaptor<JournalEntry>()
-        verify(journalEntryRepository).save(entryCaptor.capture())
-        val je = entryCaptor.firstValue
-
-        val apDebit = je.lines.find { it.accountCode == "2000" }
-        assertThat(apDebit!!.debit).isEqualByComparingTo(BigDecimal("500.00"))
-
-        val expenseCredit = je.lines.find { it.accountCode == "5000" }
-        assertThat(expenseCredit!!.credit).isEqualByComparingTo(BigDecimal("500.00"))
+        verify(journalEntryService).voidJournalEntry("je-1", orgId, "Duplicate")
     }
 
     @Test
@@ -227,14 +216,15 @@ class BillServiceTest {
         val bill = createBill(status = BillStatus.APPROVED)
         val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
         val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
 
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
             .thenReturn(Optional.of(apAccount))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
             .thenReturn(Optional.of(cashAccount))
-        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
-        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
         `when`(billPaymentRepository.save(any<BillPayment>())).thenAnswer { it.arguments[0] }
         `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
 
@@ -261,14 +251,15 @@ class BillServiceTest {
         val bill = createBill(status = BillStatus.APPROVED)
         val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
         val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
 
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
             .thenReturn(Optional.of(apAccount))
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
             .thenReturn(Optional.of(cashAccount))
-        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
-        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
         `when`(billPaymentRepository.save(any<BillPayment>())).thenAnswer { it.arguments[0] }
         `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
 
@@ -406,6 +397,7 @@ class BillServiceTest {
         totalAmount: BigDecimal = BigDecimal("500.00"),
         amountPaid: BigDecimal = BigDecimal.ZERO,
         dueDate: LocalDate = LocalDate.of(2026, 3, 31),
+        journalEntryId: String? = null,
     ) = Bill(
         id = id,
         billNumber = "BILL-0001",
@@ -426,6 +418,19 @@ class BillServiceTest {
             ),
         totalAmount = totalAmount,
         amountPaid = amountPaid,
+        journalEntryId = journalEntryId,
         createdBy = userId,
     )
+
+    private fun createMockJournalEntry() =
+        JournalEntry(
+            id = "je-1",
+            entryNumber = "JE-0001",
+            date = LocalDate.of(2026, 3, 1),
+            description = "Mock entry",
+            organizationId = orgId,
+            status = JournalEntryStatus.POSTED,
+            lines = emptyList(),
+            createdBy = userId,
+        )
 }

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -29,6 +29,7 @@ import org.springframework.data.mongodb.core.FindAndModifyOptions
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Optional
 
 class InvitationServiceTest {
@@ -139,7 +140,7 @@ class InvitationServiceTest {
         val expiredInvitation =
             createMockInvitation(
                 email = "reinvite@example.com",
-                expiryAt = LocalDateTime.now().minusHours(1),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).minusHours(1),
             )
 
         `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
@@ -386,7 +387,7 @@ class InvitationServiceTest {
         role: String = "MEMBER",
         organizationId: String = "org-123",
         status: InvitationStatus = InvitationStatus.PENDING,
-        expiryAt: LocalDateTime = LocalDateTime.now().plusHours(72),
+        expiryAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).plusHours(72),
     ) = Invitation(
         id = "inv-123",
         email = email,

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -4,8 +4,6 @@ import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.JournalEntryLineRequest
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
-import com.froilan.synectix.model.FiscalPeriod
-import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
@@ -22,6 +20,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.Optional
@@ -42,8 +41,6 @@ class JournalEntryServiceTest {
         accountRepository = mock(AccountRepository::class.java)
         fiscalYearService = mock(FiscalYearService::class.java)
         entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
-        `when`(fiscalYearService.findPeriodForDate(any(), any()))
-            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
         journalEntryService =
             JournalEntryService(
                 journalEntryRepository = journalEntryRepository,
@@ -594,8 +591,6 @@ class JournalEntryServiceTest {
             .thenReturn(listOf(cashAccount, revenueAccount))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
-        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
 
         val request =
             CreateJournalEntryRequest(
@@ -641,17 +636,9 @@ class JournalEntryServiceTest {
 
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
-        val closedPeriod =
-            FiscalPeriod(
-                periodNumber = 1,
-                name = "January 2026",
-                startDate = LocalDate.of(2026, 1, 1),
-                endDate = LocalDate.of(2026, 1, 31),
-                status = FiscalPeriodStatus.CLOSED,
-            )
-
-        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(FiscalYearService.PeriodLookupResult.Found(closedPeriod))
+        doThrow(IllegalArgumentException("Fiscal period 'January 2026' is closed"))
+            .`when`(fiscalYearService)
+            .validatePeriodOpen(orgId, LocalDate.of(2026, 1, 15))
 
         val request =
             CreateJournalEntryRequest(
@@ -697,21 +684,10 @@ class JournalEntryServiceTest {
                 type = AccountType.REVENUE,
                 orgId = orgId,
             )
-        val openPeriod =
-            FiscalPeriod(
-                periodNumber = 1,
-                name = "January 2026",
-                startDate = LocalDate.of(2026, 1, 1),
-                endDate = LocalDate.of(2026, 1, 31),
-                status = FiscalPeriodStatus.OPEN,
-            )
-
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
-        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(FiscalYearService.PeriodLookupResult.Found(openPeriod))
 
         val request =
             CreateJournalEntryRequest(
@@ -763,19 +739,10 @@ class JournalEntryServiceTest {
                 orgId = orgId,
             )
 
-        val closedPeriod =
-            FiscalPeriod(
-                periodNumber = 1,
-                name = "January 2026",
-                startDate = LocalDate.of(2026, 1, 1),
-                endDate = LocalDate.of(2026, 1, 31),
-                status = FiscalPeriodStatus.CLOSED,
-            )
-
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
-        `when`(
-            fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
-        ).thenReturn(FiscalYearService.PeriodLookupResult.Found(closedPeriod))
+        doThrow(IllegalArgumentException("Fiscal period 'January 2026' is closed"))
+            .`when`(fiscalYearService)
+            .validatePeriodOpen(orgId, LocalDate.of(2026, 1, 15))
 
         val exception =
             assertThrows<IllegalArgumentException> {

--- a/src/test/kotlin/com/froilan/synectix/service/VendorServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/VendorServiceTest.kt
@@ -31,12 +31,13 @@ class VendorServiceTest {
     fun `create should save vendor with correct fields`() {
         `when`(vendorRepository.save(any<Vendor>())).thenAnswer { it.arguments[0] }
 
-        val request = CreateVendorRequest(
-            name = "Acme Corp",
-            contactName = "John Doe",
-            contactEmail = "john@acme.com",
-            paymentTermDays = 45,
-        )
+        val request =
+            CreateVendorRequest(
+                name = "Acme Corp",
+                contactName = "John Doe",
+                contactEmail = "john@acme.com",
+                paymentTermDays = 45,
+            )
 
         val result = vendorService.createVendor(request, orgId)
 
@@ -62,9 +63,10 @@ class VendorServiceTest {
         val vendor = createVendor(orgId = "other-org")
         `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            vendorService.getVendor("v-1", orgId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                vendorService.getVendor("v-1", orgId)
+            }
         assertThat(exception.message).contains("Vendor not found")
     }
 
@@ -95,9 +97,10 @@ class VendorServiceTest {
         val vendor = createVendor(isActive = false)
         `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            vendorService.updateVendor("v-1", UpdateVendorRequest(name = "New"), orgId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                vendorService.updateVendor("v-1", UpdateVendorRequest(name = "New"), orgId)
+            }
         assertThat(exception.message).contains("inactive")
     }
 
@@ -120,9 +123,10 @@ class VendorServiceTest {
         val vendor = createVendor(isActive = false)
         `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
 
-        val exception = assertThrows<IllegalArgumentException> {
-            vendorService.deleteVendor("v-1", orgId)
-        }
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                vendorService.deleteVendor("v-1", orgId)
+            }
         assertThat(exception.message).contains("already inactive")
     }
 

--- a/src/test/kotlin/com/froilan/synectix/service/VendorServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/VendorServiceTest.kt
@@ -1,0 +1,143 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateVendorRequest
+import com.froilan.synectix.dto.UpdateVendorRequest
+import com.froilan.synectix.model.Vendor
+import com.froilan.synectix.repository.VendorRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.util.Optional
+
+class VendorServiceTest {
+    private lateinit var vendorService: VendorService
+    private lateinit var vendorRepository: VendorRepository
+
+    private val orgId = "org-123"
+
+    @BeforeEach
+    fun setup() {
+        vendorRepository = mock(VendorRepository::class.java)
+        vendorService = VendorService(vendorRepository)
+    }
+
+    @Test
+    fun `create should save vendor with correct fields`() {
+        `when`(vendorRepository.save(any<Vendor>())).thenAnswer { it.arguments[0] }
+
+        val request = CreateVendorRequest(
+            name = "Acme Corp",
+            contactName = "John Doe",
+            contactEmail = "john@acme.com",
+            paymentTermDays = 45,
+        )
+
+        val result = vendorService.createVendor(request, orgId)
+
+        assertThat(result.name).isEqualTo("Acme Corp")
+        assertThat(result.contactName).isEqualTo("John Doe")
+        assertThat(result.contactEmail).isEqualTo("john@acme.com")
+        assertThat(result.paymentTermDays).isEqualTo(45)
+        assertThat(result.organizationId).isEqualTo(orgId)
+        assertThat(result.isActive).isTrue()
+    }
+
+    @Test
+    fun `get should return vendor for correct org`() {
+        val vendor = createVendor()
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+
+        val result = vendorService.getVendor("v-1", orgId)
+        assertThat(result.id).isEqualTo("v-1")
+    }
+
+    @Test
+    fun `get should throw when vendor belongs to different org`() {
+        val vendor = createVendor(orgId = "other-org")
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            vendorService.getVendor("v-1", orgId)
+        }
+        assertThat(exception.message).contains("Vendor not found")
+    }
+
+    @Test
+    fun `list should return active vendors`() {
+        val vendors = listOf(createVendor(), createVendor(id = "v-2", name = "Beta Inc"))
+        `when`(vendorRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(vendors)
+
+        val result = vendorService.listVendors(orgId)
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun `update should apply partial changes`() {
+        val vendor = createVendor()
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+        `when`(vendorRepository.save(any<Vendor>())).thenAnswer { it.arguments[0] }
+
+        val request = UpdateVendorRequest(name = "Updated Corp")
+        val result = vendorService.updateVendor("v-1", request, orgId)
+
+        assertThat(result.name).isEqualTo("Updated Corp")
+        assertThat(result.contactName).isEqualTo("John Doe")
+    }
+
+    @Test
+    fun `update should reject inactive vendor`() {
+        val vendor = createVendor(isActive = false)
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            vendorService.updateVendor("v-1", UpdateVendorRequest(name = "New"), orgId)
+        }
+        assertThat(exception.message).contains("inactive")
+    }
+
+    @Test
+    fun `delete should soft delete vendor`() {
+        val vendor = createVendor()
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+        `when`(vendorRepository.save(any<Vendor>())).thenAnswer { it.arguments[0] }
+
+        val result = vendorService.deleteVendor("v-1", orgId)
+
+        assertThat(result.isActive).isFalse()
+        val captor = argumentCaptor<Vendor>()
+        verify(vendorRepository).save(captor.capture())
+        assertThat(captor.firstValue.isActive).isFalse()
+    }
+
+    @Test
+    fun `delete should reject already inactive vendor`() {
+        val vendor = createVendor(isActive = false)
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+
+        val exception = assertThrows<IllegalArgumentException> {
+            vendorService.deleteVendor("v-1", orgId)
+        }
+        assertThat(exception.message).contains("already inactive")
+    }
+
+    private fun createVendor(
+        id: String = "v-1",
+        name: String = "Acme Corp",
+        orgId: String = this.orgId,
+        isActive: Boolean = true,
+    ) = Vendor(
+        id = id,
+        name = name,
+        contactName = "John Doe",
+        contactEmail = "john@acme.com",
+        paymentTermDays = 30,
+        organizationId = orgId,
+        isActive = isActive,
+    )
+}


### PR DESCRIPTION
## Summary
- Add vendor management with CRUD and soft delete
- Implement bill lifecycle: DRAFT → APPROVED → PARTIALLY_PAID → PAID → VOID
- Auto-post journal entries on bill approval (debit expense, credit AP) and void (reversing entry)
- Record payments with partial payment support, auto-posting GL entries (debit AP, credit Cash)
- AP aging report with standard overdue buckets (Current, 1-30, 31-60, 61-90, 90+ days)
- Add ap:create, ap:read, ap:approve, ap:pay, ap:void permissions with role seeding
- Fiscal period validation on approve, void, and payment
- Enable Gradle configuration cache

## API Endpoints

### Vendors (`/finance/ap/vendors`)
- `POST` — create vendor
- `GET` — list active vendors
- `GET /{id}` — get vendor
- `PUT /{id}` — update vendor
- `DELETE /{id}` — soft delete

### Bills (`/finance/ap/bills`)
- `POST` — create bill (DRAFT)
- `GET` — list bills (filter by status, vendorId, or both)
- `GET /{id}` — get bill with lines
- `POST /{id}/approve` — approve and post to GL
- `POST /{id}/void` — void with reversing entry
- `POST /{id}/payments` — record payment
- `GET /{id}/payments` — list payments
- `GET /aging` — AP aging report

## Test plan
- [x] 8 VendorServiceTest cases (CRUD, org scoping, soft delete)
- [x] 13 BillServiceTest cases (create, approve with GL verification, void draft/approved, payment flows, overpayment rejection, aging report buckets)
- [x] RoleSeederTest updated with AP permissions
- [x] ktlintCheck passes
- [x] 243/244 tests pass (1 pre-existing MongoDB context load failure)

Closes #26