### PR TITLE
Extract AuthenticationContext bean from controllers

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -7,15 +7,13 @@ import com.froilan.synectix.dto.CreateAccountRequest
 import com.froilan.synectix.dto.UpdateAccountRequest
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.AccountService
 import com.froilan.synectix.service.JournalEntryService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -34,13 +32,14 @@ import java.util.Locale
 class AccountController(
     private val accountService: AccountService,
     private val journalEntryService: JournalEntryService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('account:create')")
     fun createAccount(
         @Valid @RequestBody request: CreateAccountRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val account = accountService.createAccount(request, orgId)
@@ -56,7 +55,7 @@ class AccountController(
         @RequestParam(required = false) type: String?,
         @RequestParam(required = false) parentId: String?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         val accountType =
             if (type != null) {
@@ -80,7 +79,7 @@ class AccountController(
     fun getAccount(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val account = accountService.getAccount(id, orgId)
@@ -96,7 +95,7 @@ class AccountController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateAccountRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val account = accountService.updateAccount(id, request, orgId)
@@ -112,7 +111,7 @@ class AccountController(
     fun deleteAccount(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             accountService.deleteAccount(id, orgId)
@@ -129,7 +128,7 @@ class AccountController(
         @PathVariable id: String,
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val balance = journalEntryService.getAccountBalance(id, orgId, asOfDate)
@@ -153,15 +152,6 @@ class AccountController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -12,15 +12,12 @@ import com.froilan.synectix.dto.VoidBillRequest
 import com.froilan.synectix.model.Bill
 import com.froilan.synectix.model.BillPayment
 import com.froilan.synectix.model.BillStatus
-import com.froilan.synectix.model.User
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.BillService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -37,14 +34,15 @@ import java.util.Locale
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class BillController(
     private val billService: BillService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('ap:create')")
     fun createBill(
         @Valid @RequestBody request: CreateBillRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val createdBy = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
 
         return try {
             val bill = billService.createBill(request, orgId, createdBy)
@@ -62,7 +60,7 @@ class BillController(
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) vendorId: String?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         val billStatus =
             if (status != null) {
@@ -86,7 +84,7 @@ class BillController(
     fun getBill(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val bill = billService.getBill(id, orgId)
@@ -103,8 +101,8 @@ class BillController(
     fun approveBill(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val bill = billService.approveBill(id, orgId, userId)
@@ -128,8 +126,8 @@ class BillController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidBillRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val bill = billService.voidBill(id, orgId, request.reason, userId)
@@ -153,8 +151,8 @@ class BillController(
         @PathVariable id: String,
         @Valid @RequestBody request: RecordPaymentRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val createdBy = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
 
         return try {
             val payment = billService.recordPayment(id, request, orgId, createdBy)
@@ -177,7 +175,7 @@ class BillController(
     fun listPayments(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val payments = billService.getPayments(id, orgId)
@@ -194,7 +192,7 @@ class BillController(
     fun getAgingReport(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
         val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
         return ResponseEntity.ok(report)
     }
@@ -257,20 +255,6 @@ class BillController(
             createdBy = createdBy,
             createdAt = createdAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
-
-    private fun extractUserId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return (authentication.principal as? User)?.uuid
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -7,15 +7,12 @@ import com.froilan.synectix.dto.FiscalPeriodResponse
 import com.froilan.synectix.dto.FiscalYearResponse
 import com.froilan.synectix.dto.FiscalYearSummaryResponse
 import com.froilan.synectix.model.FiscalYear
-import com.froilan.synectix.model.User
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.FiscalYearService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -28,13 +25,14 @@ import org.springframework.web.bind.annotation.RestController
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class FiscalYearController(
     private val fiscalYearService: FiscalYearService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('fiscal:create')")
     fun createFiscalYear(
         @Valid @RequestBody request: CreateFiscalYearRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val fiscalYear = fiscalYearService.createFiscalYear(request, orgId)
@@ -47,7 +45,7 @@ class FiscalYearController(
     @GetMapping
     @PreAuthorize("hasAuthority('fiscal:read')")
     fun listFiscalYears(): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
         val fiscalYears = fiscalYearService.listFiscalYears(orgId)
         return ResponseEntity.ok(fiscalYears.map { it.toSummaryResponse() })
     }
@@ -57,7 +55,7 @@ class FiscalYearController(
     fun getFiscalYear(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
@@ -75,8 +73,8 @@ class FiscalYearController(
         @PathVariable id: String,
         @PathVariable periodId: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val fiscalYear = fiscalYearService.closePeriod(id, periodId, orgId, userId)
@@ -95,8 +93,8 @@ class FiscalYearController(
         @PathVariable id: String,
         @PathVariable periodId: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val fiscalYear = fiscalYearService.reopenPeriod(id, periodId, orgId, userId)
@@ -114,8 +112,8 @@ class FiscalYearController(
     fun closeYear(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val fiscalYear = fiscalYearService.closeYear(id, orgId, userId)
@@ -174,20 +172,6 @@ class FiscalYearController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
-
-    private fun extractUserId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return (authentication.principal as? User)?.uuid
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
@@ -8,15 +8,12 @@ import com.froilan.synectix.dto.JournalEntryResponse
 import com.froilan.synectix.dto.VoidJournalEntryRequest
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryStatus
-import com.froilan.synectix.model.User
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.JournalEntryService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -32,14 +29,15 @@ import java.util.Locale
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class JournalEntryController(
     private val journalEntryService: JournalEntryService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('journal:create')")
     fun createJournalEntry(
         @Valid @RequestBody request: CreateJournalEntryRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val createdBy = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
 
         return try {
             val entry = journalEntryService.createJournalEntry(request, orgId, createdBy)
@@ -56,7 +54,7 @@ class JournalEntryController(
         @RequestParam(required = false) startDate: LocalDate?,
         @RequestParam(required = false) endDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         val entryStatus =
             if (status != null) {
@@ -80,7 +78,7 @@ class JournalEntryController(
     fun getJournalEntry(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val entry = journalEntryService.getJournalEntry(id, orgId)
@@ -95,7 +93,7 @@ class JournalEntryController(
     fun postJournalEntry(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val entry = journalEntryService.postJournalEntry(id, orgId)
@@ -112,7 +110,7 @@ class JournalEntryController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidJournalEntryRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val entry = journalEntryService.voidJournalEntry(id, orgId, request.reason)
@@ -128,7 +126,7 @@ class JournalEntryController(
     fun getTrialBalance(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
         val trialBalance = journalEntryService.getTrialBalance(orgId, asOfDate)
         return ResponseEntity.ok(trialBalance)
     }
@@ -161,20 +159,6 @@ class JournalEntryController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
-
-    private fun extractUserId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return (authentication.principal as? User)?.uuid
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -6,14 +6,12 @@ import com.froilan.synectix.dto.CreateVendorRequest
 import com.froilan.synectix.dto.UpdateVendorRequest
 import com.froilan.synectix.dto.VendorResponse
 import com.froilan.synectix.model.Vendor
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.VendorService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -28,13 +26,14 @@ import org.springframework.web.bind.annotation.RestController
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class VendorController(
     private val vendorService: VendorService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('ap:create')")
     fun createVendor(
         @Valid @RequestBody request: CreateVendorRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val vendor = vendorService.createVendor(request, orgId)
@@ -47,7 +46,7 @@ class VendorController(
     @GetMapping
     @PreAuthorize("hasAuthority('ap:read')")
     fun listVendors(): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
         val vendors = vendorService.listVendors(orgId)
         return ResponseEntity.ok(vendors.map { it.toResponse() })
     }
@@ -57,7 +56,7 @@ class VendorController(
     fun getVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val vendor = vendorService.getVendor(id, orgId)
@@ -75,7 +74,7 @@ class VendorController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateVendorRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val vendor = vendorService.updateVendor(id, request, orgId)
@@ -94,7 +93,7 @@ class VendorController(
     fun deleteVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val vendor = vendorService.deleteVendor(id, orgId)
@@ -122,15 +121,6 @@ class VendorController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/security/AuthenticationContext.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/AuthenticationContext.kt
@@ -1,0 +1,22 @@
+package com.froilan.synectix.security
+
+import com.froilan.synectix.model.User
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+@Component
+class AuthenticationContext {
+    fun organizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    fun userId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return (authentication.principal as? User)?.uuid
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
@@ -85,6 +86,9 @@ class AccountControllerTest {
     @MockitoBean
     private lateinit var journalEntryService: JournalEntryService
 
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
     private val testUser =
         User(
             uuid = "user-123",
@@ -100,6 +104,8 @@ class AccountControllerTest {
     @BeforeEach
     fun setup() {
         setupAuthWithPermissions("account:create", "account:read", "account:update", "account:delete")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+        `when`(authenticationContext.userId()).thenReturn("user-123")
     }
 
     private fun setupAuthWithPermissions(vararg permissions: String) {

--- a/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
@@ -17,6 +17,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
@@ -94,6 +95,9 @@ class JournalEntryControllerTest {
     @MockitoBean
     private lateinit var apiKeyService: ApiKeyService
 
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
     private val testUser =
         User(
             uuid = "user-123",
@@ -109,6 +113,8 @@ class JournalEntryControllerTest {
     @BeforeEach
     fun setup() {
         setupAuthWithPermissions("journal:create", "journal:read", "journal:post", "journal:void", "account:read")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+        `when`(authenticationContext.userId()).thenReturn("user-123")
     }
 
     private fun setupAuthWithPermissions(vararg permissions: String) {

--- a/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
@@ -1,0 +1,92 @@
+package com.froilan.synectix.security
+
+import com.froilan.synectix.model.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+
+class AuthenticationContextTest {
+    private val authContext = AuthenticationContext()
+
+    @AfterEach
+    fun cleanup() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `organizationId should return id from SessionContext`() {
+        val auth = UsernamePasswordAuthenticationToken("principal", null, emptyList())
+        auth.details = SessionContext(sessionId = "s-1", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.organizationId()).isEqualTo("org-123")
+    }
+
+    @Test
+    fun `organizationId should return id from ApiKeyContext`() {
+        val auth = UsernamePasswordAuthenticationToken("principal", null, emptyList())
+        auth.details = ApiKeyContext(apiKeyId = "ak-1", organizationId = "org-456")
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.organizationId()).isEqualTo("org-456")
+    }
+
+    @Test
+    fun `organizationId should return null when no authentication`() {
+        SecurityContextHolder.clearContext()
+
+        assertThat(authContext.organizationId()).isNull()
+    }
+
+    @Test
+    fun `organizationId should return null when details is not SessionContext or ApiKeyContext`() {
+        val auth = UsernamePasswordAuthenticationToken("principal", null, emptyList())
+        auth.details = "some-string"
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.organizationId()).isNull()
+    }
+
+    @Test
+    fun `organizationId should return null when details is null`() {
+        val auth = UsernamePasswordAuthenticationToken("principal", null, emptyList())
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.organizationId()).isNull()
+    }
+
+    @Test
+    fun `userId should return uuid from User principal`() {
+        val user =
+            User(
+                uuid = "user-789",
+                username = "testuser",
+                email = "test@example.com",
+                firstName = "Test",
+                lastName = "User",
+                passwordHash = "encoded",
+                organizationId = "org-123",
+            )
+        val auth = UsernamePasswordAuthenticationToken(user, null, emptyList())
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.userId()).isEqualTo("user-789")
+    }
+
+    @Test
+    fun `userId should return null when principal is not User`() {
+        val auth = UsernamePasswordAuthenticationToken("string-principal", null, emptyList())
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.userId()).isNull()
+    }
+
+    @Test
+    fun `userId should return null when no authentication`() {
+        SecurityContextHolder.clearContext()
+
+        assertThat(authContext.userId()).isNull()
+    }
+}


### PR DESCRIPTION
## Summary
- Extract duplicated `extractOrganizationId()` and `extractUserId()` private methods from 5 controllers into a shared `AuthenticationContext` `@Component` bean
- Inject `AuthenticationContext` via constructor in all finance and account controllers
- Remove ~34 lines of duplicated boilerplate

## Files changed
- **New:** `AuthenticationContext.kt` — shared bean with `organizationId()` and `userId()` methods
- **Modified:** `AccountController`, `JournalEntryController`, `FiscalYearController`, `VendorController`, `BillController` — inject and use `authContext`
- **Modified:** `AccountControllerTest`, `JournalEntryControllerTest` — add `@MockitoBean` for `AuthenticationContext`

## Test plan
- [x] All 243 tests pass (1 pre-existing MongoDB context load failure)
- [x] ktlintCheck passes
- [x] No functional changes — pure refactor