### PR TITLE
Release: Fiscal Periods, Accounts Payable, and AuthenticationContext refactor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -56,6 +56,11 @@ class RoleSeeder(
                             Permissions.FISCAL_CREATE,
                             Permissions.FISCAL_READ,
                             Permissions.FISCAL_CLOSE,
+                            Permissions.AP_CREATE,
+                            Permissions.AP_READ,
+                            Permissions.AP_APPROVE,
+                            Permissions.AP_PAY,
+                            Permissions.AP_VOID,
                         ),
                 ),
                 Role(
@@ -82,6 +87,10 @@ class RoleSeeder(
                             Permissions.FISCAL_CREATE,
                             Permissions.FISCAL_READ,
                             Permissions.FISCAL_CLOSE,
+                            Permissions.AP_CREATE,
+                            Permissions.AP_READ,
+                            Permissions.AP_APPROVE,
+                            Permissions.AP_PAY,
                         ),
                 ),
                 Role(
@@ -99,6 +108,8 @@ class RoleSeeder(
                             Permissions.JOURNAL_CREATE,
                             Permissions.JOURNAL_READ,
                             Permissions.FISCAL_READ,
+                            Permissions.AP_CREATE,
+                            Permissions.AP_READ,
                         ),
                 ),
                 Role(
@@ -112,6 +123,7 @@ class RoleSeeder(
                             Permissions.ACCOUNT_READ,
                             Permissions.JOURNAL_READ,
                             Permissions.FISCAL_READ,
+                            Permissions.AP_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -53,6 +53,9 @@ class RoleSeeder(
                             Permissions.JOURNAL_READ,
                             Permissions.JOURNAL_POST,
                             Permissions.JOURNAL_VOID,
+                            Permissions.FISCAL_CREATE,
+                            Permissions.FISCAL_READ,
+                            Permissions.FISCAL_CLOSE,
                         ),
                 ),
                 Role(
@@ -76,6 +79,9 @@ class RoleSeeder(
                             Permissions.JOURNAL_CREATE,
                             Permissions.JOURNAL_READ,
                             Permissions.JOURNAL_POST,
+                            Permissions.FISCAL_CREATE,
+                            Permissions.FISCAL_READ,
+                            Permissions.FISCAL_CLOSE,
                         ),
                 ),
                 Role(
@@ -92,6 +98,7 @@ class RoleSeeder(
                             Permissions.ACCOUNT_READ,
                             Permissions.JOURNAL_CREATE,
                             Permissions.JOURNAL_READ,
+                            Permissions.FISCAL_READ,
                         ),
                 ),
                 Role(
@@ -104,6 +111,7 @@ class RoleSeeder(
                             Permissions.ORGANIZATION_READ,
                             Permissions.ACCOUNT_READ,
                             Permissions.JOURNAL_READ,
+                            Permissions.FISCAL_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/TokenAuthenticationFilter.kt
@@ -17,6 +17,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 
 @Component
@@ -59,7 +60,7 @@ class TokenAuthenticationFilter(
 
             if (sessionTokenOpt.isPresent) {
                 val sessionToken = sessionTokenOpt.get()
-                if (sessionToken.expiryAt.isAfter(LocalDateTime.now())) {
+                if (sessionToken.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
                     val userOpt = userRepository.findById(sessionToken.userId)
                     if (userOpt.isPresent && userOpt.get().isActive) {
                         val user = userOpt.get()

--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -7,15 +7,13 @@ import com.froilan.synectix.dto.CreateAccountRequest
 import com.froilan.synectix.dto.UpdateAccountRequest
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.AccountService
 import com.froilan.synectix.service.JournalEntryService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -34,13 +32,14 @@ import java.util.Locale
 class AccountController(
     private val accountService: AccountService,
     private val journalEntryService: JournalEntryService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('account:create')")
     fun createAccount(
         @Valid @RequestBody request: CreateAccountRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val account = accountService.createAccount(request, orgId)
@@ -56,7 +55,7 @@ class AccountController(
         @RequestParam(required = false) type: String?,
         @RequestParam(required = false) parentId: String?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         val accountType =
             if (type != null) {
@@ -80,7 +79,7 @@ class AccountController(
     fun getAccount(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val account = accountService.getAccount(id, orgId)
@@ -96,7 +95,7 @@ class AccountController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateAccountRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val account = accountService.updateAccount(id, request, orgId)
@@ -112,7 +111,7 @@ class AccountController(
     fun deleteAccount(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             accountService.deleteAccount(id, orgId)
@@ -129,7 +128,7 @@ class AccountController(
         @PathVariable id: String,
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val balance = journalEntryService.getAccountBalance(id, orgId, asOfDate)
@@ -153,15 +152,6 @@ class AccountController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -12,15 +12,12 @@ import com.froilan.synectix.dto.VoidBillRequest
 import com.froilan.synectix.model.Bill
 import com.froilan.synectix.model.BillPayment
 import com.froilan.synectix.model.BillStatus
-import com.froilan.synectix.model.User
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.BillService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -37,14 +34,15 @@ import java.util.Locale
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class BillController(
     private val billService: BillService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('ap:create')")
     fun createBill(
         @Valid @RequestBody request: CreateBillRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val createdBy = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
 
         return try {
             val bill = billService.createBill(request, orgId, createdBy)
@@ -62,7 +60,7 @@ class BillController(
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) vendorId: String?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         val billStatus =
             if (status != null) {
@@ -86,7 +84,7 @@ class BillController(
     fun getBill(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val bill = billService.getBill(id, orgId)
@@ -103,8 +101,8 @@ class BillController(
     fun approveBill(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val bill = billService.approveBill(id, orgId, userId)
@@ -128,8 +126,8 @@ class BillController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidBillRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val bill = billService.voidBill(id, orgId, request.reason, userId)
@@ -153,8 +151,8 @@ class BillController(
         @PathVariable id: String,
         @Valid @RequestBody request: RecordPaymentRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val createdBy = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
 
         return try {
             val payment = billService.recordPayment(id, request, orgId, createdBy)
@@ -177,7 +175,7 @@ class BillController(
     fun listPayments(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val payments = billService.getPayments(id, orgId)
@@ -194,7 +192,7 @@ class BillController(
     fun getAgingReport(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
         val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
         return ResponseEntity.ok(report)
     }
@@ -257,20 +255,6 @@ class BillController(
             createdBy = createdBy,
             createdAt = createdAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
-
-    private fun extractUserId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return (authentication.principal as? User)?.uuid
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -1,0 +1,279 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.BillLineResponse
+import com.froilan.synectix.dto.BillPaymentResponse
+import com.froilan.synectix.dto.BillResponse
+import com.froilan.synectix.dto.BillSummaryResponse
+import com.froilan.synectix.dto.CreateBillRequest
+import com.froilan.synectix.dto.RecordPaymentRequest
+import com.froilan.synectix.dto.VoidBillRequest
+import com.froilan.synectix.model.Bill
+import com.froilan.synectix.model.BillPayment
+import com.froilan.synectix.model.BillStatus
+import com.froilan.synectix.model.User
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.BillService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.Locale
+
+@RestController
+@RequestMapping("/finance/ap/bills")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class BillController(
+    private val billService: BillService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('ap:create')")
+    fun createBill(
+        @Valid @RequestBody request: CreateBillRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val createdBy = extractUserId() ?: "api-key"
+
+        return try {
+            val bill = billService.createBill(request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(bill.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity
+                .badRequest()
+                .body(mapOf("error" to (e.message ?: "Failed to create bill")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun listBills(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) vendorId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        val billStatus =
+            if (status != null) {
+                try {
+                    BillStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity
+                        .badRequest()
+                        .body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+
+        val bills = billService.listBills(orgId, billStatus, vendorId)
+        return ResponseEntity.ok(bills.map { it.toSummaryResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun getBill(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val bill = billService.getBill(id, orgId)
+            ResponseEntity.ok(bill.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Bill not found")))
+        }
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('ap:approve')")
+    fun approveBill(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val bill = billService.approveBill(id, orgId, userId)
+            ResponseEntity.ok(bill.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
+        }
+    }
+
+    @PostMapping("/{id}/void")
+    @PreAuthorize("hasAuthority('ap:void')")
+    fun voidBill(
+        @PathVariable id: String,
+        @Valid @RequestBody request: VoidBillRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val bill = billService.voidBill(id, orgId, request.reason, userId)
+            ResponseEntity.ok(bill.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to void bill")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to void bill")))
+        }
+    }
+
+    @PostMapping("/{id}/payments")
+    @PreAuthorize("hasAuthority('ap:pay')")
+    fun recordPayment(
+        @PathVariable id: String,
+        @Valid @RequestBody request: RecordPaymentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val createdBy = extractUserId() ?: "api-key"
+
+        return try {
+            val payment = billService.recordPayment(id, request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(payment.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to record payment")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to record payment")))
+        }
+    }
+
+    @GetMapping("/{id}/payments")
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun listPayments(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val payments = billService.getPayments(id, orgId)
+            ResponseEntity.ok(payments.map { it.toResponse() })
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Bill not found")))
+        }
+    }
+
+    @GetMapping("/aging")
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun getAgingReport(
+        @RequestParam(required = false) asOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
+        return ResponseEntity.ok(report)
+    }
+
+    private fun Bill.toResponse() =
+        BillResponse(
+            id = id,
+            billNumber = billNumber,
+            vendorId = vendorId,
+            vendorName = vendorName,
+            date = date.toString(),
+            dueDate = dueDate.toString(),
+            referenceNumber = referenceNumber,
+            organizationId = organizationId,
+            status = status.name,
+            lines =
+                lines.map { line ->
+                    BillLineResponse(
+                        accountId = line.accountId,
+                        accountCode = line.accountCode,
+                        accountName = line.accountName,
+                        amount = line.amount,
+                        description = line.description,
+                    )
+                },
+            totalAmount = totalAmount,
+            amountPaid = amountPaid,
+            journalEntryId = journalEntryId,
+            createdBy = createdBy,
+            approvedAt = approvedAt?.toString(),
+            approvedBy = approvedBy,
+            paidAt = paidAt?.toString(),
+            voidedAt = voidedAt?.toString(),
+            voidReason = voidReason,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun Bill.toSummaryResponse() =
+        BillSummaryResponse(
+            id = id,
+            billNumber = billNumber,
+            vendorName = vendorName,
+            date = date.toString(),
+            dueDate = dueDate.toString(),
+            status = status.name,
+            totalAmount = totalAmount,
+            amountPaid = amountPaid,
+        )
+
+    private fun BillPayment.toResponse() =
+        BillPaymentResponse(
+            id = id,
+            billId = billId,
+            paymentDate = paymentDate.toString(),
+            amount = amount,
+            paymentMethod = paymentMethod.name,
+            referenceNumber = referenceNumber,
+            journalEntryId = journalEntryId,
+            createdBy = createdBy,
+            createdAt = createdAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun extractUserId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return (authentication.principal as? User)?.uuid
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -1,0 +1,196 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateFiscalYearRequest
+import com.froilan.synectix.dto.FiscalPeriodResponse
+import com.froilan.synectix.dto.FiscalYearResponse
+import com.froilan.synectix.dto.FiscalYearSummaryResponse
+import com.froilan.synectix.model.FiscalYear
+import com.froilan.synectix.model.User
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.FiscalYearService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/finance/fiscal")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class FiscalYearController(
+    private val fiscalYearService: FiscalYearService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('fiscal:create')")
+    fun createFiscalYear(
+        @Valid @RequestBody request: CreateFiscalYearRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val fiscalYear = fiscalYearService.createFiscalYear(request, orgId)
+            ResponseEntity.status(HttpStatus.CREATED).body(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create fiscal year")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('fiscal:read')")
+    fun listFiscalYears(): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val fiscalYears = fiscalYearService.listFiscalYears(orgId)
+        return ResponseEntity.ok(fiscalYears.map { it.toSummaryResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('fiscal:read')")
+    fun getFiscalYear(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
+            ResponseEntity.ok(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Fiscal year not found")))
+        }
+    }
+
+    @PostMapping("/{id}/periods/{periodId}/close")
+    @PreAuthorize("hasAuthority('fiscal:close')")
+    fun closePeriod(
+        @PathVariable id: String,
+        @PathVariable periodId: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val fiscalYear = fiscalYearService.closePeriod(id, periodId, orgId, userId)
+            ResponseEntity.ok(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Fiscal period not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to close period")))
+        }
+    }
+
+    @PostMapping("/{id}/periods/{periodId}/reopen")
+    @PreAuthorize("hasAuthority('fiscal:close')")
+    fun reopenPeriod(
+        @PathVariable id: String,
+        @PathVariable periodId: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val fiscalYear = fiscalYearService.reopenPeriod(id, periodId, orgId, userId)
+            ResponseEntity.ok(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status = if (e.message == "Fiscal period not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to reopen period")))
+        }
+    }
+
+    @PostMapping("/{id}/close")
+    @PreAuthorize("hasAuthority('fiscal:close')")
+    fun closeYear(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val userId = extractUserId() ?: "api-key"
+
+        return try {
+            val fiscalYear = fiscalYearService.closeYear(id, orgId, userId)
+            ResponseEntity.ok(fiscalYear.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Fiscal year not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to close fiscal year")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to generate closing entry")))
+        }
+    }
+
+    private fun FiscalYear.toResponse() =
+        FiscalYearResponse(
+            id = id,
+            name = name,
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
+            status = status.name,
+            organizationId = organizationId,
+            periods =
+                periods.map { period ->
+                    FiscalPeriodResponse(
+                        id = period.id,
+                        periodNumber = period.periodNumber,
+                        name = period.name,
+                        startDate = period.startDate.toString(),
+                        endDate = period.endDate.toString(),
+                        status = period.status.name,
+                        closedAt = period.closedAt?.toString(),
+                        closedBy = period.closedBy,
+                        reopenedAt = period.reopenedAt?.toString(),
+                        reopenedBy = period.reopenedBy,
+                    )
+                },
+            closedAt = closedAt?.toString(),
+            closedBy = closedBy,
+            closingEntryId = closingEntryId,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun FiscalYear.toSummaryResponse() =
+        FiscalYearSummaryResponse(
+            id = id,
+            name = name,
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
+            status = status.name,
+            organizationId = organizationId,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun extractUserId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return (authentication.principal as? User)?.uuid
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -7,15 +7,12 @@ import com.froilan.synectix.dto.FiscalPeriodResponse
 import com.froilan.synectix.dto.FiscalYearResponse
 import com.froilan.synectix.dto.FiscalYearSummaryResponse
 import com.froilan.synectix.model.FiscalYear
-import com.froilan.synectix.model.User
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.FiscalYearService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -28,13 +25,14 @@ import org.springframework.web.bind.annotation.RestController
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class FiscalYearController(
     private val fiscalYearService: FiscalYearService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('fiscal:create')")
     fun createFiscalYear(
         @Valid @RequestBody request: CreateFiscalYearRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val fiscalYear = fiscalYearService.createFiscalYear(request, orgId)
@@ -47,7 +45,7 @@ class FiscalYearController(
     @GetMapping
     @PreAuthorize("hasAuthority('fiscal:read')")
     fun listFiscalYears(): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
         val fiscalYears = fiscalYearService.listFiscalYears(orgId)
         return ResponseEntity.ok(fiscalYears.map { it.toSummaryResponse() })
     }
@@ -57,7 +55,7 @@ class FiscalYearController(
     fun getFiscalYear(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
@@ -75,8 +73,8 @@ class FiscalYearController(
         @PathVariable id: String,
         @PathVariable periodId: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val fiscalYear = fiscalYearService.closePeriod(id, periodId, orgId, userId)
@@ -95,8 +93,8 @@ class FiscalYearController(
         @PathVariable id: String,
         @PathVariable periodId: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val fiscalYear = fiscalYearService.reopenPeriod(id, periodId, orgId, userId)
@@ -114,8 +112,8 @@ class FiscalYearController(
     fun closeYear(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val userId = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
 
         return try {
             val fiscalYear = fiscalYearService.closeYear(id, orgId, userId)
@@ -174,20 +172,6 @@ class FiscalYearController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
-
-    private fun extractUserId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return (authentication.principal as? User)?.uuid
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @RestController
 @RequestMapping("/health")
@@ -25,7 +26,7 @@ class HealthController(
         val healthData =
             mutableMapOf<String, Any>(
                 "status" to "UP",
-                "timestamp" to LocalDateTime.now(),
+                "timestamp" to LocalDateTime.now(ZoneOffset.UTC),
                 "application" to "Synectix ERP System",
                 "version" to "0.0.1-SNAPSHOT",
             )
@@ -56,7 +57,7 @@ class HealthController(
         val detailedHealth =
             mutableMapOf<String, Any>(
                 "status" to "UP",
-                "timestamp" to LocalDateTime.now(),
+                "timestamp" to LocalDateTime.now(ZoneOffset.UTC),
                 "application" to
                     mapOf(
                         "name" to "Synectix ERP System",

--- a/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
@@ -8,15 +8,12 @@ import com.froilan.synectix.dto.JournalEntryResponse
 import com.froilan.synectix.dto.VoidJournalEntryRequest
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryStatus
-import com.froilan.synectix.model.User
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.JournalEntryService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -32,14 +29,15 @@ import java.util.Locale
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class JournalEntryController(
     private val journalEntryService: JournalEntryService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('journal:create')")
     fun createJournalEntry(
         @Valid @RequestBody request: CreateJournalEntryRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
-        val createdBy = extractUserId() ?: "api-key"
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
 
         return try {
             val entry = journalEntryService.createJournalEntry(request, orgId, createdBy)
@@ -56,7 +54,7 @@ class JournalEntryController(
         @RequestParam(required = false) startDate: LocalDate?,
         @RequestParam(required = false) endDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         val entryStatus =
             if (status != null) {
@@ -80,7 +78,7 @@ class JournalEntryController(
     fun getJournalEntry(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val entry = journalEntryService.getJournalEntry(id, orgId)
@@ -95,7 +93,7 @@ class JournalEntryController(
     fun postJournalEntry(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val entry = journalEntryService.postJournalEntry(id, orgId)
@@ -112,7 +110,7 @@ class JournalEntryController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidJournalEntryRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val entry = journalEntryService.voidJournalEntry(id, orgId, request.reason)
@@ -128,7 +126,7 @@ class JournalEntryController(
     fun getTrialBalance(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
         val trialBalance = journalEntryService.getTrialBalance(orgId, asOfDate)
         return ResponseEntity.ok(trialBalance)
     }
@@ -161,20 +159,6 @@ class JournalEntryController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
-
-    private fun extractUserId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return (authentication.principal as? User)?.uuid
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -6,14 +6,12 @@ import com.froilan.synectix.dto.CreateVendorRequest
 import com.froilan.synectix.dto.UpdateVendorRequest
 import com.froilan.synectix.dto.VendorResponse
 import com.froilan.synectix.model.Vendor
-import com.froilan.synectix.security.ApiKeyContext
-import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.VendorService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -28,13 +26,14 @@ import org.springframework.web.bind.annotation.RestController
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class VendorController(
     private val vendorService: VendorService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('ap:create')")
     fun createVendor(
         @Valid @RequestBody request: CreateVendorRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val vendor = vendorService.createVendor(request, orgId)
@@ -47,7 +46,7 @@ class VendorController(
     @GetMapping
     @PreAuthorize("hasAuthority('ap:read')")
     fun listVendors(): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
         val vendors = vendorService.listVendors(orgId)
         return ResponseEntity.ok(vendors.map { it.toResponse() })
     }
@@ -57,7 +56,7 @@ class VendorController(
     fun getVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val vendor = vendorService.getVendor(id, orgId)
@@ -75,7 +74,7 @@ class VendorController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateVendorRequest,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val vendor = vendorService.updateVendor(id, request, orgId)
@@ -94,7 +93,7 @@ class VendorController(
     fun deleteVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = extractOrganizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
             val vendor = vendorService.deleteVendor(id, orgId)
@@ -122,15 +121,6 @@ class VendorController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun extractOrganizationId(): String? {
-        val authentication = SecurityContextHolder.getContext().authentication ?: return null
-        return when (val details = authentication.details) {
-            is SessionContext -> details.organizationId
-            is ApiKeyContext -> details.organizationId
-            else -> null
-        }
-    }
 
     private fun unauthorized(): ResponseEntity<Any> =
         ResponseEntity

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -1,0 +1,139 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateVendorRequest
+import com.froilan.synectix.dto.UpdateVendorRequest
+import com.froilan.synectix.dto.VendorResponse
+import com.froilan.synectix.model.Vendor
+import com.froilan.synectix.security.ApiKeyContext
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.service.VendorService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/finance/ap/vendors")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class VendorController(
+    private val vendorService: VendorService,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('ap:create')")
+    fun createVendor(
+        @Valid @RequestBody request: CreateVendorRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val vendor = vendorService.createVendor(request, orgId)
+            ResponseEntity.status(HttpStatus.CREATED).body(vendor.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create vendor")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun listVendors(): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+        val vendors = vendorService.listVendors(orgId)
+        return ResponseEntity.ok(vendors.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('ap:read')")
+    fun getVendor(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val vendor = vendorService.getVendor(id, orgId)
+            ResponseEntity.ok(vendor.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Vendor not found")))
+        }
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('ap:create')")
+    fun updateVendor(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateVendorRequest,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val vendor = vendorService.updateVendor(id, request, orgId)
+            ResponseEntity.ok(vendor.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Vendor not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to update vendor")))
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('ap:create')")
+    fun deleteVendor(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = extractOrganizationId() ?: return unauthorized()
+
+        return try {
+            val vendor = vendorService.deleteVendor(id, orgId)
+            ResponseEntity.ok(vendor.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Vendor not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to delete vendor")))
+        }
+    }
+
+    private fun Vendor.toResponse() =
+        VendorResponse(
+            id = id,
+            name = name,
+            contactName = contactName,
+            contactEmail = contactEmail,
+            contactPhone = contactPhone,
+            paymentTermDays = paymentTermDays,
+            defaultExpenseAccountId = defaultExpenseAccountId,
+            organizationId = organizationId,
+            isActive = isActive,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun extractOrganizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/BillDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/BillDtos.kt
@@ -1,0 +1,117 @@
+package com.froilan.synectix.dto
+
+import com.froilan.synectix.model.PaymentMethod
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class BillLineRequest(
+    @field:NotBlank(message = "Account ID is required")
+    val accountId: String,
+    @field:Positive(message = "Amount must be positive")
+    val amount: BigDecimal,
+    val description: String? = null,
+)
+
+data class CreateBillRequest(
+    @field:NotBlank(message = "Vendor ID is required")
+    val vendorId: String,
+    val date: LocalDate,
+    val dueDate: LocalDate,
+    val referenceNumber: String? = null,
+    @field:NotEmpty(message = "At least one line item is required")
+    @field:Valid
+    val lines: List<BillLineRequest>,
+)
+
+data class VoidBillRequest(
+    @field:NotBlank(message = "Void reason is required")
+    val reason: String,
+)
+
+data class RecordPaymentRequest(
+    val paymentDate: LocalDate,
+    @field:Positive(message = "Payment amount must be positive")
+    val amount: BigDecimal,
+    val paymentMethod: PaymentMethod,
+    val referenceNumber: String? = null,
+)
+
+data class BillLineResponse(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val amount: BigDecimal,
+    val description: String?,
+)
+
+data class BillResponse(
+    val id: String,
+    val billNumber: String,
+    val vendorId: String,
+    val vendorName: String,
+    val date: String,
+    val dueDate: String,
+    val referenceNumber: String?,
+    val organizationId: String,
+    val status: String,
+    val lines: List<BillLineResponse>,
+    val totalAmount: BigDecimal,
+    val amountPaid: BigDecimal,
+    val journalEntryId: String?,
+    val createdBy: String,
+    val approvedAt: String?,
+    val approvedBy: String?,
+    val paidAt: String?,
+    val voidedAt: String?,
+    val voidReason: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class BillSummaryResponse(
+    val id: String,
+    val billNumber: String,
+    val vendorName: String,
+    val date: String,
+    val dueDate: String,
+    val status: String,
+    val totalAmount: BigDecimal,
+    val amountPaid: BigDecimal,
+)
+
+data class BillPaymentResponse(
+    val id: String,
+    val billId: String,
+    val paymentDate: String,
+    val amount: BigDecimal,
+    val paymentMethod: String,
+    val referenceNumber: String?,
+    val journalEntryId: String?,
+    val createdBy: String,
+    val createdAt: String?,
+)
+
+data class AgingBucket(
+    val current: BigDecimal,
+    val days1to30: BigDecimal,
+    val days31to60: BigDecimal,
+    val days61to90: BigDecimal,
+    val days90plus: BigDecimal,
+    val total: BigDecimal,
+)
+
+data class VendorAgingResponse(
+    val vendorId: String,
+    val vendorName: String,
+    val aging: AgingBucket,
+)
+
+data class ApAgingReportResponse(
+    val asOfDate: String,
+    val vendors: List<VendorAgingResponse>,
+    val totals: AgingBucket,
+)

--- a/src/main/kotlin/com/froilan/synectix/dto/FiscalYearDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/FiscalYearDtos.kt
@@ -1,0 +1,50 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDate
+
+data class CreateFiscalYearRequest(
+    @field:NotBlank(message = "Fiscal year name is required")
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+)
+
+data class FiscalPeriodResponse(
+    val id: String,
+    val periodNumber: Int,
+    val name: String,
+    val startDate: String,
+    val endDate: String,
+    val status: String,
+    val closedAt: String?,
+    val closedBy: String?,
+    val reopenedAt: String?,
+    val reopenedBy: String?,
+)
+
+data class FiscalYearResponse(
+    val id: String,
+    val name: String,
+    val startDate: String,
+    val endDate: String,
+    val status: String,
+    val organizationId: String,
+    val periods: List<FiscalPeriodResponse>,
+    val closedAt: String?,
+    val closedBy: String?,
+    val closingEntryId: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class FiscalYearSummaryResponse(
+    val id: String,
+    val name: String,
+    val startDate: String,
+    val endDate: String,
+    val status: String,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/dto/VendorDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/VendorDtos.kt
@@ -1,0 +1,42 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+data class CreateVendorRequest(
+    @field:NotBlank(message = "Vendor name is required")
+    val name: String,
+    val contactName: String? = null,
+    @field:Email(message = "Invalid email format")
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    @field:Min(value = 0, message = "Payment term days must be zero or positive")
+    val paymentTermDays: Int = 30,
+    val defaultExpenseAccountId: String? = null,
+)
+
+data class UpdateVendorRequest(
+    val name: String? = null,
+    val contactName: String? = null,
+    @field:Email(message = "Invalid email format")
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    @field:Min(value = 0, message = "Payment term days must be zero or positive")
+    val paymentTermDays: Int? = null,
+    val defaultExpenseAccountId: String? = null,
+)
+
+data class VendorResponse(
+    val id: String,
+    val name: String,
+    val contactName: String?,
+    val contactEmail: String?,
+    val contactPhone: String?,
+    val paymentTermDays: Int,
+    val defaultExpenseAccountId: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Bill.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Bill.kt
@@ -1,0 +1,72 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class BillStatus {
+    DRAFT,
+    APPROVED,
+    PARTIALLY_PAID,
+    PAID,
+    VOID,
+}
+
+enum class PaymentMethod {
+    CASH,
+    CHECK,
+    BANK_TRANSFER,
+    CREDIT_CARD,
+    OTHER,
+}
+
+data class BillLine(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val amount: BigDecimal,
+    val description: String? = null,
+)
+
+@Document(collection = "bills")
+@CompoundIndex(
+    name = "unique_bill_number_per_org",
+    def = "{'organizationId': 1, 'billNumber': 1}",
+    unique = true,
+)
+@CompoundIndex(name = "org_status", def = "{'organizationId': 1, 'status': 1}")
+@CompoundIndex(name = "org_vendor", def = "{'organizationId': 1, 'vendorId': 1}")
+data class Bill(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val billNumber: String,
+    val vendorId: String,
+    val vendorName: String,
+    val date: LocalDate,
+    val dueDate: LocalDate,
+    val referenceNumber: String? = null,
+    @Indexed
+    val organizationId: String,
+    val status: BillStatus = BillStatus.DRAFT,
+    val lines: List<BillLine>,
+    val totalAmount: BigDecimal,
+    val amountPaid: BigDecimal = BigDecimal.ZERO,
+    val journalEntryId: String? = null,
+    val createdBy: String,
+    val approvedAt: LocalDateTime? = null,
+    val approvedBy: String? = null,
+    val paidAt: LocalDateTime? = null,
+    val voidedAt: LocalDateTime? = null,
+    val voidReason: String? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/BillPayment.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/BillPayment.kt
@@ -1,0 +1,33 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "bill_payments")
+@CompoundIndex(
+    name = "org_bill_payment",
+    def = "{'organizationId': 1, 'billId': 1}",
+)
+data class BillPayment(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    @Indexed
+    val billId: String,
+    val paymentDate: LocalDate,
+    val amount: BigDecimal,
+    val paymentMethod: PaymentMethod,
+    val referenceNumber: String? = null,
+    val journalEntryId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val createdBy: String,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/FiscalYear.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/FiscalYear.kt
@@ -1,0 +1,60 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class FiscalYearStatus {
+    ACTIVE,
+    CLOSED,
+}
+
+enum class FiscalPeriodStatus {
+    OPEN,
+    CLOSED,
+    REOPENED,
+}
+
+data class FiscalPeriod(
+    val id: String = UUID.randomUUID().toString(),
+    val periodNumber: Int,
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val status: FiscalPeriodStatus = FiscalPeriodStatus.OPEN,
+    val closedAt: LocalDateTime? = null,
+    val closedBy: String? = null,
+    val reopenedAt: LocalDateTime? = null,
+    val reopenedBy: String? = null,
+)
+
+@Document(collection = "fiscal_years")
+@CompoundIndex(
+    name = "unique_name_per_org",
+    def = "{'organizationId': 1, 'name': 1}",
+    unique = true,
+)
+data class FiscalYear(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val status: FiscalYearStatus = FiscalYearStatus.ACTIVE,
+    @Indexed
+    val organizationId: String,
+    val periods: List<FiscalPeriod> = emptyList(),
+    val closedAt: LocalDateTime? = null,
+    val closedBy: String? = null,
+    val closingEntryId: String? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Organizations.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Organizations.kt
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Document(collection = "organizations")
@@ -21,6 +22,6 @@ data class Organizations(
     val fiscalYearStart: LocalDateTime,
     val timezone: String,
     val status: String = "ACTIVE",
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
     val isActive: Boolean = true,
 )

--- a/src/main/kotlin/com/froilan/synectix/model/PasswordResetToken.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/PasswordResetToken.kt
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Document(collection = "password_reset_tokens")
@@ -15,5 +16,5 @@ data class PasswordResetToken(
     val userId: String,
     @Indexed(expireAfterSeconds = 0)
     val expiryAt: LocalDateTime,
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
 )

--- a/src/main/kotlin/com/froilan/synectix/model/RefreshToken.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/RefreshToken.kt
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Document(collection = "refresh_tokens")
@@ -16,5 +17,5 @@ data class RefreshToken(
     val sessionTokenId: String,
     @Indexed(expireAfterSeconds = 0)
     val expiryAt: LocalDateTime,
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
 )

--- a/src/main/kotlin/com/froilan/synectix/model/SessionToken.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/SessionToken.kt
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Document(collection = "session_tokens")
@@ -18,5 +19,5 @@ data class SessionToken(
     val expiryAt: LocalDateTime,
     val ipAddress: String? = null,
     val userAgent: String? = null,
-    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
 )

--- a/src/main/kotlin/com/froilan/synectix/model/Vendor.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Vendor.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "vendors")
+@CompoundIndex(
+    name = "unique_name_per_org",
+    def = "{'organizationId': 1, 'name': 1}",
+    unique = true,
+)
+data class Vendor(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val contactName: String? = null,
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    val paymentTermDays: Int = 30,
+    val defaultExpenseAccountId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/BillPaymentRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/BillPaymentRepository.kt
@@ -1,0 +1,15 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.BillPayment
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface BillPaymentRepository : MongoRepository<BillPayment, String> {
+    fun findByBillIdAndOrganizationId(
+        billId: String,
+        organizationId: String,
+    ): List<BillPayment>
+
+    fun findByOrganizationId(organizationId: String): List<BillPayment>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/BillRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/BillRepository.kt
@@ -1,0 +1,41 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Bill
+import com.froilan.synectix.model.BillStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+interface BillRepository : MongoRepository<Bill, String> {
+    fun findByOrganizationId(organizationId: String): List<Bill>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: BillStatus,
+    ): List<Bill>
+
+    fun findByOrganizationIdAndVendorId(
+        organizationId: String,
+        vendorId: String,
+    ): List<Bill>
+
+    fun findByOrganizationIdAndStatusAndVendorId(
+        organizationId: String,
+        status: BillStatus,
+        vendorId: String,
+    ): List<Bill>
+
+    fun findByOrganizationIdAndStatusIn(
+        organizationId: String,
+        statuses: List<BillStatus>,
+    ): List<Bill>
+
+    fun findByOrganizationIdAndDateBetween(
+        organizationId: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<Bill>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/FiscalYearRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/FiscalYearRepository.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.FiscalYear
+import com.froilan.synectix.model.FiscalYearStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FiscalYearRepository : MongoRepository<FiscalYear, String> {
+    fun findByOrganizationId(organizationId: String): List<FiscalYear>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: FiscalYearStatus,
+    ): List<FiscalYear>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
@@ -55,6 +55,13 @@ interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
         statuses: List<JournalEntryStatus>,
     ): List<JournalEntry>
 
+    fun findByOrganizationIdAndStatusInAndDateBetween(
+        organizationId: String,
+        statuses: List<JournalEntryStatus>,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<JournalEntry>
+
     fun findByOrganizationIdAndStatusInAndDateLessThanEqual(
         organizationId: String,
         statuses: List<JournalEntryStatus>,
@@ -62,4 +69,9 @@ interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
     ): List<JournalEntry>
 
     fun countByOrganizationId(organizationId: String): Long
+
+    fun existsByOrganizationIdAndSourceReference(
+        organizationId: String,
+        sourceReference: String,
+    ): Boolean
 }

--- a/src/main/kotlin/com/froilan/synectix/repository/VendorRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/VendorRepository.kt
@@ -1,0 +1,13 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Vendor
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface VendorRepository : MongoRepository<Vendor, String> {
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Vendor>
+}

--- a/src/main/kotlin/com/froilan/synectix/security/AuthenticationContext.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/AuthenticationContext.kt
@@ -1,0 +1,22 @@
+package com.froilan.synectix.security
+
+import com.froilan.synectix.model.User
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+@Component
+class AuthenticationContext {
+    fun organizationId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return when (val details = authentication.details) {
+            is SessionContext -> details.organizationId
+            is ApiKeyContext -> details.organizationId
+            else -> null
+        }
+    }
+
+    fun userId(): String? {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return null
+        return (authentication.principal as? User)?.uuid
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -33,6 +33,12 @@ object Permissions {
     const val FISCAL_READ = "fiscal:read"
     const val FISCAL_CLOSE = "fiscal:close"
 
+    const val AP_CREATE = "ap:create"
+    const val AP_READ = "ap:read"
+    const val AP_APPROVE = "ap:approve"
+    const val AP_PAY = "ap:pay"
+    const val AP_VOID = "ap:void"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -58,5 +64,10 @@ object Permissions {
             FISCAL_CREATE,
             FISCAL_READ,
             FISCAL_CLOSE,
+            AP_CREATE,
+            AP_READ,
+            AP_APPROVE,
+            AP_PAY,
+            AP_VOID,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -29,6 +29,10 @@ object Permissions {
     const val JOURNAL_POST = "journal:post"
     const val JOURNAL_VOID = "journal:void"
 
+    const val FISCAL_CREATE = "fiscal:create"
+    const val FISCAL_READ = "fiscal:read"
+    const val FISCAL_CLOSE = "fiscal:close"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -51,5 +55,8 @@ object Permissions {
             JOURNAL_READ,
             JOURNAL_POST,
             JOURNAL_VOID,
+            FISCAL_CREATE,
+            FISCAL_READ,
+            FISCAL_CLOSE,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
@@ -56,7 +56,7 @@ class AccountService(
         return try {
             accountRepository.save(account)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException("Account code '${request.code}' already exists in this organization")
+            throw IllegalArgumentException("Account code '${request.code}' already exists in this organization", e)
         }
     }
 

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Update
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @Service
 class ApiKeyService(
@@ -81,11 +82,11 @@ class ApiKeyService(
         val apiKey = apiKeyRepository.findByKeyHash(keyHash).orElse(null) ?: return null
 
         if (!apiKey.isActive) return null
-        if (apiKey.expiresAt != null && !apiKey.expiresAt.isAfter(LocalDateTime.now())) return null
+        if (apiKey.expiresAt != null && !apiKey.expiresAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) return null
 
         mongoTemplate.updateFirst(
             Query.query(Criteria.where("_id").`is`(apiKey.id)),
-            Update.update("lastUsedAt", LocalDateTime.now()),
+            Update.update("lastUsedAt", LocalDateTime.now(ZoneOffset.UTC)),
             ApiKey::class.java,
         )
 

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -27,6 +27,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.Locale
 
@@ -83,15 +84,15 @@ class AuthService(
             val errorMessage = e.message ?: ""
             when {
                 errorMessage.contains("username", ignoreCase = true) ->
-                    throw IllegalArgumentException("Username already exists")
+                    throw IllegalArgumentException("Username already exists", e)
                 errorMessage.contains("email", ignoreCase = true) ->
-                    throw IllegalArgumentException("Email already exists")
+                    throw IllegalArgumentException("Email already exists", e)
                 errorMessage.contains("orgSlug", ignoreCase = true) ->
-                    throw IllegalArgumentException("Organization slug already exists")
+                    throw IllegalArgumentException("Organization slug already exists", e)
                 errorMessage.contains("name", ignoreCase = true) ->
-                    throw IllegalArgumentException("Organization name already exists")
+                    throw IllegalArgumentException("Organization name already exists", e)
                 else ->
-                    throw IllegalArgumentException("Registration failed due to a conflict")
+                    throw IllegalArgumentException("Registration failed due to a conflict", e)
             }
         }
     }
@@ -116,7 +117,7 @@ class AuthService(
         }
 
         val accessTokenStr = generateToken()
-        val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
+        val expiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(tokenValidityMs, ChronoUnit.MILLIS)
 
         val orgId = user.organizationId
         val sessionToken =
@@ -131,7 +132,7 @@ class AuthService(
         val savedSession = sessionTokenRepository.save(sessionToken)
 
         val refreshTokenStr = generateToken()
-        val refreshExpiryAt = LocalDateTime.now().plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+        val refreshExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
 
         val refreshToken =
             RefreshToken(
@@ -162,7 +163,7 @@ class AuthService(
                 .findByTokenHash(refreshTokenHash)
                 .orElseThrow { IllegalArgumentException("Invalid or expired refresh token") }
 
-        if (!existing.expiryAt.isAfter(LocalDateTime.now())) {
+        if (!existing.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
             throw IllegalArgumentException("Invalid or expired refresh token")
         }
 
@@ -179,7 +180,7 @@ class AuthService(
         val orgId = oldSession?.organizationId ?: user.organizationId
 
         val accessTokenStr = generateToken()
-        val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
+        val expiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(tokenValidityMs, ChronoUnit.MILLIS)
 
         val sessionToken =
             SessionToken(
@@ -192,7 +193,7 @@ class AuthService(
 
         val refreshTokenStr = generateToken()
         val newRefreshTokenHash = tokenHasher.hash(refreshTokenStr)
-        val refreshExpiryAt = LocalDateTime.now().plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+        val refreshExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
 
         val newRefreshToken =
             RefreshToken(
@@ -263,7 +264,7 @@ class AuthService(
             PasswordResetToken(
                 tokenHash = tokenHasher.hash(rawToken),
                 userId = user.uuid,
-                expiryAt = LocalDateTime.now().plusMinutes(resetTokenExpiryMinutes),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(resetTokenExpiryMinutes),
             )
         passwordResetTokenRepository.save(resetToken)
 
@@ -282,7 +283,7 @@ class AuthService(
                 .findByTokenHash(tokenHash)
                 .orElseThrow { IllegalArgumentException("Invalid or expired reset token") }
 
-        if (!existing.expiryAt.isAfter(LocalDateTime.now())) {
+        if (!existing.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
             passwordResetTokenRepository.deleteById(existing.id)
             throw IllegalArgumentException("Invalid or expired reset token")
         }
@@ -306,7 +307,8 @@ class AuthService(
         refreshTokenRepository.deleteByUserId(user.uuid)
     }
 
-    fun listSessions(userId: String): List<SessionToken> = sessionTokenRepository.findByUserIdAndExpiryAtAfter(userId, LocalDateTime.now())
+    fun listSessions(userId: String): List<SessionToken> =
+        sessionTokenRepository.findByUserIdAndExpiryAtAfter(userId, LocalDateTime.now(ZoneOffset.UTC))
 
     @Transactional
     fun revokeSession(
@@ -362,7 +364,7 @@ class AuthService(
         }
 
         val accessTokenStr = generateToken()
-        val expiryAt = LocalDateTime.now().plus(tokenValidityMs, ChronoUnit.MILLIS)
+        val expiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(tokenValidityMs, ChronoUnit.MILLIS)
 
         val sessionToken =
             SessionToken(
@@ -376,7 +378,7 @@ class AuthService(
         val savedSession = sessionTokenRepository.save(sessionToken)
 
         val refreshTokenStr = generateToken()
-        val refreshExpiryAt = LocalDateTime.now().plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+        val refreshExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
 
         val refreshToken =
             RefreshToken(

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -1,0 +1,450 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AgingBucket
+import com.froilan.synectix.dto.ApAgingReportResponse
+import com.froilan.synectix.dto.CreateBillRequest
+import com.froilan.synectix.dto.RecordPaymentRequest
+import com.froilan.synectix.dto.VendorAgingResponse
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.Bill
+import com.froilan.synectix.model.BillLine
+import com.froilan.synectix.model.BillPayment
+import com.froilan.synectix.model.BillStatus
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.BillPaymentRepository
+import com.froilan.synectix.repository.BillRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+@Service
+class BillService(
+    private val billRepository: BillRepository,
+    private val billPaymentRepository: BillPaymentRepository,
+    private val accountRepository: AccountRepository,
+    private val vendorService: VendorService,
+    private val journalEntryService: JournalEntryService,
+) {
+    @Transactional
+    fun createBill(
+        request: CreateBillRequest,
+        organizationId: String,
+        createdBy: String,
+    ): Bill {
+        val vendor = vendorService.getVendor(request.vendorId, organizationId)
+        if (!vendor.isActive) {
+            throw IllegalArgumentException("Cannot create bill for inactive vendor")
+        }
+
+        if (request.date.isAfter(request.dueDate)) {
+            throw IllegalArgumentException("Due date must be on or after bill date")
+        }
+
+        if (request.lines.isEmpty()) {
+            throw IllegalArgumentException("At least one line item is required")
+        }
+
+        request.lines.forEach { line ->
+            if (line.amount <= BigDecimal.ZERO) {
+                throw IllegalArgumentException("Line item amounts must be positive")
+            }
+        }
+
+        val accountIds = request.lines.map { it.accountId }.distinct()
+        val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
+
+        val missingAccounts = accountIds.filter { it !in accounts }
+        if (missingAccounts.isNotEmpty()) {
+            throw IllegalArgumentException("Accounts not found: ${missingAccounts.joinToString(", ")}")
+        }
+
+        accounts.values.forEach { account ->
+            if (account.organizationId != organizationId) {
+                throw IllegalArgumentException("Account '${account.id}' not found")
+            }
+            if (!account.isActive) {
+                throw IllegalArgumentException("Account '${account.code}' is inactive")
+            }
+        }
+
+        val lines =
+            request.lines.map { lineReq ->
+                val account = accounts.getValue(lineReq.accountId)
+                BillLine(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    amount = lineReq.amount,
+                    description = lineReq.description,
+                )
+            }
+
+        val totalAmount = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.amount) }
+
+        return saveBillWithRetry(organizationId) { billNumber ->
+            Bill(
+                billNumber = billNumber,
+                vendorId = vendor.id,
+                vendorName = vendor.name,
+                date = request.date,
+                dueDate = request.dueDate,
+                referenceNumber = request.referenceNumber,
+                organizationId = organizationId,
+                lines = lines,
+                totalAmount = totalAmount,
+                createdBy = createdBy,
+            )
+        }
+    }
+
+    fun getBill(
+        billId: String,
+        organizationId: String,
+    ): Bill {
+        val bill =
+            billRepository.findById(billId).orElseThrow {
+                IllegalArgumentException("Bill not found")
+            }
+        if (bill.organizationId != organizationId) {
+            throw IllegalArgumentException("Bill not found")
+        }
+        return bill
+    }
+
+    fun listBills(
+        organizationId: String,
+        status: BillStatus? = null,
+        vendorId: String? = null,
+    ): List<Bill> =
+        when {
+            status != null && vendorId != null ->
+                billRepository.findByOrganizationIdAndStatusAndVendorId(organizationId, status, vendorId)
+            status != null ->
+                billRepository.findByOrganizationIdAndStatus(organizationId, status)
+            vendorId != null ->
+                billRepository.findByOrganizationIdAndVendorId(organizationId, vendorId)
+            else ->
+                billRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun approveBill(
+        billId: String,
+        organizationId: String,
+        approvedBy: String,
+    ): Bill {
+        val bill = getBill(billId, organizationId)
+
+        if (bill.status != BillStatus.DRAFT) {
+            throw IllegalArgumentException("Only draft bills can be approved")
+        }
+
+        val apAccount = getApAccount(organizationId)
+
+        val journalLines =
+            bill.lines.map { line ->
+                JournalEntryLine(
+                    accountId = line.accountId,
+                    accountCode = line.accountCode,
+                    accountName = line.accountName,
+                    debit = line.amount,
+                    credit = BigDecimal.ZERO,
+                    description = line.description,
+                )
+            } +
+                JournalEntryLine(
+                    accountId = apAccount.id,
+                    accountCode = apAccount.code,
+                    accountName = apAccount.name,
+                    debit = BigDecimal.ZERO,
+                    credit = bill.totalAmount,
+                    description = "AP - ${bill.vendorName} - ${bill.billNumber}",
+                )
+
+        val journalEntry =
+            journalEntryService.createSystemEntry(
+                date = bill.date,
+                description = "Bill ${bill.billNumber} - ${bill.vendorName}",
+                organizationId = organizationId,
+                lines = journalLines,
+                sourceReference = "BILL-APPROVE-${bill.id}",
+                createdBy = approvedBy,
+            )
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        return billRepository.save(
+            bill.copy(
+                status = BillStatus.APPROVED,
+                journalEntryId = journalEntry.id,
+                approvedAt = now,
+                approvedBy = approvedBy,
+            ),
+        )
+    }
+
+    @Transactional
+    fun voidBill(
+        billId: String,
+        organizationId: String,
+        reason: String,
+        voidedBy: String,
+    ): Bill {
+        val bill = getBill(billId, organizationId)
+
+        if (bill.status == BillStatus.VOID) {
+            throw IllegalArgumentException("Bill is already voided")
+        }
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+
+        // Draft voids skip fiscal validation — no GL entries are posted
+        if (bill.status == BillStatus.DRAFT) {
+            return billRepository.save(
+                bill.copy(
+                    status = BillStatus.VOID,
+                    voidedAt = now,
+                    voidReason = reason,
+                ),
+            )
+        }
+        if (bill.amountPaid.compareTo(BigDecimal.ZERO) != 0) {
+            throw IllegalArgumentException("Cannot void a bill with recorded payments")
+        }
+
+        if (bill.journalEntryId != null) {
+            journalEntryService.voidJournalEntry(
+                bill.journalEntryId,
+                organizationId,
+                reason,
+            )
+        }
+
+        return billRepository.save(
+            bill.copy(
+                status = BillStatus.VOID,
+                voidedAt = now,
+                voidReason = reason,
+            ),
+        )
+    }
+
+    @Transactional
+    fun recordPayment(
+        billId: String,
+        request: RecordPaymentRequest,
+        organizationId: String,
+        createdBy: String,
+    ): BillPayment {
+        val bill = getBill(billId, organizationId)
+
+        if (bill.status != BillStatus.APPROVED && bill.status != BillStatus.PARTIALLY_PAID) {
+            throw IllegalArgumentException("Bill must be approved or partially paid to record payment")
+        }
+
+        if (request.amount <= BigDecimal.ZERO) {
+            throw IllegalArgumentException("Payment amount must be positive")
+        }
+
+        val remaining = bill.totalAmount.subtract(bill.amountPaid)
+        if (request.amount.compareTo(remaining) > 0) {
+            throw IllegalArgumentException(
+                "Payment amount exceeds remaining balance of $remaining",
+            )
+        }
+
+        val apAccount = getApAccount(organizationId)
+        val cashAccount = getCashAccount(organizationId)
+
+        val paymentId = UUID.randomUUID().toString()
+
+        val journalEntry =
+            journalEntryService.createSystemEntry(
+                date = request.paymentDate,
+                description = "Payment for bill ${bill.billNumber} - ${bill.vendorName}",
+                organizationId = organizationId,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = apAccount.id,
+                            accountCode = apAccount.code,
+                            accountName = apAccount.name,
+                            debit = request.amount,
+                            credit = BigDecimal.ZERO,
+                            description = "Payment - ${bill.vendorName}",
+                        ),
+                        JournalEntryLine(
+                            accountId = cashAccount.id,
+                            accountCode = cashAccount.code,
+                            accountName = cashAccount.name,
+                            debit = BigDecimal.ZERO,
+                            credit = request.amount,
+                            description = "Payment - ${bill.vendorName}",
+                        ),
+                    ),
+                sourceReference = "BILL-PAYMENT-$paymentId",
+                createdBy = createdBy,
+            )
+
+        val payment =
+            billPaymentRepository.save(
+                BillPayment(
+                    id = paymentId,
+                    billId = bill.id,
+                    paymentDate = request.paymentDate,
+                    amount = request.amount,
+                    paymentMethod = request.paymentMethod,
+                    referenceNumber = request.referenceNumber,
+                    journalEntryId = journalEntry.id,
+                    organizationId = organizationId,
+                    createdBy = createdBy,
+                ),
+            )
+
+        val newAmountPaid = bill.amountPaid.add(request.amount)
+        val fullyPaid = newAmountPaid.compareTo(bill.totalAmount) >= 0
+        val newStatus = if (fullyPaid) BillStatus.PAID else BillStatus.PARTIALLY_PAID
+
+        billRepository.save(
+            bill.copy(
+                amountPaid = newAmountPaid,
+                status = newStatus,
+                paidAt = if (fullyPaid) LocalDateTime.now(ZoneOffset.UTC) else null,
+            ),
+        )
+
+        return payment
+    }
+
+    fun getPayments(
+        billId: String,
+        organizationId: String,
+    ): List<BillPayment> {
+        getBill(billId, organizationId)
+        return billPaymentRepository.findByBillIdAndOrganizationId(billId, organizationId)
+    }
+
+    fun getAgingReport(
+        organizationId: String,
+        asOfDate: LocalDate = LocalDate.now(ZoneOffset.UTC),
+    ): ApAgingReportResponse {
+        val outstandingStatuses =
+            listOf(BillStatus.APPROVED, BillStatus.PARTIALLY_PAID)
+        val bills = billRepository.findByOrganizationIdAndStatusIn(organizationId, outstandingStatuses)
+
+        val vendorBills = bills.groupBy { it.vendorId }
+
+        val vendorAgingList =
+            vendorBills.map { (_, vendorBillList) ->
+                val vendorName = vendorBillList.first().vendorName
+                val vendorId = vendorBillList.first().vendorId
+                val bucket = calculateAgingBucket(vendorBillList, asOfDate)
+                VendorAgingResponse(
+                    vendorId = vendorId,
+                    vendorName = vendorName,
+                    aging = bucket,
+                )
+            }
+
+        val totals =
+            AgingBucket(
+                current = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.current) },
+                days1to30 = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.days1to30) },
+                days31to60 = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.days31to60) },
+                days61to90 = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.days61to90) },
+                days90plus = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.days90plus) },
+                total = vendorAgingList.fold(BigDecimal.ZERO) { sum, v -> sum.add(v.aging.total) },
+            )
+
+        return ApAgingReportResponse(
+            asOfDate = asOfDate.toString(),
+            vendors = vendorAgingList,
+            totals = totals,
+        )
+    }
+
+    private fun calculateAgingBucket(
+        bills: List<Bill>,
+        asOfDate: LocalDate,
+    ): AgingBucket {
+        var current = BigDecimal.ZERO
+        var days1to30 = BigDecimal.ZERO
+        var days31to60 = BigDecimal.ZERO
+        var days61to90 = BigDecimal.ZERO
+        var days90plus = BigDecimal.ZERO
+
+        bills.forEach { bill ->
+            val outstanding = bill.totalAmount.subtract(bill.amountPaid)
+            val daysOverdue = ChronoUnit.DAYS.between(bill.dueDate, asOfDate)
+
+            when {
+                daysOverdue <= 0 -> current = current.add(outstanding)
+                daysOverdue <= 30 -> days1to30 = days1to30.add(outstanding)
+                daysOverdue <= 60 -> days31to60 = days31to60.add(outstanding)
+                daysOverdue <= 90 -> days61to90 = days61to90.add(outstanding)
+                else -> days90plus = days90plus.add(outstanding)
+            }
+        }
+
+        val total =
+            current
+                .add(days1to30)
+                .add(days31to60)
+                .add(days61to90)
+                .add(days90plus)
+        return AgingBucket(
+            current = current,
+            days1to30 = days1to30,
+            days31to60 = days31to60,
+            days61to90 = days61to90,
+            days90plus = days90plus,
+            total = total,
+        )
+    }
+
+    private fun saveBillWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildBill: (String) -> Bill,
+    ): Bill {
+        repeat(maxRetries) {
+            val count = billRepository.countByOrganizationId(organizationId)
+            val billNumber = "BILL-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return billRepository.save(buildBill(billNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique bill number: $billNumber", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique bill number")
+    }
+
+    private fun getApAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "2000").orElseThrow {
+                IllegalStateException("Accounts Payable account (2000) not found")
+            }
+        if (!account.isActive) {
+            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
+        }
+        return account
+    }
+
+    private fun getCashAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "1000").orElseThrow {
+                IllegalStateException("Cash account (1000) not found")
+            }
+        if (!account.isActive) {
+            throw IllegalArgumentException("Cash account (1000) is inactive")
+        }
+        return account
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -1,0 +1,396 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateFiscalYearRequest
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.FiscalPeriod
+import com.froilan.synectix.model.FiscalPeriodStatus
+import com.froilan.synectix.model.FiscalYear
+import com.froilan.synectix.model.FiscalYearStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntrySource
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.FiscalYearRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.TextStyle
+import java.util.Locale
+
+@Service
+class FiscalYearService(
+    private val fiscalYearRepository: FiscalYearRepository,
+    private val journalEntryRepository: JournalEntryRepository,
+    private val accountRepository: AccountRepository,
+    private val entryNumberGenerator: JournalEntryNumberGenerator,
+) {
+    @Transactional
+    fun createFiscalYear(
+        request: CreateFiscalYearRequest,
+        organizationId: String,
+    ): FiscalYear {
+        if (!request.startDate.isBefore(request.endDate)) {
+            throw IllegalArgumentException("Start date must be before end date")
+        }
+
+        val existing = fiscalYearRepository.findByOrganizationId(organizationId)
+
+        val activeFiscalYear = existing.firstOrNull { it.status == FiscalYearStatus.ACTIVE }
+        if (activeFiscalYear != null) {
+            throw IllegalArgumentException(
+                "An active fiscal year '${activeFiscalYear.name}' already exists in this organization",
+            )
+        }
+
+        existing.forEach { fy ->
+            if (!request.startDate.isAfter(fy.endDate) && !request.endDate.isBefore(fy.startDate)) {
+                throw IllegalArgumentException(
+                    "Date range overlaps with existing fiscal year '${fy.name}'",
+                )
+            }
+        }
+
+        val periods = generateMonthlyPeriods(request.startDate, request.endDate)
+
+        val fiscalYear =
+            FiscalYear(
+                name = request.name,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                organizationId = organizationId,
+                periods = periods,
+            )
+
+        return try {
+            fiscalYearRepository.save(fiscalYear)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Fiscal year '${request.name}' already exists in this organization",
+            )
+        }
+    }
+
+    fun getFiscalYear(
+        fiscalYearId: String,
+        organizationId: String,
+    ): FiscalYear = findFiscalYear(fiscalYearId, organizationId)
+
+    fun listFiscalYears(organizationId: String): List<FiscalYear> = fiscalYearRepository.findByOrganizationId(organizationId)
+
+    @Transactional
+    fun closePeriod(
+        fiscalYearId: String,
+        periodId: String,
+        organizationId: String,
+        closedBy: String,
+    ): FiscalYear {
+        val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
+
+        if (fiscalYear.status == FiscalYearStatus.CLOSED) {
+            throw IllegalArgumentException("Fiscal year is already closed")
+        }
+
+        val periodIndex = fiscalYear.periods.indexOfFirst { it.id == periodId }
+        if (periodIndex == -1) {
+            throw IllegalArgumentException("Fiscal period not found")
+        }
+
+        val period = fiscalYear.periods[periodIndex]
+        if (period.status == FiscalPeriodStatus.CLOSED) {
+            throw IllegalArgumentException("Fiscal period is already closed")
+        }
+
+        val precedingOpen =
+            fiscalYear.periods
+                .take(periodIndex)
+                .any { it.status != FiscalPeriodStatus.CLOSED }
+        if (precedingOpen) {
+            throw IllegalArgumentException("All preceding periods must be closed first")
+        }
+
+        val updatedPeriods = fiscalYear.periods.toMutableList()
+        updatedPeriods[periodIndex] =
+            period.copy(
+                status = FiscalPeriodStatus.CLOSED,
+                closedAt = LocalDateTime.now(),
+                closedBy = closedBy,
+            )
+
+        return fiscalYearRepository.save(
+            fiscalYear.copy(periods = updatedPeriods),
+        )
+    }
+
+    @Transactional
+    fun reopenPeriod(
+        fiscalYearId: String,
+        periodId: String,
+        organizationId: String,
+        reopenedBy: String,
+    ): FiscalYear {
+        val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
+
+        if (fiscalYear.status == FiscalYearStatus.CLOSED) {
+            throw IllegalArgumentException("Cannot reopen period in a closed fiscal year")
+        }
+
+        val periodIndex = fiscalYear.periods.indexOfFirst { it.id == periodId }
+        if (periodIndex == -1) {
+            throw IllegalArgumentException("Fiscal period not found")
+        }
+
+        val period = fiscalYear.periods[periodIndex]
+        if (period.status != FiscalPeriodStatus.CLOSED) {
+            throw IllegalArgumentException("Only closed periods can be reopened")
+        }
+
+        val subsequentOpen =
+            fiscalYear.periods
+                .drop(periodIndex + 1)
+                .any { it.status != FiscalPeriodStatus.CLOSED }
+        if (subsequentOpen) {
+            throw IllegalArgumentException("All subsequent periods must be closed first")
+        }
+
+        val updatedPeriods = fiscalYear.periods.toMutableList()
+        updatedPeriods[periodIndex] =
+            period.copy(
+                status = FiscalPeriodStatus.REOPENED,
+                reopenedAt = LocalDateTime.now(),
+                reopenedBy = reopenedBy,
+            )
+
+        return fiscalYearRepository.save(
+            fiscalYear.copy(periods = updatedPeriods),
+        )
+    }
+
+    @Transactional
+    fun closeYear(
+        fiscalYearId: String,
+        organizationId: String,
+        closedBy: String,
+    ): FiscalYear {
+        val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
+
+        if (fiscalYear.status == FiscalYearStatus.CLOSED) {
+            throw IllegalArgumentException("Fiscal year is already closed")
+        }
+
+        val allPeriodsClosed = fiscalYear.periods.all { it.status == FiscalPeriodStatus.CLOSED }
+        if (!allPeriodsClosed) {
+            throw IllegalArgumentException("All periods must be closed before closing the fiscal year")
+        }
+
+        val closingEntry = createClosingEntry(fiscalYear, organizationId, closedBy)
+
+        return fiscalYearRepository.save(
+            fiscalYear.copy(
+                status = FiscalYearStatus.CLOSED,
+                closedAt = LocalDateTime.now(),
+                closedBy = closedBy,
+                closingEntryId = closingEntry?.id,
+            ),
+        )
+    }
+
+    fun findPeriodForDate(
+        organizationId: String,
+        date: LocalDate,
+    ): PeriodLookupResult {
+        val allFiscalYears = fiscalYearRepository.findByOrganizationId(organizationId)
+        if (allFiscalYears.isEmpty()) return PeriodLookupResult.NoFiscalYears
+
+        for (fy in allFiscalYears) {
+            for (period in fy.periods) {
+                if (!date.isBefore(period.startDate) && !date.isAfter(period.endDate)) {
+                    return PeriodLookupResult.Found(period)
+                }
+            }
+        }
+        return PeriodLookupResult.NotFound
+    }
+
+    sealed class PeriodLookupResult {
+        data object NoFiscalYears : PeriodLookupResult()
+
+        data object NotFound : PeriodLookupResult()
+
+        data class Found(
+            val period: FiscalPeriod,
+        ) : PeriodLookupResult()
+    }
+
+    private fun createClosingEntry(
+        fiscalYear: FiscalYear,
+        organizationId: String,
+        closedBy: String,
+    ): JournalEntry? {
+        val sourceRef = "YEAR-END-CLOSE-${fiscalYear.id}"
+        if (journalEntryRepository.existsByOrganizationIdAndSourceReference(organizationId, sourceRef)) {
+            throw IllegalArgumentException("Year-end closing entry already exists for this fiscal year")
+        }
+
+        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
+        val entries =
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                organizationId,
+                postedStatuses,
+                fiscalYear.startDate,
+                fiscalYear.endDate,
+            )
+
+        val accountTotals = mutableMapOf<String, Pair<BigDecimal, BigDecimal>>()
+        entries.forEach { entry ->
+            entry.lines.forEach { line ->
+                val (debits, credits) =
+                    accountTotals.getOrDefault(
+                        line.accountId,
+                        BigDecimal.ZERO to BigDecimal.ZERO,
+                    )
+                accountTotals[line.accountId] = debits.add(line.debit) to credits.add(line.credit)
+            }
+        }
+
+        val accounts =
+            accountRepository
+                .findAllById(accountTotals.keys)
+                .associateBy { it.id }
+
+        val missingAccountIds = accountTotals.keys - accounts.keys
+        if (missingAccountIds.isNotEmpty()) {
+            throw IllegalStateException(
+                "Cannot create closing entry: missing accounts ${missingAccountIds.sorted().joinToString(", ")}",
+            )
+        }
+
+        val closingLines = mutableListOf<JournalEntryLine>()
+
+        accountTotals.forEach { (accountId, totals) ->
+            val account = accounts.getValue(accountId)
+            val (totalDebits, totalCredits) = totals
+
+            when (account.type) {
+                AccountType.REVENUE -> {
+                    val balance = totalCredits.subtract(totalDebits)
+                    if (balance.compareTo(BigDecimal.ZERO) != 0) {
+                        closingLines.add(
+                            JournalEntryLine(
+                                accountId = account.id,
+                                accountCode = account.code,
+                                accountName = account.name,
+                                debit = if (balance > BigDecimal.ZERO) balance else BigDecimal.ZERO,
+                                credit = if (balance < BigDecimal.ZERO) balance.negate() else BigDecimal.ZERO,
+                            ),
+                        )
+                    }
+                }
+                AccountType.EXPENSE -> {
+                    val balance = totalDebits.subtract(totalCredits)
+                    if (balance.compareTo(BigDecimal.ZERO) != 0) {
+                        closingLines.add(
+                            JournalEntryLine(
+                                accountId = account.id,
+                                accountCode = account.code,
+                                accountName = account.name,
+                                debit = if (balance < BigDecimal.ZERO) balance.negate() else BigDecimal.ZERO,
+                                credit = if (balance > BigDecimal.ZERO) balance else BigDecimal.ZERO,
+                            ),
+                        )
+                    }
+                }
+                else -> {}
+            }
+        }
+
+        if (closingLines.isEmpty()) return null
+
+        val totalClosingDebits = closingLines.fold(BigDecimal.ZERO) { sum, l -> sum.add(l.debit) }
+        val totalClosingCredits = closingLines.fold(BigDecimal.ZERO) { sum, l -> sum.add(l.credit) }
+        val difference = totalClosingDebits.subtract(totalClosingCredits)
+
+        if (difference.compareTo(BigDecimal.ZERO) != 0) {
+            val retainedEarnings =
+                accountRepository
+                    .findByOrganizationIdAndCode(organizationId, "3100")
+                    .orElseThrow {
+                        IllegalStateException("Retained Earnings account (3100) not found")
+                    }
+
+            closingLines.add(
+                JournalEntryLine(
+                    accountId = retainedEarnings.id,
+                    accountCode = retainedEarnings.code,
+                    accountName = retainedEarnings.name,
+                    debit = if (difference < BigDecimal.ZERO) difference.negate() else BigDecimal.ZERO,
+                    credit = if (difference > BigDecimal.ZERO) difference else BigDecimal.ZERO,
+                ),
+            )
+        }
+
+        return entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
+            JournalEntry(
+                entryNumber = entryNumber,
+                date = fiscalYear.endDate,
+                description = "Year-end closing entry for ${fiscalYear.name}",
+                organizationId = organizationId,
+                status = JournalEntryStatus.POSTED,
+                source = JournalEntrySource.SYSTEM,
+                sourceReference = sourceRef,
+                lines = closingLines,
+                createdBy = closedBy,
+                postedAt = LocalDateTime.now(),
+            )
+        }
+    }
+
+    private fun generateMonthlyPeriods(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<FiscalPeriod> {
+        val periods = mutableListOf<FiscalPeriod>()
+        var periodStart = startDate
+        var periodNumber = 1
+
+        while (periodStart.isBefore(endDate) || periodStart.isEqual(endDate)) {
+            val monthEnd = periodStart.withDayOfMonth(periodStart.lengthOfMonth())
+            val periodEnd = if (monthEnd.isAfter(endDate)) endDate else monthEnd
+
+            val monthName = periodStart.month.getDisplayName(TextStyle.FULL, Locale.ENGLISH)
+            val name = "$monthName ${periodStart.year}"
+
+            periods.add(
+                FiscalPeriod(
+                    periodNumber = periodNumber,
+                    name = name,
+                    startDate = periodStart,
+                    endDate = periodEnd,
+                ),
+            )
+
+            periodStart = periodEnd.plusDays(1)
+            periodNumber++
+        }
+
+        return periods
+    }
+
+    private fun findFiscalYear(
+        fiscalYearId: String,
+        organizationId: String,
+    ): FiscalYear {
+        val fiscalYear =
+            fiscalYearRepository.findById(fiscalYearId).orElseThrow {
+                IllegalArgumentException("Fiscal year not found")
+            }
+        if (fiscalYear.organizationId != organizationId) {
+            throw IllegalArgumentException("Fiscal year not found")
+        }
+        return fiscalYear
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.time.format.TextStyle
 import java.util.Locale
 
@@ -71,6 +72,7 @@ class FiscalYearService(
         } catch (e: DuplicateKeyException) {
             throw IllegalArgumentException(
                 "Fiscal year '${request.name}' already exists in this organization",
+                e,
             )
         }
     }
@@ -117,7 +119,7 @@ class FiscalYearService(
         updatedPeriods[periodIndex] =
             period.copy(
                 status = FiscalPeriodStatus.CLOSED,
-                closedAt = LocalDateTime.now(),
+                closedAt = LocalDateTime.now(ZoneOffset.UTC),
                 closedBy = closedBy,
             )
 
@@ -161,7 +163,7 @@ class FiscalYearService(
         updatedPeriods[periodIndex] =
             period.copy(
                 status = FiscalPeriodStatus.REOPENED,
-                reopenedAt = LocalDateTime.now(),
+                reopenedAt = LocalDateTime.now(ZoneOffset.UTC),
                 reopenedBy = reopenedBy,
             )
 
@@ -192,7 +194,7 @@ class FiscalYearService(
         return fiscalYearRepository.save(
             fiscalYear.copy(
                 status = FiscalYearStatus.CLOSED,
-                closedAt = LocalDateTime.now(),
+                closedAt = LocalDateTime.now(ZoneOffset.UTC),
                 closedBy = closedBy,
                 closingEntryId = closingEntry?.id,
             ),
@@ -214,6 +216,22 @@ class FiscalYearService(
             }
         }
         return PeriodLookupResult.NotFound
+    }
+
+    fun validatePeriodOpen(
+        organizationId: String,
+        date: LocalDate,
+    ) {
+        when (val result = findPeriodForDate(organizationId, date)) {
+            is PeriodLookupResult.NoFiscalYears -> return
+            is PeriodLookupResult.NotFound ->
+                throw IllegalArgumentException("No fiscal period covers the date $date")
+            is PeriodLookupResult.Found -> {
+                if (result.period.status == FiscalPeriodStatus.CLOSED) {
+                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
+                }
+            }
+        }
     }
 
     sealed class PeriodLookupResult {
@@ -344,7 +362,7 @@ class FiscalYearService(
                 sourceReference = sourceRef,
                 lines = closingLines,
                 createdBy = closedBy,
-                postedAt = LocalDateTime.now(),
+                postedAt = LocalDateTime.now(ZoneOffset.UTC),
             )
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -23,6 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Locale
 
 @Service
@@ -60,7 +61,7 @@ class InvitationService(
             )
         if (existing.isPresent) {
             val pendingInvitation = existing.get()
-            if (pendingInvitation.expiryAt.isAfter(LocalDateTime.now())) {
+            if (pendingInvitation.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
                 throw IllegalArgumentException("An invitation has already been sent to this email")
             }
             invitationRepository.save(pendingInvitation.copy(status = InvitationStatus.EXPIRED))
@@ -74,12 +75,12 @@ class InvitationService(
                 role = role.name,
                 tokenHash = tokenHasher.hash(rawToken),
                 invitedBy = inviter.uuid,
-                expiryAt = LocalDateTime.now().plusHours(invitationExpiryHours),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(invitationExpiryHours),
             )
         try {
             invitationRepository.save(invitation)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException("An invitation has already been sent to this email")
+            throw IllegalArgumentException("An invitation has already been sent to this email", e)
         }
 
         return rawToken
@@ -91,7 +92,7 @@ class InvitationService(
             invitationRepository.findByTokenHash(tokenHash).orElseThrow {
                 IllegalArgumentException("Invalid or expired invitation token")
             }
-        if (invitation.status != InvitationStatus.PENDING || !invitation.expiryAt.isAfter(LocalDateTime.now())) {
+        if (invitation.status != InvitationStatus.PENDING || !invitation.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
             throw IllegalArgumentException("Invalid or expired invitation token")
         }
         val existingUser = userRepository.findByEmail(invitation.email).isPresent
@@ -116,7 +117,7 @@ class InvitationService(
                         .and("status")
                         .`is`(InvitationStatus.PENDING)
                         .and("expiryAt")
-                        .gt(LocalDateTime.now()),
+                        .gt(LocalDateTime.now(ZoneOffset.UTC)),
                 ),
                 Update.update("status", InvitationStatus.ACCEPTED),
                 FindAndModifyOptions.options().returnNew(true),
@@ -175,11 +176,11 @@ class InvitationService(
             val errorMessage = e.message ?: ""
             when {
                 errorMessage.contains("username", ignoreCase = true) ->
-                    throw IllegalArgumentException("Username already exists")
+                    throw IllegalArgumentException("Username already exists", e)
                 errorMessage.contains("email", ignoreCase = true) ->
-                    throw IllegalArgumentException("Email already exists")
+                    throw IllegalArgumentException("Email already exists", e)
                 else ->
-                    throw IllegalArgumentException("Account could not be created")
+                    throw IllegalArgumentException("Account could not be created", e)
             }
         }
     }
@@ -206,6 +207,6 @@ class InvitationService(
         invitationRepository.findByOrganizationIdAndStatusAndExpiryAtAfter(
             organizationId,
             InvitationStatus.PENDING,
-            LocalDateTime.now(),
+            LocalDateTime.now(ZoneOffset.UTC),
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
@@ -20,7 +20,9 @@ class JournalEntryNumberGenerator(
             try {
                 return journalEntryRepository.save(buildEntry(entryNumber))
             } catch (e: DuplicateKeyException) {
-                if (it == maxRetries - 1) throw e
+                if (it == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique entry number: $entryNumber", e)
+                }
             }
         }
         throw IllegalStateException("Failed to generate unique entry number")

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryNumberGenerator.kt
@@ -1,0 +1,28 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Component
+
+@Component
+class JournalEntryNumberGenerator(
+    private val journalEntryRepository: JournalEntryRepository,
+) {
+    fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildEntry: (String) -> JournalEntry,
+    ): JournalEntry {
+        repeat(maxRetries) {
+            val count = journalEntryRepository.countByOrganizationId(organizationId)
+            val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return journalEntryRepository.save(buildEntry(entryNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) throw e
+            }
+        }
+        throw IllegalStateException("Failed to generate unique entry number")
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -4,13 +4,13 @@ import com.froilan.synectix.dto.AccountBalanceResponse
 import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.TrialBalanceResponse
 import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
-import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -21,6 +21,8 @@ import java.time.LocalDateTime
 class JournalEntryService(
     private val journalEntryRepository: JournalEntryRepository,
     private val accountRepository: AccountRepository,
+    private val fiscalYearService: FiscalYearService,
+    private val entryNumberGenerator: JournalEntryNumberGenerator,
 ) {
     @Transactional
     fun createJournalEntry(
@@ -78,7 +80,9 @@ class JournalEntryService(
                 )
             }
 
-        return saveWithRetry(organizationId) { entryNumber ->
+        validateFiscalPeriodOpen(organizationId, request.date)
+
+        return entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
             JournalEntry(
                 entryNumber = entryNumber,
                 date = request.date,
@@ -106,6 +110,8 @@ class JournalEntryService(
         if (totalDebits.compareTo(totalCredits) != 0) {
             throw IllegalArgumentException("Journal entry is not balanced")
         }
+
+        validateFiscalPeriodOpen(organizationId, entry.date)
 
         return journalEntryRepository.save(
             entry.copy(
@@ -140,7 +146,7 @@ class JournalEntryService(
                 line.copy(debit = line.credit, credit = line.debit)
             }
 
-        saveWithRetry(organizationId) { reversingNumber ->
+        entryNumberGenerator.saveWithRetry(organizationId) { reversingNumber ->
             JournalEntry(
                 entryNumber = reversingNumber,
                 date = LocalDate.now(),
@@ -317,20 +323,19 @@ class JournalEntryService(
         return entry
     }
 
-    private fun saveWithRetry(
+    private fun validateFiscalPeriodOpen(
         organizationId: String,
-        maxRetries: Int = 3,
-        buildEntry: (String) -> JournalEntry,
-    ): JournalEntry {
-        repeat(maxRetries) {
-            val count = journalEntryRepository.countByOrganizationId(organizationId)
-            val entryNumber = "JE-${(count + 1).toString().padStart(4, '0')}"
-            try {
-                return journalEntryRepository.save(buildEntry(entryNumber))
-            } catch (e: DuplicateKeyException) {
-                if (it == maxRetries - 1) throw e
+        date: LocalDate,
+    ) {
+        when (val result = fiscalYearService.findPeriodForDate(organizationId, date)) {
+            is FiscalYearService.PeriodLookupResult.NoFiscalYears -> return
+            is FiscalYearService.PeriodLookupResult.NotFound ->
+                throw IllegalArgumentException("No fiscal period covers the date $date")
+            is FiscalYearService.PeriodLookupResult.Found -> {
+                if (result.period.status == FiscalPeriodStatus.CLOSED) {
+                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
+                }
             }
         }
-        throw IllegalStateException("Failed to generate unique entry number")
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -104,6 +104,24 @@ class JournalEntryService(
         sourceReference: String,
         createdBy: String,
     ): JournalEntry {
+        if (lines.isEmpty()) {
+            throw IllegalArgumentException("System journal entry must have at least one line item")
+        }
+
+        lines.forEach { line ->
+            if (line.debit.compareTo(BigDecimal.ZERO) < 0 || line.credit.compareTo(BigDecimal.ZERO) < 0) {
+                throw IllegalArgumentException("Debit and credit amounts must not be negative")
+            }
+            val hasDebit = line.debit.compareTo(BigDecimal.ZERO) > 0
+            val hasCredit = line.credit.compareTo(BigDecimal.ZERO) > 0
+            if (hasDebit && hasCredit) {
+                throw IllegalArgumentException("A line item cannot have both debit and credit")
+            }
+            if (!hasDebit && !hasCredit) {
+                throw IllegalArgumentException("A line item must have either a debit or credit amount")
+            }
+        }
+
         val totalDebits = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
         val totalCredits = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
         if (totalDebits.compareTo(totalCredits) != 0) {
@@ -166,17 +184,18 @@ class JournalEntryService(
             throw IllegalArgumentException("Only posted entries can be voided")
         }
 
+        val reversalDate = LocalDate.now(ZoneOffset.UTC)
+        validateFiscalPeriodOpen(organizationId, reversalDate)
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
         val voidedEntry =
             journalEntryRepository.save(
                 entry.copy(
                     status = JournalEntryStatus.VOIDED,
-                    voidedAt = LocalDateTime.now(ZoneOffset.UTC),
+                    voidedAt = now,
                     voidReason = reason,
                 ),
             )
-
-        val reversalDate = LocalDate.now(ZoneOffset.UTC)
-        validateFiscalPeriodOpen(organizationId, reversalDate)
 
         val reversedLines =
             entry.lines.map { line ->
@@ -194,7 +213,7 @@ class JournalEntryService(
                 sourceReference = "VOID-${entry.id}",
                 lines = reversedLines,
                 createdBy = entry.createdBy,
-                postedAt = LocalDateTime.now(ZoneOffset.UTC),
+                postedAt = now,
             )
         }
 

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -4,7 +4,6 @@ import com.froilan.synectix.dto.AccountBalanceResponse
 import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.TrialBalanceResponse
 import com.froilan.synectix.model.AccountType
-import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
@@ -16,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @Service
 class JournalEntryService(
@@ -96,6 +96,40 @@ class JournalEntryService(
     }
 
     @Transactional
+    fun createSystemEntry(
+        date: LocalDate,
+        description: String,
+        organizationId: String,
+        lines: List<JournalEntryLine>,
+        sourceReference: String,
+        createdBy: String,
+    ): JournalEntry {
+        val totalDebits = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
+        val totalCredits = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
+        if (totalDebits.compareTo(totalCredits) != 0) {
+            throw IllegalArgumentException("System journal entry is not balanced")
+        }
+
+        validateFiscalPeriodOpen(organizationId, date)
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        return entryNumberGenerator.saveWithRetry(organizationId) { entryNumber ->
+            JournalEntry(
+                entryNumber = entryNumber,
+                date = date,
+                description = description,
+                organizationId = organizationId,
+                status = JournalEntryStatus.POSTED,
+                source = JournalEntrySource.SYSTEM,
+                sourceReference = sourceReference,
+                lines = lines,
+                createdBy = createdBy,
+                postedAt = now,
+            )
+        }
+    }
+
+    @Transactional
     fun postJournalEntry(
         entryId: String,
         organizationId: String,
@@ -116,7 +150,7 @@ class JournalEntryService(
         return journalEntryRepository.save(
             entry.copy(
                 status = JournalEntryStatus.POSTED,
-                postedAt = LocalDateTime.now(),
+                postedAt = LocalDateTime.now(ZoneOffset.UTC),
             ),
         )
     }
@@ -136,10 +170,13 @@ class JournalEntryService(
             journalEntryRepository.save(
                 entry.copy(
                     status = JournalEntryStatus.VOIDED,
-                    voidedAt = LocalDateTime.now(),
+                    voidedAt = LocalDateTime.now(ZoneOffset.UTC),
                     voidReason = reason,
                 ),
             )
+
+        val reversalDate = LocalDate.now(ZoneOffset.UTC)
+        validateFiscalPeriodOpen(organizationId, reversalDate)
 
         val reversedLines =
             entry.lines.map { line ->
@@ -149,7 +186,7 @@ class JournalEntryService(
         entryNumberGenerator.saveWithRetry(organizationId) { reversingNumber ->
             JournalEntry(
                 entryNumber = reversingNumber,
-                date = LocalDate.now(),
+                date = reversalDate,
                 description = "Reversal of ${entry.entryNumber}: $reason",
                 organizationId = organizationId,
                 status = JournalEntryStatus.POSTED,
@@ -157,7 +194,7 @@ class JournalEntryService(
                 sourceReference = "VOID-${entry.id}",
                 lines = reversedLines,
                 createdBy = entry.createdBy,
-                postedAt = LocalDateTime.now(),
+                postedAt = LocalDateTime.now(ZoneOffset.UTC),
             )
         }
 
@@ -326,16 +363,5 @@ class JournalEntryService(
     private fun validateFiscalPeriodOpen(
         organizationId: String,
         date: LocalDate,
-    ) {
-        when (val result = fiscalYearService.findPeriodForDate(organizationId, date)) {
-            is FiscalYearService.PeriodLookupResult.NoFiscalYears -> return
-            is FiscalYearService.PeriodLookupResult.NotFound ->
-                throw IllegalArgumentException("No fiscal period covers the date $date")
-            is FiscalYearService.PeriodLookupResult.Found -> {
-                if (result.period.status == FiscalPeriodStatus.CLOSED) {
-                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
-                }
-            }
-        }
-    }
+    ) = fiscalYearService.validatePeriodOpen(organizationId, date)
 }

--- a/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
@@ -1,0 +1,106 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateVendorRequest
+import com.froilan.synectix.dto.UpdateVendorRequest
+import com.froilan.synectix.model.Vendor
+import com.froilan.synectix.repository.VendorRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class VendorService(
+    private val vendorRepository: VendorRepository,
+) {
+    @Transactional
+    fun createVendor(
+        request: CreateVendorRequest,
+        organizationId: String,
+    ): Vendor {
+        val vendor =
+            Vendor(
+                name = request.name,
+                contactName = request.contactName,
+                contactEmail = request.contactEmail,
+                contactPhone = request.contactPhone,
+                paymentTermDays = request.paymentTermDays,
+                defaultExpenseAccountId = request.defaultExpenseAccountId,
+                organizationId = organizationId,
+            )
+
+        return try {
+            vendorRepository.save(vendor)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Vendor '${request.name}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    fun getVendor(
+        vendorId: String,
+        organizationId: String,
+    ): Vendor {
+        val vendor =
+            vendorRepository.findById(vendorId).orElseThrow {
+                IllegalArgumentException("Vendor not found")
+            }
+        if (vendor.organizationId != organizationId) {
+            throw IllegalArgumentException("Vendor not found")
+        }
+        return vendor
+    }
+
+    fun listVendors(organizationId: String): List<Vendor> = vendorRepository.findByOrganizationIdAndIsActive(organizationId, true)
+
+    @Transactional
+    fun updateVendor(
+        vendorId: String,
+        request: UpdateVendorRequest,
+        organizationId: String,
+    ): Vendor {
+        val vendor = getVendor(vendorId, organizationId)
+
+        if (!vendor.isActive) {
+            throw IllegalArgumentException("Cannot update inactive vendor")
+        }
+
+        if (request.name != null && request.name.isBlank()) {
+            throw IllegalArgumentException("Vendor name cannot be blank")
+        }
+
+        val updated =
+            vendor.copy(
+                name = request.name ?: vendor.name,
+                contactName = request.contactName ?: vendor.contactName,
+                contactEmail = request.contactEmail ?: vendor.contactEmail,
+                contactPhone = request.contactPhone ?: vendor.contactPhone,
+                paymentTermDays = request.paymentTermDays ?: vendor.paymentTermDays,
+                defaultExpenseAccountId = request.defaultExpenseAccountId ?: vendor.defaultExpenseAccountId,
+            )
+
+        return try {
+            vendorRepository.save(updated)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Vendor '${updated.name}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    @Transactional
+    fun deleteVendor(
+        vendorId: String,
+        organizationId: String,
+    ): Vendor {
+        val vendor = getVendor(vendorId, organizationId)
+
+        if (!vendor.isActive) {
+            throw IllegalArgumentException("Vendor is already inactive")
+        }
+
+        return vendorRepository.save(vendor.copy(isActive = false))
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -73,6 +73,9 @@ class RoleSeederTest {
                         Permissions.JOURNAL_READ,
                         Permissions.JOURNAL_POST,
                         Permissions.JOURNAL_VOID,
+                        Permissions.FISCAL_CREATE,
+                        Permissions.FISCAL_READ,
+                        Permissions.FISCAL_CLOSE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -138,6 +141,9 @@ class RoleSeederTest {
                         Permissions.JOURNAL_READ,
                         Permissions.JOURNAL_POST,
                         Permissions.JOURNAL_VOID,
+                        Permissions.FISCAL_CREATE,
+                        Permissions.FISCAL_READ,
+                        Permissions.FISCAL_CLOSE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -230,6 +236,9 @@ class RoleSeederTest {
                         Permissions.JOURNAL_READ,
                         Permissions.JOURNAL_POST,
                         Permissions.JOURNAL_VOID,
+                        Permissions.FISCAL_CREATE,
+                        Permissions.FISCAL_READ,
+                        Permissions.FISCAL_CLOSE,
                     ),
             )
         val admin =
@@ -254,6 +263,9 @@ class RoleSeederTest {
                         Permissions.JOURNAL_CREATE,
                         Permissions.JOURNAL_READ,
                         Permissions.JOURNAL_POST,
+                        Permissions.FISCAL_CREATE,
+                        Permissions.FISCAL_READ,
+                        Permissions.FISCAL_CLOSE,
                     ),
             )
         val member =
@@ -271,6 +283,7 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.JOURNAL_CREATE,
                         Permissions.JOURNAL_READ,
+                        Permissions.FISCAL_READ,
                     ),
             )
         val viewer =
@@ -284,6 +297,7 @@ class RoleSeederTest {
                         Permissions.ORGANIZATION_READ,
                         Permissions.ACCOUNT_READ,
                         Permissions.JOURNAL_READ,
+                        Permissions.FISCAL_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -76,6 +76,11 @@ class RoleSeederTest {
                         Permissions.FISCAL_CREATE,
                         Permissions.FISCAL_READ,
                         Permissions.FISCAL_CLOSE,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
+                        Permissions.AP_APPROVE,
+                        Permissions.AP_PAY,
+                        Permissions.AP_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -144,6 +149,11 @@ class RoleSeederTest {
                         Permissions.FISCAL_CREATE,
                         Permissions.FISCAL_READ,
                         Permissions.FISCAL_CLOSE,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
+                        Permissions.AP_APPROVE,
+                        Permissions.AP_PAY,
+                        Permissions.AP_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -239,6 +249,11 @@ class RoleSeederTest {
                         Permissions.FISCAL_CREATE,
                         Permissions.FISCAL_READ,
                         Permissions.FISCAL_CLOSE,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
+                        Permissions.AP_APPROVE,
+                        Permissions.AP_PAY,
+                        Permissions.AP_VOID,
                     ),
             )
         val admin =
@@ -266,6 +281,10 @@ class RoleSeederTest {
                         Permissions.FISCAL_CREATE,
                         Permissions.FISCAL_READ,
                         Permissions.FISCAL_CLOSE,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
+                        Permissions.AP_APPROVE,
+                        Permissions.AP_PAY,
                     ),
             )
         val member =
@@ -284,6 +303,8 @@ class RoleSeederTest {
                         Permissions.JOURNAL_CREATE,
                         Permissions.JOURNAL_READ,
                         Permissions.FISCAL_READ,
+                        Permissions.AP_CREATE,
+                        Permissions.AP_READ,
                     ),
             )
         val viewer =
@@ -298,6 +319,7 @@ class RoleSeederTest {
                         Permissions.ACCOUNT_READ,
                         Permissions.JOURNAL_READ,
                         Permissions.FISCAL_READ,
+                        Permissions.AP_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
@@ -85,6 +86,9 @@ class AccountControllerTest {
     @MockitoBean
     private lateinit var journalEntryService: JournalEntryService
 
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
     private val testUser =
         User(
             uuid = "user-123",
@@ -100,6 +104,8 @@ class AccountControllerTest {
     @BeforeEach
     fun setup() {
         setupAuthWithPermissions("account:create", "account:read", "account:update", "account:delete")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+        `when`(authenticationContext.userId()).thenReturn("user-123")
     }
 
     private fun setupAuthWithPermissions(vararg permissions: String) {

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -41,6 +41,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @WebMvcTest(controllers = [AuthController::class])
 @Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
@@ -288,8 +289,8 @@ class AuthControllerTest {
                 username = "testuser",
                 roles = listOf("OWNER"),
                 organizationId = "org-123",
-                expiresAt = LocalDateTime.now().plusHours(24).toString(),
-                refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(24).toString(),
+                refreshTokenExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30).toString(),
             )
 
         `when`(authService.login(any<LoginRequest>(), anyOrNull(), anyOrNull())).thenReturn(authResponse)
@@ -402,8 +403,8 @@ class AuthControllerTest {
                 username = "testuser",
                 roles = listOf("OWNER"),
                 organizationId = "org-123",
-                expiresAt = LocalDateTime.now().plusHours(24).toString(),
-                refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(24).toString(),
+                refreshTokenExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30).toString(),
             )
 
         `when`(authService.refresh(any<String>())).thenReturn(authResponse)
@@ -700,8 +701,8 @@ class AuthControllerTest {
                 username = "testuser",
                 roles = listOf("MEMBER"),
                 organizationId = "org-456",
-                expiresAt = LocalDateTime.now().plusHours(24).toString(),
-                refreshTokenExpiresAt = LocalDateTime.now().plusDays(30).toString(),
+                expiresAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(24).toString(),
+                refreshTokenExpiresAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30).toString(),
             )
         `when`(authService.switchOrganization(any(), any(), anyOrNull(), anyOrNull())).thenReturn(switchResponse)
 

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -38,6 +38,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @WebMvcTest(controllers = [InvitationController::class])
 @Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
@@ -160,7 +161,7 @@ class InvitationControllerTest {
                     role = "MEMBER",
                     tokenHash = "hash1",
                     invitedBy = "user-123",
-                    expiryAt = LocalDateTime.now().plusHours(72),
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(72),
                 ),
             )
         `when`(invitationService.listInvitations("org-123")).thenReturn(invitations)

--- a/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
@@ -17,6 +17,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
@@ -94,6 +95,9 @@ class JournalEntryControllerTest {
     @MockitoBean
     private lateinit var apiKeyService: ApiKeyService
 
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
     private val testUser =
         User(
             uuid = "user-123",
@@ -109,6 +113,8 @@ class JournalEntryControllerTest {
     @BeforeEach
     fun setup() {
         setupAuthWithPermissions("journal:create", "journal:read", "journal:post", "journal:void", "account:read")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+        `when`(authenticationContext.userId()).thenReturn("user-123")
     }
 
     private fun setupAuthWithPermissions(vararg permissions: String) {

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @WebMvcTest(controllers = [SessionController::class])
 @Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
@@ -106,7 +107,7 @@ class SessionControllerTest {
                     id = "s1",
                     token = currentToken,
                     userId = testUser.uuid,
-                    expiryAt = LocalDateTime.now().plusHours(12),
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12),
                     ipAddress = "127.0.0.1",
                     userAgent = "Mozilla/5.0",
                 ),
@@ -114,7 +115,7 @@ class SessionControllerTest {
                     id = "s2",
                     token = "other-token",
                     userId = testUser.uuid,
-                    expiryAt = LocalDateTime.now().plusHours(6),
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(6),
                     ipAddress = "192.168.1.1",
                     userAgent = "Chrome",
                 ),

--- a/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
@@ -1,0 +1,92 @@
+package com.froilan.synectix.security
+
+import com.froilan.synectix.model.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+
+class AuthenticationContextTest {
+    private val authContext = AuthenticationContext()
+
+    @AfterEach
+    fun cleanup() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `organizationId should return id from SessionContext`() {
+        val auth = UsernamePasswordAuthenticationToken("principal", null, emptyList())
+        auth.details = SessionContext(sessionId = "s-1", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.organizationId()).isEqualTo("org-123")
+    }
+
+    @Test
+    fun `organizationId should return id from ApiKeyContext`() {
+        val auth = UsernamePasswordAuthenticationToken("principal", null, emptyList())
+        auth.details = ApiKeyContext(apiKeyId = "ak-1", organizationId = "org-456")
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.organizationId()).isEqualTo("org-456")
+    }
+
+    @Test
+    fun `organizationId should return null when no authentication`() {
+        SecurityContextHolder.clearContext()
+
+        assertThat(authContext.organizationId()).isNull()
+    }
+
+    @Test
+    fun `organizationId should return null when details is not SessionContext or ApiKeyContext`() {
+        val auth = UsernamePasswordAuthenticationToken("principal", null, emptyList())
+        auth.details = "some-string"
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.organizationId()).isNull()
+    }
+
+    @Test
+    fun `organizationId should return null when details is null`() {
+        val auth = UsernamePasswordAuthenticationToken("principal", null, emptyList())
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.organizationId()).isNull()
+    }
+
+    @Test
+    fun `userId should return uuid from User principal`() {
+        val user =
+            User(
+                uuid = "user-789",
+                username = "testuser",
+                email = "test@example.com",
+                firstName = "Test",
+                lastName = "User",
+                passwordHash = "encoded",
+                organizationId = "org-123",
+            )
+        val auth = UsernamePasswordAuthenticationToken(user, null, emptyList())
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.userId()).isEqualTo("user-789")
+    }
+
+    @Test
+    fun `userId should return null when principal is not User`() {
+        val auth = UsernamePasswordAuthenticationToken("string-principal", null, emptyList())
+        SecurityContextHolder.getContext().authentication = auth
+
+        assertThat(authContext.userId()).isNull()
+    }
+
+    @Test
+    fun `userId should return null when no authentication`() {
+        SecurityContextHolder.clearContext()
+
+        assertThat(authContext.userId()).isNull()
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.springframework.data.mongodb.core.MongoTemplate
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Optional
 
 class ApiKeyServiceTest {
@@ -132,7 +133,7 @@ class ApiKeyServiceTest {
 
     @Test
     fun `authenticateByApiKey should return null for expired key`() {
-        val apiKey = createMockApiKey(expiresAt = LocalDateTime.now().minusHours(1))
+        val apiKey = createMockApiKey(expiresAt = LocalDateTime.now(ZoneOffset.UTC).minusHours(1))
         `when`(apiKeyRepository.findByKeyHash("hashed-expired-key")).thenReturn(Optional.of(apiKey))
 
         val result = apiKeyService.authenticateByApiKey("expired-key")

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -31,6 +31,7 @@ import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Optional
 import java.util.UUID
 
@@ -255,7 +256,7 @@ class AuthServiceTest {
         assertThat(result.accessToken).isNotNull().isNotEmpty()
         assertThat(result.refreshToken).isNotNull().isNotEmpty()
 
-        val expectedRefreshExpiry = LocalDateTime.now().plusDays(30)
+        val expectedRefreshExpiry = LocalDateTime.now(ZoneOffset.UTC).plusDays(30)
         val actualRefreshExpiry = LocalDateTime.parse(result.refreshTokenExpiresAt)
         assertThat(actualRefreshExpiry).isAfter(expectedRefreshExpiry.minusMinutes(1))
         assertThat(actualRefreshExpiry).isBefore(expectedRefreshExpiry.plusMinutes(1))
@@ -306,7 +307,7 @@ class AuthServiceTest {
         val capturedToken = tokenCaptor.firstValue
         assertThat(capturedToken.userId).isEqualTo(user.uuid)
 
-        val expectedExpiry = LocalDateTime.now().plusHours(24)
+        val expectedExpiry = LocalDateTime.now(ZoneOffset.UTC).plusHours(24)
         val actualExpiry = capturedToken.expiryAt
         assertThat(actualExpiry).isAfter(expectedExpiry.minusMinutes(1))
         assertThat(actualExpiry).isBefore(expectedExpiry.plusMinutes(1))
@@ -355,7 +356,7 @@ class AuthServiceTest {
                 tokenHash = oldRefreshTokenHash,
                 userId = user.uuid,
                 sessionTokenId = oldSessionToken.id,
-                expiryAt = LocalDateTime.now().plusDays(30),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30),
             )
 
         `when`(refreshTokenRepository.findByTokenHash(oldRefreshTokenHash)).thenReturn(Optional.of(existingRefreshToken))
@@ -383,7 +384,7 @@ class AuthServiceTest {
                 tokenHash = expiredTokenHash,
                 userId = "user-123",
                 sessionTokenId = "session-123",
-                expiryAt = LocalDateTime.now().minusHours(1),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).minusHours(1),
             )
 
         `when`(refreshTokenRepository.findByTokenHash(expiredTokenHash)).thenReturn(Optional.of(expiredRefreshToken))
@@ -419,7 +420,7 @@ class AuthServiceTest {
                 tokenHash = refreshTokenHash,
                 userId = inactiveUser.uuid,
                 sessionTokenId = "session-123",
-                expiryAt = LocalDateTime.now().plusDays(30),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusDays(30),
             )
 
         `when`(refreshTokenRepository.findByTokenHash(refreshTokenHash)).thenReturn(Optional.of(existingRefreshToken))
@@ -461,7 +462,8 @@ class AuthServiceTest {
     @Test
     fun `listSessions should return only non-expired sessions`() {
         val userId = "user-123"
-        val activeSession = SessionToken(id = "s1", token = "t1", userId = userId, expiryAt = LocalDateTime.now().plusHours(12))
+        val activeSession =
+            SessionToken(id = "s1", token = "t1", userId = userId, expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12))
         `when`(sessionTokenRepository.findByUserIdAndExpiryAtAfter(eq(userId), any())).thenReturn(listOf(activeSession))
 
         val result = authService.listSessions(userId)
@@ -473,7 +475,7 @@ class AuthServiceTest {
     @Test
     fun `revokeSession should delete session and its refresh token`() {
         val userId = "user-123"
-        val session = SessionToken(id = "s1", token = "t1", userId = userId, expiryAt = LocalDateTime.now().plusHours(12))
+        val session = SessionToken(id = "s1", token = "t1", userId = userId, expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12))
 
         `when`(sessionTokenRepository.findById("s1")).thenReturn(Optional.of(session))
 
@@ -485,7 +487,8 @@ class AuthServiceTest {
 
     @Test
     fun `revokeSession should throw when session belongs to different user`() {
-        val session = SessionToken(id = "s1", token = "t1", userId = "other-user", expiryAt = LocalDateTime.now().plusHours(12))
+        val session =
+            SessionToken(id = "s1", token = "t1", userId = "other-user", expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12))
 
         `when`(sessionTokenRepository.findById("s1")).thenReturn(Optional.of(session))
 
@@ -500,7 +503,8 @@ class AuthServiceTest {
     fun `revokeSession should throw when attempting to revoke the current session`() {
         val userId = "user-123"
         val currentToken = "current-token"
-        val session = SessionToken(id = "s1", token = currentToken, userId = userId, expiryAt = LocalDateTime.now().plusHours(12))
+        val session =
+            SessionToken(id = "s1", token = currentToken, userId = userId, expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12))
 
         `when`(sessionTokenRepository.findById("s1")).thenReturn(Optional.of(session))
 
@@ -517,7 +521,7 @@ class AuthServiceTest {
         val currentToken = "current-token"
         val otherSessions =
             listOf(
-                SessionToken(id = "s2", token = "other-token", userId = userId, expiryAt = LocalDateTime.now().plusHours(12)),
+                SessionToken(id = "s2", token = "other-token", userId = userId, expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(12)),
             )
         `when`(sessionTokenRepository.findByUserIdAndTokenNot(userId, currentToken)).thenReturn(otherSessions)
 
@@ -608,7 +612,7 @@ class AuthServiceTest {
             PasswordResetToken(
                 tokenHash = "hashed-valid-token",
                 userId = user.uuid,
-                expiryAt = LocalDateTime.now().plusMinutes(30),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(30),
             )
 
         `when`(passwordResetTokenRepository.findByTokenHash("hashed-valid-token")).thenReturn(Optional.of(resetToken))
@@ -641,7 +645,7 @@ class AuthServiceTest {
             PasswordResetToken(
                 tokenHash = "hashed-expired-token",
                 userId = "user-123",
-                expiryAt = LocalDateTime.now().minusMinutes(10),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).minusMinutes(10),
             )
 
         `when`(passwordResetTokenRepository.findByTokenHash("hashed-expired-token"))
@@ -834,6 +838,6 @@ class AuthServiceTest {
             id = "token-123",
             token = "generated-token",
             userId = "user-123",
-            expiryAt = LocalDateTime.now().plusHours(24),
+            expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusHours(24),
         )
 }

--- a/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
@@ -1,0 +1,436 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.BillLineRequest
+import com.froilan.synectix.dto.CreateBillRequest
+import com.froilan.synectix.dto.RecordPaymentRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.Bill
+import com.froilan.synectix.model.BillLine
+import com.froilan.synectix.model.BillPayment
+import com.froilan.synectix.model.BillStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.PaymentMethod
+import com.froilan.synectix.model.Vendor
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.BillPaymentRepository
+import com.froilan.synectix.repository.BillRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class BillServiceTest {
+    private lateinit var billService: BillService
+    private lateinit var billRepository: BillRepository
+    private lateinit var billPaymentRepository: BillPaymentRepository
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var vendorService: VendorService
+    private lateinit var journalEntryService: JournalEntryService
+
+    private val orgId = "org-123"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        billRepository = mock(BillRepository::class.java)
+        billPaymentRepository = mock(BillPaymentRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        vendorService = mock(VendorService::class.java)
+        journalEntryService = mock(JournalEntryService::class.java)
+        billService =
+            BillService(
+                billRepository = billRepository,
+                billPaymentRepository = billPaymentRepository,
+                accountRepository = accountRepository,
+                vendorService = vendorService,
+                journalEntryService = journalEntryService,
+            )
+    }
+
+    @Test
+    fun `create should save bill as DRAFT with correct total`() {
+        val vendor = createVendor()
+        val expenseAccount = createAccount("acc-1", "5000", "Office Supplies", AccountType.EXPENSE)
+
+        `when`(vendorService.getVendor("v-1", orgId)).thenReturn(vendor)
+        `when`(accountRepository.findAllById(listOf("acc-1")))
+            .thenReturn(listOf(expenseAccount))
+        `when`(billRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateBillRequest(
+                vendorId = "v-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                lines =
+                    listOf(
+                        BillLineRequest(accountId = "acc-1", amount = BigDecimal("250.00")),
+                    ),
+            )
+
+        val result = billService.createBill(request, orgId, userId)
+
+        assertThat(result.status).isEqualTo(BillStatus.DRAFT)
+        assertThat(result.vendorName).isEqualTo("Acme Corp")
+        assertThat(result.totalAmount).isEqualByComparingTo(BigDecimal("250.00"))
+        assertThat(result.amountPaid).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.billNumber).isEqualTo("BILL-0001")
+        assertThat(result.lines).hasSize(1)
+        assertThat(result.lines[0].accountCode).isEqualTo("5000")
+    }
+
+    @Test
+    fun `create should reject inactive vendor`() {
+        val vendor = createVendor(isActive = false)
+        `when`(vendorService.getVendor("v-1", orgId)).thenReturn(vendor)
+
+        val request =
+            CreateBillRequest(
+                vendorId = "v-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                lines =
+                    listOf(
+                        BillLineRequest(accountId = "acc-1", amount = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.createBill(request, orgId, userId)
+            }
+        assertThat(exception.message).contains("inactive vendor")
+    }
+
+    @Test
+    fun `approve should post journal entry and update status`() {
+        val bill = createBill()
+        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+        val mockEntry =
+            JournalEntry(
+                id = "je-1",
+                entryNumber = "JE-0001",
+                date = bill.date,
+                description = "Bill BILL-0001 - Acme Corp",
+                organizationId = orgId,
+                status = JournalEntryStatus.POSTED,
+                lines = emptyList(),
+                createdBy = userId,
+            )
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
+            .thenReturn(Optional.of(apAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val result = billService.approveBill("bill-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(BillStatus.APPROVED)
+        assertThat(result.journalEntryId).isEqualTo("je-1")
+        assertThat(result.approvedBy).isEqualTo(userId)
+
+        verify(journalEntryService).createSystemEntry(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `approve should reject non-draft bill`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.approveBill("bill-1", orgId, userId)
+            }
+        assertThat(exception.message).contains("Only draft")
+    }
+
+    @Test
+    fun `void should void journal entry for approved bill`() {
+        val bill = createBill(status = BillStatus.APPROVED, journalEntryId = "je-1")
+        val voidedEntry =
+            JournalEntry(
+                id = "je-1",
+                entryNumber = "JE-0001",
+                date = bill.date,
+                description = "Bill BILL-0001",
+                organizationId = orgId,
+                status = JournalEntryStatus.VOIDED,
+                lines = emptyList(),
+                createdBy = userId,
+            )
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(journalEntryService.voidJournalEntry("je-1", orgId, "Duplicate"))
+            .thenReturn(voidedEntry)
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val result = billService.voidBill("bill-1", orgId, "Duplicate", userId)
+
+        assertThat(result.status).isEqualTo(BillStatus.VOID)
+        assertThat(result.voidReason).isEqualTo("Duplicate")
+        verify(journalEntryService).voidJournalEntry("je-1", orgId, "Duplicate")
+    }
+
+    @Test
+    fun `void should allow voiding draft without journal entry`() {
+        val bill = createBill(status = BillStatus.DRAFT)
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val result = billService.voidBill("bill-1", orgId, "Not needed", userId)
+
+        assertThat(result.status).isEqualTo(BillStatus.VOID)
+    }
+
+    @Test
+    fun `void should reject bill with payments`() {
+        val bill =
+            createBill(
+                status = BillStatus.PARTIALLY_PAID,
+                amountPaid = BigDecimal("100.00"),
+            )
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.voidBill("bill-1", orgId, "Cancel", userId)
+            }
+        assertThat(exception.message).contains("recorded payments")
+    }
+
+    @Test
+    fun `recordPayment should create payment and update bill status`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+        val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
+            .thenReturn(Optional.of(apAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
+            .thenReturn(Optional.of(cashAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(billPaymentRepository.save(any<BillPayment>())).thenAnswer { it.arguments[0] }
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            RecordPaymentRequest(
+                paymentDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("200.00"),
+                paymentMethod = PaymentMethod.BANK_TRANSFER,
+            )
+
+        val payment = billService.recordPayment("bill-1", request, orgId, userId)
+
+        assertThat(payment.amount).isEqualByComparingTo(BigDecimal("200.00"))
+        assertThat(payment.paymentMethod).isEqualTo(PaymentMethod.BANK_TRANSFER)
+
+        val billCaptor = argumentCaptor<Bill>()
+        verify(billRepository).save(billCaptor.capture())
+        assertThat(billCaptor.firstValue.status).isEqualTo(BillStatus.PARTIALLY_PAID)
+        assertThat(billCaptor.firstValue.amountPaid).isEqualByComparingTo(BigDecimal("200.00"))
+    }
+
+    @Test
+    fun `recordPayment should mark bill as PAID when fully paid`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+        val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
+            .thenReturn(Optional.of(apAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
+            .thenReturn(Optional.of(cashAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(billPaymentRepository.save(any<BillPayment>())).thenAnswer { it.arguments[0] }
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            RecordPaymentRequest(
+                paymentDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("500.00"),
+                paymentMethod = PaymentMethod.CHECK,
+            )
+
+        billService.recordPayment("bill-1", request, orgId, userId)
+
+        val billCaptor = argumentCaptor<Bill>()
+        verify(billRepository).save(billCaptor.capture())
+        assertThat(billCaptor.firstValue.status).isEqualTo(BillStatus.PAID)
+        assertThat(billCaptor.firstValue.paidAt).isNotNull()
+    }
+
+    @Test
+    fun `recordPayment should reject overpayment`() {
+        val bill = createBill(status = BillStatus.APPROVED)
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+
+        val request =
+            RecordPaymentRequest(
+                paymentDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("999.00"),
+                paymentMethod = PaymentMethod.CASH,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.recordPayment("bill-1", request, orgId, userId)
+            }
+        assertThat(exception.message).contains("exceeds remaining balance")
+    }
+
+    @Test
+    fun `recordPayment should reject draft bill`() {
+        val bill = createBill(status = BillStatus.DRAFT)
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+
+        val request =
+            RecordPaymentRequest(
+                paymentDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("100.00"),
+                paymentMethod = PaymentMethod.CASH,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                billService.recordPayment("bill-1", request, orgId, userId)
+            }
+        assertThat(exception.message).contains("approved or partially paid")
+    }
+
+    @Test
+    fun `aging report should bucket bills by overdue days`() {
+        val asOfDate = LocalDate.of(2026, 5, 1)
+        val bills =
+            listOf(
+                createBill(
+                    id = "bill-1",
+                    vendorId = "v-1",
+                    dueDate = LocalDate.of(2026, 5, 15),
+                    totalAmount = BigDecimal("100.00"),
+                    status = BillStatus.APPROVED,
+                ),
+                createBill(
+                    id = "bill-2",
+                    vendorId = "v-1",
+                    dueDate = LocalDate.of(2026, 4, 15),
+                    totalAmount = BigDecimal("200.00"),
+                    status = BillStatus.APPROVED,
+                ),
+                createBill(
+                    id = "bill-3",
+                    vendorId = "v-1",
+                    dueDate = LocalDate.of(2026, 2, 1),
+                    totalAmount = BigDecimal("300.00"),
+                    status = BillStatus.PARTIALLY_PAID,
+                    amountPaid = BigDecimal("50.00"),
+                ),
+            )
+
+        val outstandingStatuses = listOf(BillStatus.APPROVED, BillStatus.PARTIALLY_PAID)
+        `when`(billRepository.findByOrganizationIdAndStatusIn(orgId, outstandingStatuses))
+            .thenReturn(bills)
+
+        val report = billService.getAgingReport(orgId, asOfDate)
+
+        assertThat(report.vendors).hasSize(1)
+        val vendorAging = report.vendors[0]
+        assertThat(vendorAging.vendorName).isEqualTo("Acme Corp")
+
+        // bill-1: due May 15, asOf May 1 -> not overdue -> current
+        assertThat(vendorAging.aging.current).isEqualByComparingTo(BigDecimal("100.00"))
+        // bill-2: due Apr 15, asOf May 1 -> 16 days overdue -> 1-30 bucket
+        assertThat(vendorAging.aging.days1to30).isEqualByComparingTo(BigDecimal("200.00"))
+        // bill-3: due Feb 1, asOf May 1 -> 89 days overdue -> 61-90 bucket, outstanding = 250
+        assertThat(vendorAging.aging.days61to90).isEqualByComparingTo(BigDecimal("250.00"))
+
+        assertThat(report.totals.total).isEqualByComparingTo(BigDecimal("550.00"))
+    }
+
+    private fun createVendor(
+        id: String = "v-1",
+        isActive: Boolean = true,
+    ) = Vendor(
+        id = id,
+        name = "Acme Corp",
+        contactName = "John",
+        paymentTermDays = 30,
+        organizationId = orgId,
+        isActive = isActive,
+    )
+
+    private fun createAccount(
+        id: String,
+        code: String,
+        name: String,
+        type: AccountType,
+    ) = Account(
+        id = id,
+        code = code,
+        name = name,
+        type = type,
+        organizationId = orgId,
+    )
+
+    private fun createBill(
+        id: String = "bill-1",
+        vendorId: String = "v-1",
+        status: BillStatus = BillStatus.DRAFT,
+        totalAmount: BigDecimal = BigDecimal("500.00"),
+        amountPaid: BigDecimal = BigDecimal.ZERO,
+        dueDate: LocalDate = LocalDate.of(2026, 3, 31),
+        journalEntryId: String? = null,
+    ) = Bill(
+        id = id,
+        billNumber = "BILL-0001",
+        vendorId = vendorId,
+        vendorName = "Acme Corp",
+        date = LocalDate.of(2026, 3, 1),
+        dueDate = dueDate,
+        organizationId = orgId,
+        status = status,
+        lines =
+            listOf(
+                BillLine(
+                    accountId = "acc-1",
+                    accountCode = "5000",
+                    accountName = "Office Supplies",
+                    amount = totalAmount,
+                ),
+            ),
+        totalAmount = totalAmount,
+        amountPaid = amountPaid,
+        journalEntryId = journalEntryId,
+        createdBy = userId,
+    )
+
+    private fun createMockJournalEntry() =
+        JournalEntry(
+            id = "je-1",
+            entryNumber = "JE-0001",
+            date = LocalDate.of(2026, 3, 1),
+            description = "Mock entry",
+            organizationId = orgId,
+            status = JournalEntryStatus.POSTED,
+            lines = emptyList(),
+            createdBy = userId,
+        )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -1,0 +1,696 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateFiscalYearRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.FiscalPeriod
+import com.froilan.synectix.model.FiscalPeriodStatus
+import com.froilan.synectix.model.FiscalYear
+import com.froilan.synectix.model.FiscalYearStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.FiscalYearRepository
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class FiscalYearServiceTest {
+    private lateinit var fiscalYearService: FiscalYearService
+    private lateinit var fiscalYearRepository: FiscalYearRepository
+    private lateinit var journalEntryRepository: JournalEntryRepository
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var entryNumberGenerator: JournalEntryNumberGenerator
+
+    private val orgId = "org-123"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        fiscalYearRepository = mock(FiscalYearRepository::class.java)
+        journalEntryRepository = mock(JournalEntryRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
+        fiscalYearService =
+            FiscalYearService(
+                fiscalYearRepository = fiscalYearRepository,
+                journalEntryRepository = journalEntryRepository,
+                accountRepository = accountRepository,
+                entryNumberGenerator = entryNumberGenerator,
+            )
+    }
+
+    @Test
+    fun `create should auto-generate 12 monthly periods for calendar year`() {
+        `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(emptyList())
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2026",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 12, 31),
+            )
+
+        val result = fiscalYearService.createFiscalYear(request, orgId)
+
+        assertThat(result.name).isEqualTo("FY 2026")
+        assertThat(result.status).isEqualTo(FiscalYearStatus.ACTIVE)
+        assertThat(result.periods).hasSize(12)
+        assertThat(result.periods[0].name).isEqualTo("January 2026")
+        assertThat(result.periods[0].startDate).isEqualTo(LocalDate.of(2026, 1, 1))
+        assertThat(result.periods[0].endDate).isEqualTo(LocalDate.of(2026, 1, 31))
+        assertThat(result.periods[11].name).isEqualTo("December 2026")
+        assertThat(result.periods[11].startDate).isEqualTo(LocalDate.of(2026, 12, 1))
+        assertThat(result.periods[11].endDate).isEqualTo(LocalDate.of(2026, 12, 31))
+
+        result.periods.forEach { period ->
+            assertThat(period.status).isEqualTo(FiscalPeriodStatus.OPEN)
+        }
+    }
+
+    @Test
+    fun `create should handle partial months at boundaries`() {
+        `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(emptyList())
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2026-2027",
+                startDate = LocalDate.of(2026, 4, 15),
+                endDate = LocalDate.of(2027, 3, 15),
+            )
+
+        val result = fiscalYearService.createFiscalYear(request, orgId)
+
+        assertThat(result.periods).hasSize(12)
+        assertThat(result.periods[0].startDate).isEqualTo(LocalDate.of(2026, 4, 15))
+        assertThat(result.periods[0].endDate).isEqualTo(LocalDate.of(2026, 4, 30))
+        assertThat(result.periods.last().endDate).isEqualTo(LocalDate.of(2027, 3, 15))
+    }
+
+    @Test
+    fun `create should reject if startDate is not before endDate`() {
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2026",
+                startDate = LocalDate.of(2026, 12, 31),
+                endDate = LocalDate.of(2026, 1, 1),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.createFiscalYear(request, orgId)
+            }
+        assertThat(exception.message).contains("Start date must be before end date")
+    }
+
+    @Test
+    fun `create should reject if active fiscal year already exists`() {
+        val existing =
+            createFiscalYear(
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 12, 31),
+                status = FiscalYearStatus.ACTIVE,
+            )
+        `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(listOf(existing))
+
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2027",
+                startDate = LocalDate.of(2027, 1, 1),
+                endDate = LocalDate.of(2027, 12, 31),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.createFiscalYear(request, orgId)
+            }
+        assertThat(exception.message).contains("active fiscal year")
+    }
+
+    @Test
+    fun `create should reject if dates overlap existing fiscal year`() {
+        val existing =
+            createFiscalYear(
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 12, 31),
+                status = FiscalYearStatus.CLOSED,
+            )
+        `when`(fiscalYearRepository.findByOrganizationId(orgId)).thenReturn(listOf(existing))
+
+        val request =
+            CreateFiscalYearRequest(
+                name = "FY 2026 Overlap",
+                startDate = LocalDate.of(2026, 6, 1),
+                endDate = LocalDate.of(2027, 5, 31),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.createFiscalYear(request, orgId)
+            }
+        assertThat(exception.message).contains("overlaps")
+    }
+
+    @Test
+    fun `closePeriod should update period status to CLOSED`() {
+        val fiscalYear = createFiscalYear()
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val result =
+            fiscalYearService.closePeriod(
+                "fy-1",
+                fiscalYear.periods[0].id,
+                orgId,
+                userId,
+            )
+
+        assertThat(result.periods[0].status).isEqualTo(FiscalPeriodStatus.CLOSED)
+        assertThat(result.periods[0].closedBy).isEqualTo(userId)
+        assertThat(result.periods[0].closedAt).isNotNull()
+    }
+
+    @Test
+    fun `closePeriod should reject if period is already closed`() {
+        val fiscalYear =
+            createFiscalYear(
+                periods =
+                    listOf(
+                        createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+                    ),
+            )
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.closePeriod(
+                    "fy-1",
+                    fiscalYear.periods[0].id,
+                    orgId,
+                    userId,
+                )
+            }
+        assertThat(exception.message).contains("already closed")
+    }
+
+    @Test
+    fun `closePeriod should reject if preceding period is still open`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.OPEN),
+                createPeriod(2, status = FiscalPeriodStatus.OPEN),
+            )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.closePeriod(
+                    "fy-1",
+                    fiscalYear.periods[1].id,
+                    orgId,
+                    userId,
+                )
+            }
+        assertThat(exception.message).contains("preceding periods must be closed")
+    }
+
+    @Test
+    fun `reopenPeriod should set status to REOPENED`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+                createPeriod(2, status = FiscalPeriodStatus.CLOSED),
+            )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+
+        val result =
+            fiscalYearService.reopenPeriod(
+                "fy-1",
+                fiscalYear.periods[1].id,
+                orgId,
+                userId,
+            )
+
+        assertThat(result.periods[1].status).isEqualTo(FiscalPeriodStatus.REOPENED)
+        assertThat(result.periods[1].reopenedBy).isEqualTo(userId)
+        assertThat(result.periods[1].reopenedAt).isNotNull()
+    }
+
+    @Test
+    fun `reopenPeriod should reject if subsequent period is open`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+                createPeriod(2, status = FiscalPeriodStatus.OPEN),
+            )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.reopenPeriod(
+                    "fy-1",
+                    fiscalYear.periods[0].id,
+                    orgId,
+                    userId,
+                )
+            }
+        assertThat(exception.message).contains("subsequent periods must be closed")
+    }
+
+    @Test
+    fun `reopenPeriod should reject if fiscal year is closed`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            )
+        val fiscalYear =
+            createFiscalYear(
+                periods = periods,
+                status = FiscalYearStatus.CLOSED,
+            )
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.reopenPeriod(
+                    "fy-1",
+                    fiscalYear.periods[0].id,
+                    orgId,
+                    userId,
+                )
+            }
+        assertThat(exception.message).contains("closed fiscal year")
+    }
+
+    @Test
+    fun `closeYear should reject if any period is not closed`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+                createPeriod(2, status = FiscalPeriodStatus.OPEN),
+            )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                fiscalYearService.closeYear("fy-1", orgId, userId)
+            }
+        assertThat(exception.message).contains("All periods must be closed")
+    }
+
+    @Test
+    fun `closeYear should create closing journal entry zeroing revenue and expense`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryRepository.existsByOrganizationIdAndSourceReference(orgId, "YEAR-END-CLOSE-fy-1"))
+            .thenReturn(false)
+
+        val cashAccount =
+            Account(
+                id = "acc-cash",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                organizationId = orgId,
+            )
+        val revenueAccount =
+            Account(
+                id = "acc-revenue",
+                code = "4000",
+                name = "Sales Revenue",
+                type = AccountType.REVENUE,
+                organizationId = orgId,
+            )
+        val expenseAccount =
+            Account(
+                id = "acc-expense",
+                code = "5000",
+                name = "Cost of Goods Sold",
+                type = AccountType.EXPENSE,
+                organizationId = orgId,
+            )
+        val retainedEarnings =
+            Account(
+                id = "acc-re",
+                code = "3100",
+                name = "Retained Earnings",
+                type = AccountType.EQUITY,
+                organizationId = orgId,
+            )
+
+        val entries =
+            listOf(
+                JournalEntry(
+                    id = "entry-1",
+                    entryNumber = "JE-0001",
+                    date = LocalDate.of(2026, 1, 15),
+                    description = "Sale",
+                    organizationId = orgId,
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-cash",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal("1000.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-revenue",
+                                accountCode = "4000",
+                                accountName = "Sales Revenue",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("1000.00"),
+                            ),
+                        ),
+                    createdBy = userId,
+                ),
+                JournalEntry(
+                    id = "entry-2",
+                    entryNumber = "JE-0002",
+                    date = LocalDate.of(2026, 1, 20),
+                    description = "Purchase",
+                    organizationId = orgId,
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-expense",
+                                accountCode = "5000",
+                                accountName = "Cost of Goods Sold",
+                                debit = BigDecimal("300.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-cash",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("300.00"),
+                            ),
+                        ),
+                    createdBy = userId,
+                ),
+            )
+
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                fiscalYear.startDate,
+                fiscalYear.endDate,
+            ),
+        ).thenReturn(entries)
+
+        `when`(accountRepository.findAllById(any<Iterable<String>>()))
+            .thenReturn(listOf(cashAccount, revenueAccount, expenseAccount, retainedEarnings))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "3100"))
+            .thenReturn(Optional.of(retainedEarnings))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(2L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val result = fiscalYearService.closeYear("fy-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(FiscalYearStatus.CLOSED)
+        assertThat(result.closedBy).isEqualTo(userId)
+        assertThat(result.closedAt).isNotNull()
+        assertThat(result.closingEntryId).isNotNull()
+
+        val entryCaptor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(entryCaptor.capture())
+
+        val closingEntry = entryCaptor.firstValue
+        assertThat(closingEntry.description).contains("Year-end closing entry")
+        assertThat(closingEntry.status).isEqualTo(JournalEntryStatus.POSTED)
+
+        // Revenue (1000 credit balance) should be debited to zero it
+        val revenueLine = closingEntry.lines.find { it.accountId == "acc-revenue" }
+        assertThat(revenueLine).isNotNull
+        assertThat(revenueLine!!.debit).isEqualByComparingTo(BigDecimal("1000.00"))
+
+        // Expense (300 debit balance) should be credited to zero it
+        val expenseLine = closingEntry.lines.find { it.accountId == "acc-expense" }
+        assertThat(expenseLine).isNotNull
+        assertThat(expenseLine!!.credit).isEqualByComparingTo(BigDecimal("300.00"))
+
+        // Net income = 1000 - 300 = 700, credited to Retained Earnings
+        val reLine = closingEntry.lines.find { it.accountId == "acc-re" }
+        assertThat(reLine).isNotNull
+        assertThat(reLine!!.credit).isEqualByComparingTo(BigDecimal("700.00"))
+    }
+
+    @Test
+    fun `closeYear should handle net loss correctly`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryRepository.existsByOrganizationIdAndSourceReference(orgId, "YEAR-END-CLOSE-fy-1"))
+            .thenReturn(false)
+
+        val cashAccount =
+            Account(
+                id = "acc-cash",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                organizationId = orgId,
+            )
+        val expenseAccount =
+            Account(
+                id = "acc-expense",
+                code = "5000",
+                name = "Cost of Goods Sold",
+                type = AccountType.EXPENSE,
+                organizationId = orgId,
+            )
+        val retainedEarnings =
+            Account(
+                id = "acc-re",
+                code = "3100",
+                name = "Retained Earnings",
+                type = AccountType.EQUITY,
+                organizationId = orgId,
+            )
+
+        val entries =
+            listOf(
+                JournalEntry(
+                    id = "entry-1",
+                    entryNumber = "JE-0001",
+                    date = LocalDate.of(2026, 1, 15),
+                    description = "Expense only",
+                    organizationId = orgId,
+                    status = JournalEntryStatus.POSTED,
+                    lines =
+                        listOf(
+                            JournalEntryLine(
+                                accountId = "acc-expense",
+                                accountCode = "5000",
+                                accountName = "Cost of Goods Sold",
+                                debit = BigDecimal("500.00"),
+                                credit = BigDecimal.ZERO,
+                            ),
+                            JournalEntryLine(
+                                accountId = "acc-cash",
+                                accountCode = "1000",
+                                accountName = "Cash",
+                                debit = BigDecimal.ZERO,
+                                credit = BigDecimal("500.00"),
+                            ),
+                        ),
+                    createdBy = userId,
+                ),
+            )
+
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                fiscalYear.startDate,
+                fiscalYear.endDate,
+            ),
+        ).thenReturn(entries)
+
+        `when`(accountRepository.findAllById(any<Iterable<String>>()))
+            .thenReturn(listOf(cashAccount, expenseAccount, retainedEarnings))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "3100"))
+            .thenReturn(Optional.of(retainedEarnings))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(1L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+
+        val result = fiscalYearService.closeYear("fy-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(FiscalYearStatus.CLOSED)
+
+        val entryCaptor = argumentCaptor<JournalEntry>()
+        verify(journalEntryRepository).save(entryCaptor.capture())
+
+        val closingEntry = entryCaptor.firstValue
+        // Net loss: 0 revenue - 500 expense = -500
+        // Retained Earnings should be debited (reducing equity)
+        val reLine = closingEntry.lines.find { it.accountId == "acc-re" }
+        assertThat(reLine).isNotNull
+        assertThat(reLine!!.debit).isEqualByComparingTo(BigDecimal("500.00"))
+        assertThat(reLine.credit).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `closeYear should skip closing entry when no revenue or expense activity`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.CLOSED),
+            )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
+        `when`(fiscalYearRepository.save(any<FiscalYear>())).thenAnswer { it.arguments[0] }
+        `when`(journalEntryRepository.existsByOrganizationIdAndSourceReference(orgId, "YEAR-END-CLOSE-fy-1"))
+            .thenReturn(false)
+
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                fiscalYear.startDate,
+                fiscalYear.endDate,
+            ),
+        ).thenReturn(emptyList())
+
+        `when`(accountRepository.findAllById(any<Iterable<String>>()))
+            .thenReturn(emptyList())
+
+        val result = fiscalYearService.closeYear("fy-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(FiscalYearStatus.CLOSED)
+        assertThat(result.closingEntryId).isNull()
+        verify(journalEntryRepository, never()).save(any<JournalEntry>())
+    }
+
+    @Test
+    fun `findPeriodForDate should return matching open period`() {
+        val fiscalYear = createFiscalYear()
+        `when`(fiscalYearRepository.findByOrganizationId(orgId))
+            .thenReturn(listOf(fiscalYear))
+
+        val result =
+            fiscalYearService.findPeriodForDate(
+                orgId,
+                LocalDate.of(2026, 1, 15),
+            )
+
+        assertThat(result).isInstanceOf(FiscalYearService.PeriodLookupResult.Found::class.java)
+        val found = result as FiscalYearService.PeriodLookupResult.Found
+        assertThat(found.period.status).isEqualTo(FiscalPeriodStatus.OPEN)
+    }
+
+    @Test
+    fun `findPeriodForDate should return NoFiscalYears when no fiscal year exists`() {
+        `when`(fiscalYearRepository.findByOrganizationId(orgId))
+            .thenReturn(emptyList())
+
+        val result =
+            fiscalYearService.findPeriodForDate(
+                orgId,
+                LocalDate.of(2026, 1, 15),
+            )
+
+        assertThat(result).isEqualTo(FiscalYearService.PeriodLookupResult.NoFiscalYears)
+    }
+
+    @Test
+    fun `findPeriodForDate should return NotFound when date is outside fiscal year`() {
+        val fiscalYear = createFiscalYear()
+        `when`(fiscalYearRepository.findByOrganizationId(orgId))
+            .thenReturn(listOf(fiscalYear))
+
+        val result =
+            fiscalYearService.findPeriodForDate(
+                orgId,
+                LocalDate.of(2025, 6, 15),
+            )
+
+        assertThat(result).isEqualTo(FiscalYearService.PeriodLookupResult.NotFound)
+    }
+
+    @Test
+    fun `findPeriodForDate should return reopened period`() {
+        val periods =
+            listOf(
+                createPeriod(1, status = FiscalPeriodStatus.REOPENED),
+            )
+        val fiscalYear = createFiscalYear(periods = periods)
+        `when`(fiscalYearRepository.findByOrganizationId(orgId))
+            .thenReturn(listOf(fiscalYear))
+
+        val result =
+            fiscalYearService.findPeriodForDate(
+                orgId,
+                LocalDate.of(2026, 1, 15),
+            )
+
+        assertThat(result).isInstanceOf(FiscalYearService.PeriodLookupResult.Found::class.java)
+        val found = result as FiscalYearService.PeriodLookupResult.Found
+        assertThat(found.period.status).isEqualTo(FiscalPeriodStatus.REOPENED)
+    }
+
+    private fun createFiscalYear(
+        id: String = "fy-1",
+        name: String = "FY 2026",
+        startDate: LocalDate = LocalDate.of(2026, 1, 1),
+        endDate: LocalDate = LocalDate.of(2026, 12, 31),
+        status: FiscalYearStatus = FiscalYearStatus.ACTIVE,
+        periods: List<FiscalPeriod>? = null,
+    ): FiscalYear =
+        FiscalYear(
+            id = id,
+            name = name,
+            startDate = startDate,
+            endDate = endDate,
+            status = status,
+            organizationId = orgId,
+            periods =
+                periods ?: listOf(
+                    createPeriod(1),
+                ),
+        )
+
+    private fun createPeriod(
+        number: Int,
+        status: FiscalPeriodStatus = FiscalPeriodStatus.OPEN,
+    ): FiscalPeriod =
+        FiscalPeriod(
+            periodNumber = number,
+            name = "January 2026",
+            startDate = LocalDate.of(2026, 1, 1),
+            endDate = LocalDate.of(2026, 1, 31),
+            status = status,
+        )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -29,6 +29,7 @@ import org.springframework.data.mongodb.core.FindAndModifyOptions
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Optional
 
 class InvitationServiceTest {
@@ -139,7 +140,7 @@ class InvitationServiceTest {
         val expiredInvitation =
             createMockInvitation(
                 email = "reinvite@example.com",
-                expiryAt = LocalDateTime.now().minusHours(1),
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).minusHours(1),
             )
 
         `when`(roleRepository.findByName("MEMBER")).thenReturn(Optional.of(memberRole))
@@ -386,7 +387,7 @@ class InvitationServiceTest {
         role: String = "MEMBER",
         organizationId: String = "org-123",
         status: InvitationStatus = InvitationStatus.PENDING,
-        expiryAt: LocalDateTime = LocalDateTime.now().plusHours(72),
+        expiryAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).plusHours(72),
     ) = Invitation(
         id = "inv-123",
         email = email,

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -4,6 +4,8 @@ import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.JournalEntryLineRequest
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.FiscalPeriod
+import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
@@ -28,6 +30,8 @@ class JournalEntryServiceTest {
     private lateinit var journalEntryService: JournalEntryService
     private lateinit var journalEntryRepository: JournalEntryRepository
     private lateinit var accountRepository: AccountRepository
+    private lateinit var fiscalYearService: FiscalYearService
+    private lateinit var entryNumberGenerator: JournalEntryNumberGenerator
 
     private val orgId = "org-123"
     private val createdBy = "user-1"
@@ -36,10 +40,16 @@ class JournalEntryServiceTest {
     fun setup() {
         journalEntryRepository = mock(JournalEntryRepository::class.java)
         accountRepository = mock(AccountRepository::class.java)
+        fiscalYearService = mock(FiscalYearService::class.java)
+        entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
+        `when`(fiscalYearService.findPeriodForDate(any(), any()))
+            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
         journalEntryService =
             JournalEntryService(
                 journalEntryRepository = journalEntryRepository,
                 accountRepository = accountRepository,
+                fiscalYearService = fiscalYearService,
+                entryNumberGenerator = entryNumberGenerator,
             )
     }
 
@@ -559,6 +569,219 @@ class JournalEntryServiceTest {
         assertThat(revenueBalance!!.totalCredits).isEqualByComparingTo(BigDecimal("300.00"))
         // REVENUE: balance = credits - debits
         assertThat(revenueBalance.balance).isEqualByComparingTo(BigDecimal("300.00"))
+    }
+
+    @Test
+    fun `create should succeed when no fiscal year exists`() {
+        val cashAccount =
+            createMockAccount(
+                id = "acc-1",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                orgId = orgId,
+            )
+        val revenueAccount =
+            createMockAccount(
+                id = "acc-2",
+                code = "4000",
+                name = "Revenue",
+                type = AccountType.REVENUE,
+                orgId = orgId,
+            )
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
+            .thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
+            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Test entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(
+                            accountId = "acc-1",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLineRequest(
+                            accountId = "acc-2",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+            )
+
+        val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
+        assertThat(result.status).isEqualTo(JournalEntryStatus.DRAFT)
+    }
+
+    @Test
+    fun `create should reject when fiscal period is closed`() {
+        val cashAccount =
+            createMockAccount(
+                id = "acc-1",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                orgId = orgId,
+            )
+        val revenueAccount =
+            createMockAccount(
+                id = "acc-2",
+                code = "4000",
+                name = "Revenue",
+                type = AccountType.REVENUE,
+                orgId = orgId,
+            )
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
+            .thenReturn(listOf(cashAccount, revenueAccount))
+        val closedPeriod =
+            FiscalPeriod(
+                periodNumber = 1,
+                name = "January 2026",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 31),
+                status = FiscalPeriodStatus.CLOSED,
+            )
+
+        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
+            .thenReturn(FiscalYearService.PeriodLookupResult.Found(closedPeriod))
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Test entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(
+                            accountId = "acc-1",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLineRequest(
+                            accountId = "acc-2",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.createJournalEntry(request, orgId, createdBy)
+            }
+        assertThat(exception.message).contains("closed")
+    }
+
+    @Test
+    fun `create should succeed when fiscal period is open`() {
+        val cashAccount =
+            createMockAccount(
+                id = "acc-1",
+                code = "1000",
+                name = "Cash",
+                type = AccountType.ASSET,
+                orgId = orgId,
+            )
+        val revenueAccount =
+            createMockAccount(
+                id = "acc-2",
+                code = "4000",
+                name = "Revenue",
+                type = AccountType.REVENUE,
+                orgId = orgId,
+            )
+        val openPeriod =
+            FiscalPeriod(
+                periodNumber = 1,
+                name = "January 2026",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 31),
+                status = FiscalPeriodStatus.OPEN,
+            )
+
+        `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
+            .thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
+        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
+            .thenReturn(FiscalYearService.PeriodLookupResult.Found(openPeriod))
+
+        val request =
+            CreateJournalEntryRequest(
+                date = LocalDate.of(2026, 1, 15),
+                description = "Test entry",
+                lines =
+                    listOf(
+                        JournalEntryLineRequest(
+                            accountId = "acc-1",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLineRequest(
+                            accountId = "acc-2",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+            )
+
+        val result = journalEntryService.createJournalEntry(request, orgId, createdBy)
+        assertThat(result.status).isEqualTo(JournalEntryStatus.DRAFT)
+    }
+
+    @Test
+    fun `post should reject when fiscal period is closed`() {
+        val entry =
+            createMockEntry(
+                id = "entry-1",
+                entryNumber = "JE-0001",
+                status = JournalEntryStatus.DRAFT,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = "acc-1",
+                            accountCode = "1000",
+                            accountName = "Cash",
+                            debit = BigDecimal("100.00"),
+                            credit = BigDecimal.ZERO,
+                        ),
+                        JournalEntryLine(
+                            accountId = "acc-2",
+                            accountCode = "4000",
+                            accountName = "Revenue",
+                            debit = BigDecimal.ZERO,
+                            credit = BigDecimal("100.00"),
+                        ),
+                    ),
+                orgId = orgId,
+            )
+
+        val closedPeriod =
+            FiscalPeriod(
+                periodNumber = 1,
+                name = "January 2026",
+                startDate = LocalDate.of(2026, 1, 1),
+                endDate = LocalDate.of(2026, 1, 31),
+                status = FiscalPeriodStatus.CLOSED,
+            )
+
+        `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
+        `when`(
+            fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
+        ).thenReturn(FiscalYearService.PeriodLookupResult.Found(closedPeriod))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                journalEntryService.postJournalEntry("entry-1", orgId)
+            }
+        assertThat(exception.message).contains("closed")
     }
 
     private fun createMockAccount(

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -4,8 +4,6 @@ import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.JournalEntryLineRequest
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
-import com.froilan.synectix.model.FiscalPeriod
-import com.froilan.synectix.model.FiscalPeriodStatus
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
@@ -22,6 +20,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.Optional
@@ -42,8 +41,6 @@ class JournalEntryServiceTest {
         accountRepository = mock(AccountRepository::class.java)
         fiscalYearService = mock(FiscalYearService::class.java)
         entryNumberGenerator = JournalEntryNumberGenerator(journalEntryRepository)
-        `when`(fiscalYearService.findPeriodForDate(any(), any()))
-            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
         journalEntryService =
             JournalEntryService(
                 journalEntryRepository = journalEntryRepository,
@@ -594,8 +591,6 @@ class JournalEntryServiceTest {
             .thenReturn(listOf(cashAccount, revenueAccount))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
-        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(FiscalYearService.PeriodLookupResult.NoFiscalYears)
 
         val request =
             CreateJournalEntryRequest(
@@ -641,17 +636,9 @@ class JournalEntryServiceTest {
 
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
-        val closedPeriod =
-            FiscalPeriod(
-                periodNumber = 1,
-                name = "January 2026",
-                startDate = LocalDate.of(2026, 1, 1),
-                endDate = LocalDate.of(2026, 1, 31),
-                status = FiscalPeriodStatus.CLOSED,
-            )
-
-        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(FiscalYearService.PeriodLookupResult.Found(closedPeriod))
+        doThrow(IllegalArgumentException("Fiscal period 'January 2026' is closed"))
+            .`when`(fiscalYearService)
+            .validatePeriodOpen(orgId, LocalDate.of(2026, 1, 15))
 
         val request =
             CreateJournalEntryRequest(
@@ -697,21 +684,10 @@ class JournalEntryServiceTest {
                 type = AccountType.REVENUE,
                 orgId = orgId,
             )
-        val openPeriod =
-            FiscalPeriod(
-                periodNumber = 1,
-                name = "January 2026",
-                startDate = LocalDate.of(2026, 1, 1),
-                endDate = LocalDate.of(2026, 1, 31),
-                status = FiscalPeriodStatus.OPEN,
-            )
-
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
         `when`(journalEntryRepository.countByOrganizationId(orgId)).thenReturn(0L)
         `when`(journalEntryRepository.save(any<JournalEntry>())).thenAnswer { it.arguments[0] }
-        `when`(fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)))
-            .thenReturn(FiscalYearService.PeriodLookupResult.Found(openPeriod))
 
         val request =
             CreateJournalEntryRequest(
@@ -763,19 +739,10 @@ class JournalEntryServiceTest {
                 orgId = orgId,
             )
 
-        val closedPeriod =
-            FiscalPeriod(
-                periodNumber = 1,
-                name = "January 2026",
-                startDate = LocalDate.of(2026, 1, 1),
-                endDate = LocalDate.of(2026, 1, 31),
-                status = FiscalPeriodStatus.CLOSED,
-            )
-
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
-        `when`(
-            fiscalYearService.findPeriodForDate(orgId, LocalDate.of(2026, 1, 15)),
-        ).thenReturn(FiscalYearService.PeriodLookupResult.Found(closedPeriod))
+        doThrow(IllegalArgumentException("Fiscal period 'January 2026' is closed"))
+            .`when`(fiscalYearService)
+            .validatePeriodOpen(orgId, LocalDate.of(2026, 1, 15))
 
         val exception =
             assertThrows<IllegalArgumentException> {

--- a/src/test/kotlin/com/froilan/synectix/service/VendorServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/VendorServiceTest.kt
@@ -1,0 +1,147 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateVendorRequest
+import com.froilan.synectix.dto.UpdateVendorRequest
+import com.froilan.synectix.model.Vendor
+import com.froilan.synectix.repository.VendorRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.util.Optional
+
+class VendorServiceTest {
+    private lateinit var vendorService: VendorService
+    private lateinit var vendorRepository: VendorRepository
+
+    private val orgId = "org-123"
+
+    @BeforeEach
+    fun setup() {
+        vendorRepository = mock(VendorRepository::class.java)
+        vendorService = VendorService(vendorRepository)
+    }
+
+    @Test
+    fun `create should save vendor with correct fields`() {
+        `when`(vendorRepository.save(any<Vendor>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateVendorRequest(
+                name = "Acme Corp",
+                contactName = "John Doe",
+                contactEmail = "john@acme.com",
+                paymentTermDays = 45,
+            )
+
+        val result = vendorService.createVendor(request, orgId)
+
+        assertThat(result.name).isEqualTo("Acme Corp")
+        assertThat(result.contactName).isEqualTo("John Doe")
+        assertThat(result.contactEmail).isEqualTo("john@acme.com")
+        assertThat(result.paymentTermDays).isEqualTo(45)
+        assertThat(result.organizationId).isEqualTo(orgId)
+        assertThat(result.isActive).isTrue()
+    }
+
+    @Test
+    fun `get should return vendor for correct org`() {
+        val vendor = createVendor()
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+
+        val result = vendorService.getVendor("v-1", orgId)
+        assertThat(result.id).isEqualTo("v-1")
+    }
+
+    @Test
+    fun `get should throw when vendor belongs to different org`() {
+        val vendor = createVendor(orgId = "other-org")
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                vendorService.getVendor("v-1", orgId)
+            }
+        assertThat(exception.message).contains("Vendor not found")
+    }
+
+    @Test
+    fun `list should return active vendors`() {
+        val vendors = listOf(createVendor(), createVendor(id = "v-2", name = "Beta Inc"))
+        `when`(vendorRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(vendors)
+
+        val result = vendorService.listVendors(orgId)
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun `update should apply partial changes`() {
+        val vendor = createVendor()
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+        `when`(vendorRepository.save(any<Vendor>())).thenAnswer { it.arguments[0] }
+
+        val request = UpdateVendorRequest(name = "Updated Corp")
+        val result = vendorService.updateVendor("v-1", request, orgId)
+
+        assertThat(result.name).isEqualTo("Updated Corp")
+        assertThat(result.contactName).isEqualTo("John Doe")
+    }
+
+    @Test
+    fun `update should reject inactive vendor`() {
+        val vendor = createVendor(isActive = false)
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                vendorService.updateVendor("v-1", UpdateVendorRequest(name = "New"), orgId)
+            }
+        assertThat(exception.message).contains("inactive")
+    }
+
+    @Test
+    fun `delete should soft delete vendor`() {
+        val vendor = createVendor()
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+        `when`(vendorRepository.save(any<Vendor>())).thenAnswer { it.arguments[0] }
+
+        val result = vendorService.deleteVendor("v-1", orgId)
+
+        assertThat(result.isActive).isFalse()
+        val captor = argumentCaptor<Vendor>()
+        verify(vendorRepository).save(captor.capture())
+        assertThat(captor.firstValue.isActive).isFalse()
+    }
+
+    @Test
+    fun `delete should reject already inactive vendor`() {
+        val vendor = createVendor(isActive = false)
+        `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                vendorService.deleteVendor("v-1", orgId)
+            }
+        assertThat(exception.message).contains("already inactive")
+    }
+
+    private fun createVendor(
+        id: String = "v-1",
+        name: String = "Acme Corp",
+        orgId: String = this.orgId,
+        isActive: Boolean = true,
+    ) = Vendor(
+        id = id,
+        name = name,
+        contactName = "John Doe",
+        contactEmail = "john@acme.com",
+        paymentTermDays = 30,
+        organizationId = orgId,
+        isActive = isActive,
+    )
+}


### PR DESCRIPTION
## Summary
Ships 3 PRs from staging to production:

### Fiscal Period Management (#100, closes #30)
- Fiscal year with auto-generated monthly periods
- Period lifecycle: OPEN → CLOSED → REOPENED with sequential enforcement
- Year-end close generating closing journal entries (revenue/expense → Retained Earnings)
- Fiscal period validation hook on all journal entry create/post/void paths

### Accounts Payable (#102, closes #26)
- Vendor management with CRUD and soft delete
- Bill lifecycle: DRAFT → APPROVED → PARTIALLY_PAID → PAID → VOID
- Auto-posted journal entries on bill approval, void, and payment
- AP aging report with standard overdue buckets
- `createSystemEntry` in JournalEntryService for centralized system GL posting
- `validatePeriodOpen` extracted to FiscalYearService as shared method
- All `LocalDateTime.now()` and `LocalDate.now()` migrated to UTC across entire codebase
- `DuplicateKeyException` cause preserved across all services
- Gradle configuration cache enabled

### AuthenticationContext Refactor (#104)
- Extract duplicated `extractOrganizationId()`/`extractUserId()` from 5 controllers into shared `AuthenticationContext` bean
- 8 unit tests covering all branches (SessionContext, ApiKeyContext, missing auth, wrong principal type)

## Test plan
- [x] 252+ tests pass (1 pre-existing MongoDB context load failure)
- [x] ktlintCheck passes
- [x] All Copilot review findings addressed across multiple review rounds