### PR TITLE
Accounts Receivable (AR) module (#27)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -61,6 +61,11 @@ class RoleSeeder(
                             Permissions.AP_APPROVE,
                             Permissions.AP_PAY,
                             Permissions.AP_VOID,
+                            Permissions.AR_CREATE,
+                            Permissions.AR_READ,
+                            Permissions.AR_APPROVE,
+                            Permissions.AR_RECEIVE,
+                            Permissions.AR_VOID,
                         ),
                 ),
                 Role(
@@ -91,6 +96,10 @@ class RoleSeeder(
                             Permissions.AP_READ,
                             Permissions.AP_APPROVE,
                             Permissions.AP_PAY,
+                            Permissions.AR_CREATE,
+                            Permissions.AR_READ,
+                            Permissions.AR_APPROVE,
+                            Permissions.AR_RECEIVE,
                         ),
                 ),
                 Role(
@@ -110,6 +119,8 @@ class RoleSeeder(
                             Permissions.FISCAL_READ,
                             Permissions.AP_CREATE,
                             Permissions.AP_READ,
+                            Permissions.AR_CREATE,
+                            Permissions.AR_READ,
                         ),
                 ),
                 Role(
@@ -124,6 +135,7 @@ class RoleSeeder(
                             Permissions.JOURNAL_READ,
                             Permissions.FISCAL_READ,
                             Permissions.AP_READ,
+                            Permissions.AR_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -226,6 +226,7 @@ class BillController(
             approvedBy = approvedBy,
             paidAt = paidAt?.toString(),
             voidedAt = voidedAt?.toString(),
+            voidedBy = voidedBy,
             voidReason = voidReason,
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),

--- a/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
@@ -62,7 +62,8 @@ class CustomerController(
             val customer = customerService.getCustomer(id, orgId)
             ResponseEntity.ok(customer.toResponse())
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND)
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(mapOf("error" to (e.message ?: "Customer not found")))
         }
     }
@@ -81,7 +82,8 @@ class CustomerController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Customer not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to update customer")))
         }
     }
@@ -99,7 +101,8 @@ class CustomerController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Customer not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to delete customer")))
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
@@ -1,0 +1,126 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateCustomerRequest
+import com.froilan.synectix.dto.CustomerResponse
+import com.froilan.synectix.dto.UpdateCustomerRequest
+import com.froilan.synectix.model.Customer
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.CustomerService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/finance/ar/customers")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class CustomerController(
+    private val customerService: CustomerService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('ar:create')")
+    fun createCustomer(
+        @Valid @RequestBody request: CreateCustomerRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val customer = customerService.createCustomer(request, orgId)
+            ResponseEntity.status(HttpStatus.CREATED).body(customer.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create customer")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun listCustomers(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val customers = customerService.listCustomers(orgId)
+        return ResponseEntity.ok(customers.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun getCustomer(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val customer = customerService.getCustomer(id, orgId)
+            ResponseEntity.ok(customer.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Customer not found")))
+        }
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('ar:create')")
+    fun updateCustomer(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateCustomerRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val customer = customerService.updateCustomer(id, request, orgId)
+            ResponseEntity.ok(customer.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Customer not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to update customer")))
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('ar:create')")
+    fun deleteCustomer(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val customer = customerService.deleteCustomer(id, orgId)
+            ResponseEntity.ok(customer.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Customer not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to delete customer")))
+        }
+    }
+
+    private fun Customer.toResponse() =
+        CustomerResponse(
+            id = id,
+            name = name,
+            contactName = contactName,
+            contactEmail = contactEmail,
+            contactPhone = contactPhone,
+            paymentTermDays = paymentTermDays,
+            defaultRevenueAccountId = defaultRevenueAccountId,
+            organizationId = organizationId,
+            isActive = isActive,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
@@ -1,0 +1,253 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateInvoiceRequest
+import com.froilan.synectix.dto.InvoiceLineResponse
+import com.froilan.synectix.dto.InvoiceReceiptResponse
+import com.froilan.synectix.dto.InvoiceResponse
+import com.froilan.synectix.dto.InvoiceSummaryResponse
+import com.froilan.synectix.dto.RecordReceiptRequest
+import com.froilan.synectix.dto.VoidInvoiceRequest
+import com.froilan.synectix.model.Invoice
+import com.froilan.synectix.model.InvoiceReceipt
+import com.froilan.synectix.model.InvoiceStatus
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.InvoiceService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.Locale
+
+@RestController
+@RequestMapping("/finance/ar/invoices")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class InvoiceController(
+    private val invoiceService: InvoiceService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('ar:create')")
+    fun createInvoice(
+        @Valid @RequestBody request: CreateInvoiceRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
+
+        return try {
+            val invoice = invoiceService.createInvoice(request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(invoice.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest()
+                .body(mapOf("error" to (e.message ?: "Failed to create invoice")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun listInvoices(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) customerId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        val invoiceStatus =
+            if (status != null) {
+                try {
+                    InvoiceStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest()
+                        .body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+
+        val invoices = invoiceService.listInvoices(orgId, invoiceStatus, customerId)
+        return ResponseEntity.ok(invoices.map { it.toSummaryResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun getInvoice(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val invoice = invoiceService.getInvoice(id, orgId)
+            ResponseEntity.ok(invoice.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Invoice not found")))
+        }
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('ar:approve')")
+    fun approveInvoice(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+
+        return try {
+            val invoice = invoiceService.approveInvoice(id, orgId, userId)
+            ResponseEntity.ok(invoice.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to approve invoice")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to approve invoice")))
+        }
+    }
+
+    @PostMapping("/{id}/void")
+    @PreAuthorize("hasAuthority('ar:void')")
+    fun voidInvoice(
+        @PathVariable id: String,
+        @Valid @RequestBody request: VoidInvoiceRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+
+        return try {
+            val invoice = invoiceService.voidInvoice(id, orgId, request.reason, userId)
+            ResponseEntity.ok(invoice.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to void invoice")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to void invoice")))
+        }
+    }
+
+    @PostMapping("/{id}/receipts")
+    @PreAuthorize("hasAuthority('ar:receive')")
+    fun recordReceipt(
+        @PathVariable id: String,
+        @Valid @RequestBody request: RecordReceiptRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
+
+        return try {
+            val receipt = invoiceService.recordReceipt(id, request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(receipt.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity.status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to record receipt")))
+        } catch (e: IllegalStateException) {
+            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(mapOf("error" to (e.message ?: "Failed to record receipt")))
+        }
+    }
+
+    @GetMapping("/{id}/receipts")
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun listReceipts(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val receipts = invoiceService.getReceipts(id, orgId)
+            ResponseEntity.ok(receipts.map { it.toResponse() })
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Invoice not found")))
+        }
+    }
+
+    @GetMapping("/aging")
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun getAgingReport(
+        @RequestParam(required = false) asOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val report = invoiceService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
+        return ResponseEntity.ok(report)
+    }
+
+    private fun Invoice.toResponse() =
+        InvoiceResponse(
+            id = id,
+            invoiceNumber = invoiceNumber,
+            customerId = customerId,
+            customerName = customerName,
+            date = date.toString(),
+            dueDate = dueDate.toString(),
+            referenceNumber = referenceNumber,
+            organizationId = organizationId,
+            status = status.name,
+            lines =
+                lines.map { line ->
+                    InvoiceLineResponse(
+                        accountId = line.accountId,
+                        accountCode = line.accountCode,
+                        accountName = line.accountName,
+                        amount = line.amount,
+                        description = line.description,
+                    )
+                },
+            totalAmount = totalAmount,
+            amountReceived = amountReceived,
+            journalEntryId = journalEntryId,
+            createdBy = createdBy,
+            approvedAt = approvedAt?.toString(),
+            approvedBy = approvedBy,
+            paidAt = paidAt?.toString(),
+            voidedAt = voidedAt?.toString(),
+            voidReason = voidReason,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun Invoice.toSummaryResponse() =
+        InvoiceSummaryResponse(
+            id = id,
+            invoiceNumber = invoiceNumber,
+            customerName = customerName,
+            date = date.toString(),
+            dueDate = dueDate.toString(),
+            status = status.name,
+            totalAmount = totalAmount,
+            amountReceived = amountReceived,
+        )
+
+    private fun InvoiceReceipt.toResponse() =
+        InvoiceReceiptResponse(
+            id = id,
+            invoiceId = invoiceId,
+            receiptDate = receiptDate.toString(),
+            amount = amount,
+            paymentMethod = paymentMethod.name,
+            referenceNumber = referenceNumber,
+            journalEntryId = journalEntryId,
+            createdBy = createdBy,
+            createdAt = createdAt?.toString(),
+        )
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
@@ -226,6 +226,7 @@ class InvoiceController(
             approvedBy = approvedBy,
             paidAt = paidAt?.toString(),
             voidedAt = voidedAt?.toString(),
+            voidedBy = voidedBy,
             voidReason = voidReason,
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),

--- a/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
@@ -48,7 +48,8 @@ class InvoiceController(
             val invoice = invoiceService.createInvoice(request, orgId, createdBy)
             ResponseEntity.status(HttpStatus.CREATED).body(invoice.toResponse())
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest()
+            ResponseEntity
+                .badRequest()
                 .body(mapOf("error" to (e.message ?: "Failed to create invoice")))
         }
     }
@@ -66,7 +67,8 @@ class InvoiceController(
                 try {
                     InvoiceStatus.valueOf(status.uppercase(Locale.ROOT))
                 } catch (e: IllegalArgumentException) {
-                    return ResponseEntity.badRequest()
+                    return ResponseEntity
+                        .badRequest()
                         .body(mapOf("error" to "Invalid status '$status'"))
                 }
             } else {
@@ -88,7 +90,8 @@ class InvoiceController(
             val invoice = invoiceService.getInvoice(id, orgId)
             ResponseEntity.ok(invoice.toResponse())
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND)
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(mapOf("error" to (e.message ?: "Invoice not found")))
         }
     }
@@ -107,10 +110,12 @@ class InvoiceController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to approve invoice")))
         } catch (e: IllegalStateException) {
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(mapOf("error" to (e.message ?: "Failed to approve invoice")))
         }
     }
@@ -130,10 +135,12 @@ class InvoiceController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to void invoice")))
         } catch (e: IllegalStateException) {
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(mapOf("error" to (e.message ?: "Failed to void invoice")))
         }
     }
@@ -153,10 +160,12 @@ class InvoiceController(
         } catch (e: IllegalArgumentException) {
             val status =
                 if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status)
+            ResponseEntity
+                .status(status)
                 .body(mapOf("error" to (e.message ?: "Failed to record receipt")))
         } catch (e: IllegalStateException) {
-            ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(mapOf("error" to (e.message ?: "Failed to record receipt")))
         }
     }
@@ -172,7 +181,8 @@ class InvoiceController(
             val receipts = invoiceService.getReceipts(id, orgId)
             ResponseEntity.ok(receipts.map { it.toResponse() })
         } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND)
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
                 .body(mapOf("error" to (e.message ?: "Invoice not found")))
         }
     }

--- a/src/main/kotlin/com/froilan/synectix/dto/BillDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/BillDtos.kt
@@ -67,6 +67,7 @@ data class BillResponse(
     val approvedBy: String?,
     val paidAt: String?,
     val voidedAt: String?,
+    val voidedBy: String?,
     val voidReason: String?,
     val createdAt: String?,
     val updatedAt: String?,

--- a/src/main/kotlin/com/froilan/synectix/dto/CustomerDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/CustomerDtos.kt
@@ -1,0 +1,42 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+data class CreateCustomerRequest(
+    @field:NotBlank(message = "Customer name is required")
+    val name: String,
+    val contactName: String? = null,
+    @field:Email(message = "Invalid email format")
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    @field:Min(value = 0, message = "Payment term days must be zero or positive")
+    val paymentTermDays: Int = 30,
+    val defaultRevenueAccountId: String? = null,
+)
+
+data class UpdateCustomerRequest(
+    val name: String? = null,
+    val contactName: String? = null,
+    @field:Email(message = "Invalid email format")
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    @field:Min(value = 0, message = "Payment term days must be zero or positive")
+    val paymentTermDays: Int? = null,
+    val defaultRevenueAccountId: String? = null,
+)
+
+data class CustomerResponse(
+    val id: String,
+    val name: String,
+    val contactName: String?,
+    val contactEmail: String?,
+    val contactPhone: String?,
+    val paymentTermDays: Int,
+    val defaultRevenueAccountId: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/dto/InvoiceDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InvoiceDtos.kt
@@ -67,6 +67,7 @@ data class InvoiceResponse(
     val approvedBy: String?,
     val paidAt: String?,
     val voidedAt: String?,
+    val voidedBy: String?,
     val voidReason: String?,
     val createdAt: String?,
     val updatedAt: String?,

--- a/src/main/kotlin/com/froilan/synectix/dto/InvoiceDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InvoiceDtos.kt
@@ -1,0 +1,108 @@
+package com.froilan.synectix.dto
+
+import com.froilan.synectix.model.PaymentMethod
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class InvoiceLineRequest(
+    @field:NotBlank(message = "Account ID is required")
+    val accountId: String,
+    @field:Positive(message = "Amount must be positive")
+    val amount: BigDecimal,
+    val description: String? = null,
+)
+
+data class CreateInvoiceRequest(
+    @field:NotBlank(message = "Customer ID is required")
+    val customerId: String,
+    val date: LocalDate,
+    val dueDate: LocalDate,
+    val referenceNumber: String? = null,
+    @field:NotEmpty(message = "At least one line item is required")
+    @field:Valid
+    val lines: List<InvoiceLineRequest>,
+)
+
+data class VoidInvoiceRequest(
+    @field:NotBlank(message = "Void reason is required")
+    val reason: String,
+)
+
+data class RecordReceiptRequest(
+    val receiptDate: LocalDate,
+    @field:Positive(message = "Receipt amount must be positive")
+    val amount: BigDecimal,
+    val paymentMethod: PaymentMethod,
+    val referenceNumber: String? = null,
+)
+
+data class InvoiceLineResponse(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val amount: BigDecimal,
+    val description: String?,
+)
+
+data class InvoiceResponse(
+    val id: String,
+    val invoiceNumber: String,
+    val customerId: String,
+    val customerName: String,
+    val date: String,
+    val dueDate: String,
+    val referenceNumber: String?,
+    val organizationId: String,
+    val status: String,
+    val lines: List<InvoiceLineResponse>,
+    val totalAmount: BigDecimal,
+    val amountReceived: BigDecimal,
+    val journalEntryId: String?,
+    val createdBy: String,
+    val approvedAt: String?,
+    val approvedBy: String?,
+    val paidAt: String?,
+    val voidedAt: String?,
+    val voidReason: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class InvoiceSummaryResponse(
+    val id: String,
+    val invoiceNumber: String,
+    val customerName: String,
+    val date: String,
+    val dueDate: String,
+    val status: String,
+    val totalAmount: BigDecimal,
+    val amountReceived: BigDecimal,
+)
+
+data class InvoiceReceiptResponse(
+    val id: String,
+    val invoiceId: String,
+    val receiptDate: String,
+    val amount: BigDecimal,
+    val paymentMethod: String,
+    val referenceNumber: String?,
+    val journalEntryId: String?,
+    val createdBy: String,
+    val createdAt: String?,
+)
+
+data class CustomerAgingResponse(
+    val customerId: String,
+    val customerName: String,
+    val aging: AgingBucket,
+)
+
+data class ArAgingReportResponse(
+    val asOfDate: String,
+    val customers: List<CustomerAgingResponse>,
+    val totals: AgingBucket,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Bill.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Bill.kt
@@ -64,6 +64,7 @@ data class Bill(
     val approvedBy: String? = null,
     val paidAt: LocalDateTime? = null,
     val voidedAt: LocalDateTime? = null,
+    val voidedBy: String? = null,
     val voidReason: String? = null,
     @CreatedDate
     var createdAt: LocalDateTime? = null,

--- a/src/main/kotlin/com/froilan/synectix/model/Customer.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Customer.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "customers")
+@CompoundIndex(
+    name = "unique_name_per_org",
+    def = "{'organizationId': 1, 'name': 1}",
+    unique = true,
+)
+data class Customer(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val contactName: String? = null,
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    val paymentTermDays: Int = 30,
+    val defaultRevenueAccountId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Invoice.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Invoice.kt
@@ -56,6 +56,7 @@ data class Invoice(
     val approvedBy: String? = null,
     val paidAt: LocalDateTime? = null,
     val voidedAt: LocalDateTime? = null,
+    val voidedBy: String? = null,
     val voidReason: String? = null,
     @CreatedDate
     var createdAt: LocalDateTime? = null,

--- a/src/main/kotlin/com/froilan/synectix/model/Invoice.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Invoice.kt
@@ -1,0 +1,64 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class InvoiceStatus {
+    DRAFT,
+    APPROVED,
+    PARTIALLY_PAID,
+    PAID,
+    VOID,
+}
+
+data class InvoiceLine(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val amount: BigDecimal,
+    val description: String? = null,
+)
+
+@Document(collection = "invoices")
+@CompoundIndex(
+    name = "unique_invoice_number_per_org",
+    def = "{'organizationId': 1, 'invoiceNumber': 1}",
+    unique = true,
+)
+@CompoundIndex(name = "org_status", def = "{'organizationId': 1, 'status': 1}")
+@CompoundIndex(name = "org_customer", def = "{'organizationId': 1, 'customerId': 1}")
+data class Invoice(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val invoiceNumber: String,
+    val customerId: String,
+    val customerName: String,
+    val date: LocalDate,
+    val dueDate: LocalDate,
+    val referenceNumber: String? = null,
+    @Indexed
+    val organizationId: String,
+    val status: InvoiceStatus = InvoiceStatus.DRAFT,
+    val lines: List<InvoiceLine>,
+    val totalAmount: BigDecimal,
+    val amountReceived: BigDecimal = BigDecimal.ZERO,
+    val journalEntryId: String? = null,
+    val createdBy: String,
+    val approvedAt: LocalDateTime? = null,
+    val approvedBy: String? = null,
+    val paidAt: LocalDateTime? = null,
+    val voidedAt: LocalDateTime? = null,
+    val voidReason: String? = null,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/InvoiceReceipt.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/InvoiceReceipt.kt
@@ -1,0 +1,33 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "invoice_receipts")
+@CompoundIndex(
+    name = "org_invoice_receipt",
+    def = "{'organizationId': 1, 'invoiceId': 1}",
+)
+data class InvoiceReceipt(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    @Indexed
+    val invoiceId: String,
+    val receiptDate: LocalDate,
+    val amount: BigDecimal,
+    val paymentMethod: PaymentMethod,
+    val referenceNumber: String? = null,
+    val journalEntryId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val createdBy: String,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/CustomerRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/CustomerRepository.kt
@@ -1,0 +1,13 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Customer
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CustomerRepository : MongoRepository<Customer, String> {
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Customer>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/InvoiceReceiptRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvoiceReceiptRepository.kt
@@ -1,0 +1,15 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.InvoiceReceipt
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface InvoiceReceiptRepository : MongoRepository<InvoiceReceipt, String> {
+    fun findByInvoiceIdAndOrganizationId(
+        invoiceId: String,
+        organizationId: String,
+    ): List<InvoiceReceipt>
+
+    fun findByOrganizationId(organizationId: String): List<InvoiceReceipt>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/InvoiceRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvoiceRepository.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Invoice
+import com.froilan.synectix.model.InvoiceStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface InvoiceRepository : MongoRepository<Invoice, String> {
+    fun findByOrganizationId(organizationId: String): List<Invoice>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: InvoiceStatus,
+    ): List<Invoice>
+
+    fun findByOrganizationIdAndCustomerId(
+        organizationId: String,
+        customerId: String,
+    ): List<Invoice>
+
+    fun findByOrganizationIdAndStatusAndCustomerId(
+        organizationId: String,
+        status: InvoiceStatus,
+        customerId: String,
+    ): List<Invoice>
+
+    fun findByOrganizationIdAndStatusIn(
+        organizationId: String,
+        statuses: List<InvoiceStatus>,
+    ): List<Invoice>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -39,6 +39,12 @@ object Permissions {
     const val AP_PAY = "ap:pay"
     const val AP_VOID = "ap:void"
 
+    const val AR_CREATE = "ar:create"
+    const val AR_READ = "ar:read"
+    const val AR_APPROVE = "ar:approve"
+    const val AR_RECEIVE = "ar:receive"
+    const val AR_VOID = "ar:void"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -69,5 +75,10 @@ object Permissions {
             AP_APPROVE,
             AP_PAY,
             AP_VOID,
+            AR_CREATE,
+            AR_READ,
+            AR_APPROVE,
+            AR_RECEIVE,
+            AR_VOID,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -209,6 +209,7 @@ class BillService(
                 bill.copy(
                     status = BillStatus.VOID,
                     voidedAt = now,
+                    voidedBy = voidedBy,
                     voidReason = reason,
                 ),
             )
@@ -229,6 +230,7 @@ class BillService(
             bill.copy(
                 status = BillStatus.VOID,
                 voidedAt = now,
+                voidedBy = voidedBy,
                 voidReason = reason,
             ),
         )

--- a/src/main/kotlin/com/froilan/synectix/service/CustomerService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/CustomerService.kt
@@ -52,8 +52,7 @@ class CustomerService(
         return customer
     }
 
-    fun listCustomers(organizationId: String): List<Customer> =
-        customerRepository.findByOrganizationIdAndIsActive(organizationId, true)
+    fun listCustomers(organizationId: String): List<Customer> = customerRepository.findByOrganizationIdAndIsActive(organizationId, true)
 
     @Transactional
     fun updateCustomer(

--- a/src/main/kotlin/com/froilan/synectix/service/CustomerService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/CustomerService.kt
@@ -1,0 +1,107 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateCustomerRequest
+import com.froilan.synectix.dto.UpdateCustomerRequest
+import com.froilan.synectix.model.Customer
+import com.froilan.synectix.repository.CustomerRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CustomerService(
+    private val customerRepository: CustomerRepository,
+) {
+    @Transactional
+    fun createCustomer(
+        request: CreateCustomerRequest,
+        organizationId: String,
+    ): Customer {
+        val customer =
+            Customer(
+                name = request.name,
+                contactName = request.contactName,
+                contactEmail = request.contactEmail,
+                contactPhone = request.contactPhone,
+                paymentTermDays = request.paymentTermDays,
+                defaultRevenueAccountId = request.defaultRevenueAccountId,
+                organizationId = organizationId,
+            )
+
+        return try {
+            customerRepository.save(customer)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Customer '${request.name}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    fun getCustomer(
+        customerId: String,
+        organizationId: String,
+    ): Customer {
+        val customer =
+            customerRepository.findById(customerId).orElseThrow {
+                IllegalArgumentException("Customer not found")
+            }
+        if (customer.organizationId != organizationId) {
+            throw IllegalArgumentException("Customer not found")
+        }
+        return customer
+    }
+
+    fun listCustomers(organizationId: String): List<Customer> =
+        customerRepository.findByOrganizationIdAndIsActive(organizationId, true)
+
+    @Transactional
+    fun updateCustomer(
+        customerId: String,
+        request: UpdateCustomerRequest,
+        organizationId: String,
+    ): Customer {
+        val customer = getCustomer(customerId, organizationId)
+
+        if (!customer.isActive) {
+            throw IllegalArgumentException("Cannot update inactive customer")
+        }
+
+        if (request.name != null && request.name.isBlank()) {
+            throw IllegalArgumentException("Customer name cannot be blank")
+        }
+
+        val updated =
+            customer.copy(
+                name = request.name ?: customer.name,
+                contactName = request.contactName ?: customer.contactName,
+                contactEmail = request.contactEmail ?: customer.contactEmail,
+                contactPhone = request.contactPhone ?: customer.contactPhone,
+                paymentTermDays = request.paymentTermDays ?: customer.paymentTermDays,
+                defaultRevenueAccountId = request.defaultRevenueAccountId ?: customer.defaultRevenueAccountId,
+            )
+
+        return try {
+            customerRepository.save(updated)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Customer '${updated.name}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    @Transactional
+    fun deleteCustomer(
+        customerId: String,
+        organizationId: String,
+    ): Customer {
+        val customer = getCustomer(customerId, organizationId)
+
+        if (!customer.isActive) {
+            throw IllegalArgumentException("Customer is already inactive")
+        }
+
+        return customerRepository.save(customer.copy(isActive = false))
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
@@ -210,6 +210,7 @@ class InvoiceService(
                 invoice.copy(
                     status = InvoiceStatus.VOID,
                     voidedAt = now,
+                    voidedBy = voidedBy,
                     voidReason = reason,
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
@@ -1,0 +1,452 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AgingBucket
+import com.froilan.synectix.dto.ArAgingReportResponse
+import com.froilan.synectix.dto.CreateInvoiceRequest
+import com.froilan.synectix.dto.CustomerAgingResponse
+import com.froilan.synectix.dto.RecordReceiptRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.Invoice
+import com.froilan.synectix.model.InvoiceLine
+import com.froilan.synectix.model.InvoiceReceipt
+import com.froilan.synectix.model.InvoiceStatus
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.InvoiceReceiptRepository
+import com.froilan.synectix.repository.InvoiceRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+@Service
+class InvoiceService(
+    private val invoiceRepository: InvoiceRepository,
+    private val invoiceReceiptRepository: InvoiceReceiptRepository,
+    private val accountRepository: AccountRepository,
+    private val customerService: CustomerService,
+    private val journalEntryService: JournalEntryService,
+) {
+    @Transactional
+    fun createInvoice(
+        request: CreateInvoiceRequest,
+        organizationId: String,
+        createdBy: String,
+    ): Invoice {
+        val customer = customerService.getCustomer(request.customerId, organizationId)
+        if (!customer.isActive) {
+            throw IllegalArgumentException("Cannot create invoice for inactive customer")
+        }
+
+        if (request.date.isAfter(request.dueDate)) {
+            throw IllegalArgumentException("Due date must be on or after invoice date")
+        }
+
+        if (request.lines.isEmpty()) {
+            throw IllegalArgumentException("At least one line item is required")
+        }
+
+        request.lines.forEach { line ->
+            if (line.amount <= BigDecimal.ZERO) {
+                throw IllegalArgumentException("Line item amounts must be positive")
+            }
+        }
+
+        val accountIds = request.lines.map { it.accountId }.distinct()
+        val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
+
+        val missingAccounts = accountIds.filter { it !in accounts }
+        if (missingAccounts.isNotEmpty()) {
+            throw IllegalArgumentException("Accounts not found: ${missingAccounts.joinToString(", ")}")
+        }
+
+        accounts.values.forEach { account ->
+            if (account.organizationId != organizationId) {
+                throw IllegalArgumentException("Account '${account.id}' not found")
+            }
+            if (!account.isActive) {
+                throw IllegalArgumentException("Account '${account.code}' is inactive")
+            }
+        }
+
+        val lines =
+            request.lines.map { lineReq ->
+                val account = accounts.getValue(lineReq.accountId)
+                InvoiceLine(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    amount = lineReq.amount,
+                    description = lineReq.description,
+                )
+            }
+
+        val totalAmount = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.amount) }
+
+        return saveInvoiceWithRetry(organizationId) { invoiceNumber ->
+            Invoice(
+                invoiceNumber = invoiceNumber,
+                customerId = customer.id,
+                customerName = customer.name,
+                date = request.date,
+                dueDate = request.dueDate,
+                referenceNumber = request.referenceNumber,
+                organizationId = organizationId,
+                lines = lines,
+                totalAmount = totalAmount,
+                createdBy = createdBy,
+            )
+        }
+    }
+
+    fun getInvoice(
+        invoiceId: String,
+        organizationId: String,
+    ): Invoice {
+        val invoice =
+            invoiceRepository.findById(invoiceId).orElseThrow {
+                IllegalArgumentException("Invoice not found")
+            }
+        if (invoice.organizationId != organizationId) {
+            throw IllegalArgumentException("Invoice not found")
+        }
+        return invoice
+    }
+
+    fun listInvoices(
+        organizationId: String,
+        status: InvoiceStatus? = null,
+        customerId: String? = null,
+    ): List<Invoice> =
+        when {
+            status != null && customerId != null ->
+                invoiceRepository.findByOrganizationIdAndStatusAndCustomerId(organizationId, status, customerId)
+            status != null ->
+                invoiceRepository.findByOrganizationIdAndStatus(organizationId, status)
+            customerId != null ->
+                invoiceRepository.findByOrganizationIdAndCustomerId(organizationId, customerId)
+            else ->
+                invoiceRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun approveInvoice(
+        invoiceId: String,
+        organizationId: String,
+        approvedBy: String,
+    ): Invoice {
+        val invoice = getInvoice(invoiceId, organizationId)
+
+        if (invoice.status != InvoiceStatus.DRAFT) {
+            throw IllegalArgumentException("Only draft invoices can be approved")
+        }
+
+        val arAccount = getArAccount(organizationId)
+
+        val journalLines =
+            invoice.lines.map { line ->
+                JournalEntryLine(
+                    accountId = line.accountId,
+                    accountCode = line.accountCode,
+                    accountName = line.accountName,
+                    debit = BigDecimal.ZERO,
+                    credit = line.amount,
+                    description = line.description,
+                )
+            } +
+                JournalEntryLine(
+                    accountId = arAccount.id,
+                    accountCode = arAccount.code,
+                    accountName = arAccount.name,
+                    debit = invoice.totalAmount,
+                    credit = BigDecimal.ZERO,
+                    description = "AR - ${invoice.customerName} - ${invoice.invoiceNumber}",
+                )
+
+        val journalEntry =
+            journalEntryService.createSystemEntry(
+                date = invoice.date,
+                description = "Invoice ${invoice.invoiceNumber} - ${invoice.customerName}",
+                organizationId = organizationId,
+                lines = journalLines,
+                sourceReference = "INVOICE-APPROVE-${invoice.id}",
+                createdBy = approvedBy,
+            )
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        return invoiceRepository.save(
+            invoice.copy(
+                status = InvoiceStatus.APPROVED,
+                journalEntryId = journalEntry.id,
+                approvedAt = now,
+                approvedBy = approvedBy,
+            ),
+        )
+    }
+
+    @Transactional
+    fun voidInvoice(
+        invoiceId: String,
+        organizationId: String,
+        reason: String,
+        voidedBy: String,
+    ): Invoice {
+        val invoice = getInvoice(invoiceId, organizationId)
+
+        if (invoice.status == InvoiceStatus.VOID) {
+            throw IllegalArgumentException("Invoice is already voided")
+        }
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+
+        // Draft voids skip fiscal validation — no GL entries are posted
+        if (invoice.status == InvoiceStatus.DRAFT) {
+            return invoiceRepository.save(
+                invoice.copy(
+                    status = InvoiceStatus.VOID,
+                    voidedAt = now,
+                    voidReason = reason,
+                ),
+            )
+        }
+
+        if (invoice.amountReceived.compareTo(BigDecimal.ZERO) != 0) {
+            throw IllegalArgumentException("Cannot void an invoice with recorded receipts")
+        }
+
+        if (invoice.journalEntryId != null) {
+            journalEntryService.voidJournalEntry(
+                invoice.journalEntryId,
+                organizationId,
+                reason,
+            )
+        }
+
+        return invoiceRepository.save(
+            invoice.copy(
+                status = InvoiceStatus.VOID,
+                voidedAt = now,
+                voidReason = reason,
+            ),
+        )
+    }
+
+    @Transactional
+    fun recordReceipt(
+        invoiceId: String,
+        request: RecordReceiptRequest,
+        organizationId: String,
+        createdBy: String,
+    ): InvoiceReceipt {
+        val invoice = getInvoice(invoiceId, organizationId)
+
+        if (invoice.status != InvoiceStatus.APPROVED && invoice.status != InvoiceStatus.PARTIALLY_PAID) {
+            throw IllegalArgumentException("Invoice must be approved or partially paid to record receipt")
+        }
+
+        if (request.amount <= BigDecimal.ZERO) {
+            throw IllegalArgumentException("Receipt amount must be positive")
+        }
+
+        val remaining = invoice.totalAmount.subtract(invoice.amountReceived)
+        if (request.amount.compareTo(remaining) > 0) {
+            throw IllegalArgumentException(
+                "Receipt amount exceeds remaining balance of $remaining",
+            )
+        }
+
+        val arAccount = getArAccount(organizationId)
+        val cashAccount = getCashAccount(organizationId)
+
+        val receiptId = UUID.randomUUID().toString()
+
+        val journalEntry =
+            journalEntryService.createSystemEntry(
+                date = request.receiptDate,
+                description = "Receipt for invoice ${invoice.invoiceNumber} - ${invoice.customerName}",
+                organizationId = organizationId,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = cashAccount.id,
+                            accountCode = cashAccount.code,
+                            accountName = cashAccount.name,
+                            debit = request.amount,
+                            credit = BigDecimal.ZERO,
+                            description = "Receipt - ${invoice.customerName}",
+                        ),
+                        JournalEntryLine(
+                            accountId = arAccount.id,
+                            accountCode = arAccount.code,
+                            accountName = arAccount.name,
+                            debit = BigDecimal.ZERO,
+                            credit = request.amount,
+                            description = "Receipt - ${invoice.customerName}",
+                        ),
+                    ),
+                sourceReference = "INVOICE-RECEIPT-$receiptId",
+                createdBy = createdBy,
+            )
+
+        val receipt =
+            invoiceReceiptRepository.save(
+                InvoiceReceipt(
+                    id = receiptId,
+                    invoiceId = invoice.id,
+                    receiptDate = request.receiptDate,
+                    amount = request.amount,
+                    paymentMethod = request.paymentMethod,
+                    referenceNumber = request.referenceNumber,
+                    journalEntryId = journalEntry.id,
+                    organizationId = organizationId,
+                    createdBy = createdBy,
+                ),
+            )
+
+        val newAmountReceived = invoice.amountReceived.add(request.amount)
+        val fullyPaid = newAmountReceived.compareTo(invoice.totalAmount) >= 0
+        val newStatus = if (fullyPaid) InvoiceStatus.PAID else InvoiceStatus.PARTIALLY_PAID
+
+        invoiceRepository.save(
+            invoice.copy(
+                amountReceived = newAmountReceived,
+                status = newStatus,
+                paidAt = if (fullyPaid) LocalDateTime.now(ZoneOffset.UTC) else null,
+            ),
+        )
+
+        return receipt
+    }
+
+    fun getReceipts(
+        invoiceId: String,
+        organizationId: String,
+    ): List<InvoiceReceipt> {
+        getInvoice(invoiceId, organizationId)
+        return invoiceReceiptRepository.findByInvoiceIdAndOrganizationId(invoiceId, organizationId)
+    }
+
+    fun getAgingReport(
+        organizationId: String,
+        asOfDate: LocalDate = LocalDate.now(ZoneOffset.UTC),
+    ): ArAgingReportResponse {
+        val outstandingStatuses =
+            listOf(InvoiceStatus.APPROVED, InvoiceStatus.PARTIALLY_PAID)
+        val invoices = invoiceRepository.findByOrganizationIdAndStatusIn(organizationId, outstandingStatuses)
+
+        val customerInvoices = invoices.groupBy { it.customerId }
+
+        val customerAgingList =
+            customerInvoices.map { (_, invoiceList) ->
+                val customerName = invoiceList.first().customerName
+                val customerId = invoiceList.first().customerId
+                val bucket = calculateAgingBucket(invoiceList, asOfDate)
+                CustomerAgingResponse(
+                    customerId = customerId,
+                    customerName = customerName,
+                    aging = bucket,
+                )
+            }
+
+        val totals =
+            AgingBucket(
+                current = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.current) },
+                days1to30 = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.days1to30) },
+                days31to60 = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.days31to60) },
+                days61to90 = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.days61to90) },
+                days90plus = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.days90plus) },
+                total = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.total) },
+            )
+
+        return ArAgingReportResponse(
+            asOfDate = asOfDate.toString(),
+            customers = customerAgingList,
+            totals = totals,
+        )
+    }
+
+    private fun calculateAgingBucket(
+        invoices: List<Invoice>,
+        asOfDate: LocalDate,
+    ): AgingBucket {
+        var current = BigDecimal.ZERO
+        var days1to30 = BigDecimal.ZERO
+        var days31to60 = BigDecimal.ZERO
+        var days61to90 = BigDecimal.ZERO
+        var days90plus = BigDecimal.ZERO
+
+        invoices.forEach { invoice ->
+            val outstanding = invoice.totalAmount.subtract(invoice.amountReceived)
+            val daysOverdue = ChronoUnit.DAYS.between(invoice.dueDate, asOfDate)
+
+            when {
+                daysOverdue <= 0 -> current = current.add(outstanding)
+                daysOverdue <= 30 -> days1to30 = days1to30.add(outstanding)
+                daysOverdue <= 60 -> days31to60 = days31to60.add(outstanding)
+                daysOverdue <= 90 -> days61to90 = days61to90.add(outstanding)
+                else -> days90plus = days90plus.add(outstanding)
+            }
+        }
+
+        val total =
+            current
+                .add(days1to30)
+                .add(days31to60)
+                .add(days61to90)
+                .add(days90plus)
+        return AgingBucket(
+            current = current,
+            days1to30 = days1to30,
+            days31to60 = days31to60,
+            days61to90 = days61to90,
+            days90plus = days90plus,
+            total = total,
+        )
+    }
+
+    private fun getArAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "1100").orElseThrow {
+                IllegalStateException("Accounts Receivable account (1100) not found")
+            }
+        if (!account.isActive) {
+            throw IllegalArgumentException("Accounts Receivable account (1100) is inactive")
+        }
+        return account
+    }
+
+    private fun getCashAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "1000").orElseThrow {
+                IllegalStateException("Cash account (1000) not found")
+            }
+        if (!account.isActive) {
+            throw IllegalArgumentException("Cash account (1000) is inactive")
+        }
+        return account
+    }
+
+    private fun saveInvoiceWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildInvoice: (String) -> Invoice,
+    ): Invoice {
+        repeat(maxRetries) {
+            val count = invoiceRepository.countByOrganizationId(organizationId)
+            val invoiceNumber = "INV-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return invoiceRepository.save(buildInvoice(invoiceNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique invoice number: $invoiceNumber", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique invoice number")
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -81,6 +81,11 @@ class RoleSeederTest {
                         Permissions.AP_APPROVE,
                         Permissions.AP_PAY,
                         Permissions.AP_VOID,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
+                        Permissions.AR_APPROVE,
+                        Permissions.AR_RECEIVE,
+                        Permissions.AR_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -154,6 +159,11 @@ class RoleSeederTest {
                         Permissions.AP_APPROVE,
                         Permissions.AP_PAY,
                         Permissions.AP_VOID,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
+                        Permissions.AR_APPROVE,
+                        Permissions.AR_RECEIVE,
+                        Permissions.AR_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -254,6 +264,11 @@ class RoleSeederTest {
                         Permissions.AP_APPROVE,
                         Permissions.AP_PAY,
                         Permissions.AP_VOID,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
+                        Permissions.AR_APPROVE,
+                        Permissions.AR_RECEIVE,
+                        Permissions.AR_VOID,
                     ),
             )
         val admin =
@@ -285,6 +300,10 @@ class RoleSeederTest {
                         Permissions.AP_READ,
                         Permissions.AP_APPROVE,
                         Permissions.AP_PAY,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
+                        Permissions.AR_APPROVE,
+                        Permissions.AR_RECEIVE,
                     ),
             )
         val member =
@@ -305,6 +324,8 @@ class RoleSeederTest {
                         Permissions.FISCAL_READ,
                         Permissions.AP_CREATE,
                         Permissions.AP_READ,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
                     ),
             )
         val viewer =
@@ -320,6 +341,7 @@ class RoleSeederTest {
                         Permissions.JOURNAL_READ,
                         Permissions.FISCAL_READ,
                         Permissions.AP_READ,
+                        Permissions.AR_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/froilan/synectix/service/CustomerServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/CustomerServiceTest.kt
@@ -1,0 +1,159 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateCustomerRequest
+import com.froilan.synectix.dto.UpdateCustomerRequest
+import com.froilan.synectix.model.Customer
+import com.froilan.synectix.repository.CustomerRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.util.Optional
+
+class CustomerServiceTest {
+    private lateinit var customerService: CustomerService
+    private lateinit var customerRepository: CustomerRepository
+
+    private val orgId = "org-123"
+
+    @BeforeEach
+    fun setup() {
+        customerRepository = mock(CustomerRepository::class.java)
+        customerService = CustomerService(customerRepository)
+    }
+
+    @Test
+    fun `create should save customer with correct fields`() {
+        `when`(customerRepository.save(any<Customer>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateCustomerRequest(
+                name = "BigCorp",
+                contactName = "Jane Doe",
+                contactEmail = "jane@bigcorp.com",
+                paymentTermDays = 45,
+            )
+
+        val result = customerService.createCustomer(request, orgId)
+
+        assertThat(result.name).isEqualTo("BigCorp")
+        assertThat(result.contactName).isEqualTo("Jane Doe")
+        assertThat(result.contactEmail).isEqualTo("jane@bigcorp.com")
+        assertThat(result.paymentTermDays).isEqualTo(45)
+        assertThat(result.organizationId).isEqualTo(orgId)
+        assertThat(result.isActive).isTrue()
+    }
+
+    @Test
+    fun `get should return customer for correct org`() {
+        val customer = createCustomer()
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val result = customerService.getCustomer("c-1", orgId)
+        assertThat(result.id).isEqualTo("c-1")
+    }
+
+    @Test
+    fun `get should throw when customer belongs to different org`() {
+        val customer = createCustomer(orgId = "other-org")
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                customerService.getCustomer("c-1", orgId)
+            }
+        assertThat(exception.message).contains("Customer not found")
+    }
+
+    @Test
+    fun `list should return active customers`() {
+        val customers = listOf(createCustomer(), createCustomer(id = "c-2", name = "SmallCo"))
+        `when`(customerRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(customers)
+
+        val result = customerService.listCustomers(orgId)
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun `update should apply partial changes`() {
+        val customer = createCustomer()
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+        `when`(customerRepository.save(any<Customer>())).thenAnswer { it.arguments[0] }
+
+        val request = UpdateCustomerRequest(name = "Updated Corp")
+        val result = customerService.updateCustomer("c-1", request, orgId)
+
+        assertThat(result.name).isEqualTo("Updated Corp")
+        assertThat(result.contactName).isEqualTo("Jane Doe")
+    }
+
+    @Test
+    fun `update should reject inactive customer`() {
+        val customer = createCustomer(isActive = false)
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                customerService.updateCustomer("c-1", UpdateCustomerRequest(name = "New"), orgId)
+            }
+        assertThat(exception.message).contains("inactive")
+    }
+
+    @Test
+    fun `update should reject blank name`() {
+        val customer = createCustomer()
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                customerService.updateCustomer("c-1", UpdateCustomerRequest(name = "  "), orgId)
+            }
+        assertThat(exception.message).contains("blank")
+    }
+
+    @Test
+    fun `delete should soft delete customer`() {
+        val customer = createCustomer()
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+        `when`(customerRepository.save(any<Customer>())).thenAnswer { it.arguments[0] }
+
+        val result = customerService.deleteCustomer("c-1", orgId)
+
+        assertThat(result.isActive).isFalse()
+        val captor = argumentCaptor<Customer>()
+        verify(customerRepository).save(captor.capture())
+        assertThat(captor.firstValue.isActive).isFalse()
+    }
+
+    @Test
+    fun `delete should reject already inactive customer`() {
+        val customer = createCustomer(isActive = false)
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                customerService.deleteCustomer("c-1", orgId)
+            }
+        assertThat(exception.message).contains("already inactive")
+    }
+
+    private fun createCustomer(
+        id: String = "c-1",
+        name: String = "BigCorp",
+        orgId: String = this.orgId,
+        isActive: Boolean = true,
+    ) = Customer(
+        id = id,
+        name = name,
+        contactName = "Jane Doe",
+        contactEmail = "jane@bigcorp.com",
+        paymentTermDays = 30,
+        organizationId = orgId,
+        isActive = isActive,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvoiceServiceTest.kt
@@ -1,0 +1,416 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateInvoiceRequest
+import com.froilan.synectix.dto.InvoiceLineRequest
+import com.froilan.synectix.dto.RecordReceiptRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.Customer
+import com.froilan.synectix.model.Invoice
+import com.froilan.synectix.model.InvoiceLine
+import com.froilan.synectix.model.InvoiceReceipt
+import com.froilan.synectix.model.InvoiceStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.PaymentMethod
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.InvoiceReceiptRepository
+import com.froilan.synectix.repository.InvoiceRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class InvoiceServiceTest {
+    private lateinit var invoiceService: InvoiceService
+    private lateinit var invoiceRepository: InvoiceRepository
+    private lateinit var invoiceReceiptRepository: InvoiceReceiptRepository
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var customerService: CustomerService
+    private lateinit var journalEntryService: JournalEntryService
+
+    private val orgId = "org-123"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        invoiceRepository = mock(InvoiceRepository::class.java)
+        invoiceReceiptRepository = mock(InvoiceReceiptRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        customerService = mock(CustomerService::class.java)
+        journalEntryService = mock(JournalEntryService::class.java)
+        invoiceService =
+            InvoiceService(
+                invoiceRepository = invoiceRepository,
+                invoiceReceiptRepository = invoiceReceiptRepository,
+                accountRepository = accountRepository,
+                customerService = customerService,
+                journalEntryService = journalEntryService,
+            )
+    }
+
+    @Test
+    fun `create should save invoice as DRAFT with correct total`() {
+        val customer = createCustomer()
+        val revenueAccount = createAccount("acc-1", "4100", "Service Revenue", AccountType.REVENUE)
+
+        `when`(customerService.getCustomer("c-1", orgId)).thenReturn(customer)
+        `when`(accountRepository.findAllById(listOf("acc-1")))
+            .thenReturn(listOf(revenueAccount))
+        `when`(invoiceRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateInvoiceRequest(
+                customerId = "c-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                lines =
+                    listOf(
+                        InvoiceLineRequest(accountId = "acc-1", amount = BigDecimal("2000.00")),
+                    ),
+            )
+
+        val result = invoiceService.createInvoice(request, orgId, userId)
+
+        assertThat(result.status).isEqualTo(InvoiceStatus.DRAFT)
+        assertThat(result.customerName).isEqualTo("BigCorp")
+        assertThat(result.totalAmount).isEqualByComparingTo(BigDecimal("2000.00"))
+        assertThat(result.amountReceived).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.invoiceNumber).isEqualTo("INV-0001")
+        assertThat(result.lines).hasSize(1)
+        assertThat(result.lines[0].accountCode).isEqualTo("4100")
+    }
+
+    @Test
+    fun `create should reject inactive customer`() {
+        val customer = createCustomer(isActive = false)
+        `when`(customerService.getCustomer("c-1", orgId)).thenReturn(customer)
+
+        val request =
+            CreateInvoiceRequest(
+                customerId = "c-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                lines =
+                    listOf(
+                        InvoiceLineRequest(accountId = "acc-1", amount = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.createInvoice(request, orgId, userId)
+            }
+        assertThat(exception.message).contains("inactive customer")
+    }
+
+    @Test
+    fun `approve should post journal entry and update status`() {
+        val invoice = createInvoice()
+        val arAccount = createAccount("acc-ar", "1100", "Accounts Receivable", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1100"))
+            .thenReturn(Optional.of(arAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val result = invoiceService.approveInvoice("inv-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(InvoiceStatus.APPROVED)
+        assertThat(result.journalEntryId).isEqualTo("je-1")
+        assertThat(result.approvedBy).isEqualTo(userId)
+
+        verify(journalEntryService).createSystemEntry(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `approve should reject non-draft invoice`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED)
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.approveInvoice("inv-1", orgId, userId)
+            }
+        assertThat(exception.message).contains("Only draft")
+    }
+
+    @Test
+    fun `void should void journal entry for approved invoice`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED, journalEntryId = "je-1")
+        val voidedEntry = createMockJournalEntry(status = JournalEntryStatus.VOIDED)
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(journalEntryService.voidJournalEntry("je-1", orgId, "Duplicate"))
+            .thenReturn(voidedEntry)
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val result = invoiceService.voidInvoice("inv-1", orgId, "Duplicate", userId)
+
+        assertThat(result.status).isEqualTo(InvoiceStatus.VOID)
+        assertThat(result.voidReason).isEqualTo("Duplicate")
+        verify(journalEntryService).voidJournalEntry("je-1", orgId, "Duplicate")
+    }
+
+    @Test
+    fun `void should allow voiding draft without journal entry`() {
+        val invoice = createInvoice(status = InvoiceStatus.DRAFT)
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val result = invoiceService.voidInvoice("inv-1", orgId, "Not needed", userId)
+
+        assertThat(result.status).isEqualTo(InvoiceStatus.VOID)
+    }
+
+    @Test
+    fun `void should reject invoice with receipts`() {
+        val invoice =
+            createInvoice(
+                status = InvoiceStatus.PARTIALLY_PAID,
+                amountReceived = BigDecimal("500.00"),
+            )
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.voidInvoice("inv-1", orgId, "Cancel", userId)
+            }
+        assertThat(exception.message).contains("recorded receipts")
+    }
+
+    @Test
+    fun `recordReceipt should create receipt and update invoice status`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED)
+        val arAccount = createAccount("acc-ar", "1100", "Accounts Receivable", AccountType.ASSET)
+        val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1100"))
+            .thenReturn(Optional.of(arAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
+            .thenReturn(Optional.of(cashAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(invoiceReceiptRepository.save(any<InvoiceReceipt>())).thenAnswer { it.arguments[0] }
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            RecordReceiptRequest(
+                receiptDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("1000.00"),
+                paymentMethod = PaymentMethod.BANK_TRANSFER,
+            )
+
+        val receipt = invoiceService.recordReceipt("inv-1", request, orgId, userId)
+
+        assertThat(receipt.amount).isEqualByComparingTo(BigDecimal("1000.00"))
+        assertThat(receipt.paymentMethod).isEqualTo(PaymentMethod.BANK_TRANSFER)
+
+        val invoiceCaptor = argumentCaptor<Invoice>()
+        verify(invoiceRepository).save(invoiceCaptor.capture())
+        assertThat(invoiceCaptor.firstValue.status).isEqualTo(InvoiceStatus.PARTIALLY_PAID)
+        assertThat(invoiceCaptor.firstValue.amountReceived).isEqualByComparingTo(BigDecimal("1000.00"))
+    }
+
+    @Test
+    fun `recordReceipt should mark invoice as PAID when fully paid`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED)
+        val arAccount = createAccount("acc-ar", "1100", "Accounts Receivable", AccountType.ASSET)
+        val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1100"))
+            .thenReturn(Optional.of(arAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
+            .thenReturn(Optional.of(cashAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(invoiceReceiptRepository.save(any<InvoiceReceipt>())).thenAnswer { it.arguments[0] }
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            RecordReceiptRequest(
+                receiptDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("2000.00"),
+                paymentMethod = PaymentMethod.CHECK,
+            )
+
+        invoiceService.recordReceipt("inv-1", request, orgId, userId)
+
+        val invoiceCaptor = argumentCaptor<Invoice>()
+        verify(invoiceRepository).save(invoiceCaptor.capture())
+        assertThat(invoiceCaptor.firstValue.status).isEqualTo(InvoiceStatus.PAID)
+        assertThat(invoiceCaptor.firstValue.paidAt).isNotNull()
+    }
+
+    @Test
+    fun `recordReceipt should reject overpayment`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED)
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+
+        val request =
+            RecordReceiptRequest(
+                receiptDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("9999.00"),
+                paymentMethod = PaymentMethod.CASH,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.recordReceipt("inv-1", request, orgId, userId)
+            }
+        assertThat(exception.message).contains("exceeds remaining balance")
+    }
+
+    @Test
+    fun `recordReceipt should reject draft invoice`() {
+        val invoice = createInvoice(status = InvoiceStatus.DRAFT)
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+
+        val request =
+            RecordReceiptRequest(
+                receiptDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("100.00"),
+                paymentMethod = PaymentMethod.CASH,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.recordReceipt("inv-1", request, orgId, userId)
+            }
+        assertThat(exception.message).contains("approved or partially paid")
+    }
+
+    @Test
+    fun `aging report should bucket invoices by overdue days`() {
+        val asOfDate = LocalDate.of(2026, 5, 1)
+        val invoices =
+            listOf(
+                createInvoice(
+                    id = "inv-1",
+                    customerId = "c-1",
+                    dueDate = LocalDate.of(2026, 5, 15),
+                    totalAmount = BigDecimal("500.00"),
+                    status = InvoiceStatus.APPROVED,
+                ),
+                createInvoice(
+                    id = "inv-2",
+                    customerId = "c-1",
+                    dueDate = LocalDate.of(2026, 4, 15),
+                    totalAmount = BigDecimal("800.00"),
+                    status = InvoiceStatus.APPROVED,
+                ),
+                createInvoice(
+                    id = "inv-3",
+                    customerId = "c-1",
+                    dueDate = LocalDate.of(2026, 2, 1),
+                    totalAmount = BigDecimal("1000.00"),
+                    status = InvoiceStatus.PARTIALLY_PAID,
+                    amountReceived = BigDecimal("200.00"),
+                ),
+            )
+
+        val outstandingStatuses = listOf(InvoiceStatus.APPROVED, InvoiceStatus.PARTIALLY_PAID)
+        `when`(invoiceRepository.findByOrganizationIdAndStatusIn(orgId, outstandingStatuses))
+            .thenReturn(invoices)
+
+        val report = invoiceService.getAgingReport(orgId, asOfDate)
+
+        assertThat(report.customers).hasSize(1)
+        val customerAging = report.customers[0]
+        assertThat(customerAging.customerName).isEqualTo("BigCorp")
+
+        // inv-1: due May 15, asOf May 1 -> not overdue -> current
+        assertThat(customerAging.aging.current).isEqualByComparingTo(BigDecimal("500.00"))
+        // inv-2: due Apr 15, asOf May 1 -> 16 days overdue -> 1-30 bucket
+        assertThat(customerAging.aging.days1to30).isEqualByComparingTo(BigDecimal("800.00"))
+        // inv-3: due Feb 1, asOf May 1 -> 89 days overdue -> 61-90 bucket, outstanding = 800
+        assertThat(customerAging.aging.days61to90).isEqualByComparingTo(BigDecimal("800.00"))
+
+        assertThat(report.totals.total).isEqualByComparingTo(BigDecimal("2100.00"))
+    }
+
+    private fun createCustomer(
+        id: String = "c-1",
+        isActive: Boolean = true,
+    ) = Customer(
+        id = id,
+        name = "BigCorp",
+        contactName = "Jane",
+        paymentTermDays = 30,
+        organizationId = orgId,
+        isActive = isActive,
+    )
+
+    private fun createAccount(
+        id: String,
+        code: String,
+        name: String,
+        type: AccountType,
+    ) = Account(
+        id = id,
+        code = code,
+        name = name,
+        type = type,
+        organizationId = orgId,
+    )
+
+    private fun createInvoice(
+        id: String = "inv-1",
+        customerId: String = "c-1",
+        status: InvoiceStatus = InvoiceStatus.DRAFT,
+        totalAmount: BigDecimal = BigDecimal("2000.00"),
+        amountReceived: BigDecimal = BigDecimal.ZERO,
+        dueDate: LocalDate = LocalDate.of(2026, 3, 31),
+        journalEntryId: String? = null,
+    ) = Invoice(
+        id = id,
+        invoiceNumber = "INV-0001",
+        customerId = customerId,
+        customerName = "BigCorp",
+        date = LocalDate.of(2026, 3, 1),
+        dueDate = dueDate,
+        organizationId = orgId,
+        status = status,
+        lines =
+            listOf(
+                InvoiceLine(
+                    accountId = "acc-1",
+                    accountCode = "4100",
+                    accountName = "Service Revenue",
+                    amount = totalAmount,
+                ),
+            ),
+        totalAmount = totalAmount,
+        amountReceived = amountReceived,
+        journalEntryId = journalEntryId,
+        createdBy = userId,
+    )
+
+    private fun createMockJournalEntry(status: JournalEntryStatus = JournalEntryStatus.POSTED) =
+        JournalEntry(
+            id = "je-1",
+            entryNumber = "JE-0001",
+            date = LocalDate.of(2026, 3, 1),
+            description = "Mock entry",
+            organizationId = orgId,
+            status = status,
+            lines = emptyList(),
+            createdBy = userId,
+        )
+}


### PR DESCRIPTION
## Summary
- Add customer management with CRUD and soft delete
- Implement invoice lifecycle: DRAFT → APPROVED → PARTIALLY_PAID → PAID → VOID
- Auto-post journal entries on invoice approval (debit AR, credit revenue) via `createSystemEntry`
- Void invoices via `JournalEntryService.voidJournalEntry` (marks original VOIDED + creates reversal)
- Record receipts with partial receipt support, auto-posting GL entries (debit Cash, credit AR)
- AR aging report with standard overdue buckets (Current, 1-30, 31-60, 61-90, 90+ days)
- Add ar:create, ar:read, ar:approve, ar:receive, ar:void permissions with role seeding
- Uses `AuthenticationContext` bean, `createSystemEntry` for centralized GL posting, fiscal period validation

## API Endpoints

### Customers (`/finance/ar/customers`)
- `POST` — create customer
- `GET` — list active customers
- `GET /{id}` — get customer
- `PUT /{id}` — update customer
- `DELETE /{id}` — soft delete

### Invoices (`/finance/ar/invoices`)
- `POST` — create invoice (DRAFT)
- `GET` — list invoices (filter by status, customerId, or both)
- `GET /{id}` — get invoice with lines
- `POST /{id}/approve` — approve and post to GL
- `POST /{id}/void` — void with journal entry reversal
- `POST /{id}/receipts` — record receipt
- `GET /{id}/receipts` — list receipts
- `GET /aging` — AR aging report

## Test plan
- [x] 9 CustomerServiceTest cases (CRUD, org scoping, blank name, soft delete)
- [x] 13 InvoiceServiceTest cases (create, approve with GL, void draft/approved, receipts, overpayment, aging report)
- [x] RoleSeederTest updated with AR permissions
- [x] ktlintCheck passes
- [x] 272/273 tests pass (1 pre-existing MongoDB context load failure)

Closes #27