### PR TITLE
Extract unauthorized() into AuthenticationContext

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -39,7 +39,7 @@ class AccountController(
     fun createAccount(
         @Valid @RequestBody request: CreateAccountRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val account = accountService.createAccount(request, orgId)
@@ -55,7 +55,7 @@ class AccountController(
         @RequestParam(required = false) type: String?,
         @RequestParam(required = false) parentId: String?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         val accountType =
             if (type != null) {
@@ -79,7 +79,7 @@ class AccountController(
     fun getAccount(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val account = accountService.getAccount(id, orgId)
@@ -95,7 +95,7 @@ class AccountController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateAccountRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val account = accountService.updateAccount(id, request, orgId)
@@ -111,7 +111,7 @@ class AccountController(
     fun deleteAccount(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             accountService.deleteAccount(id, orgId)
@@ -128,7 +128,7 @@ class AccountController(
         @PathVariable id: String,
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val balance = journalEntryService.getAccountBalance(id, orgId, asOfDate)
@@ -152,9 +152,4 @@ class AccountController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
@@ -6,6 +6,7 @@ import com.froilan.synectix.dto.ApiKeyCreatedResponse
 import com.froilan.synectix.dto.ApiKeyResponse
 import com.froilan.synectix.dto.CreateApiKeyRequest
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.ApiKeyService
 import jakarta.validation.Valid
@@ -26,14 +27,15 @@ import org.springframework.web.bind.annotation.RestController
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class ApiKeyController(
     private val apiKeyService: ApiKeyService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('apikey:manage')")
     fun createApiKey(
         @Valid @RequestBody request: CreateApiKeyRequest,
     ): ResponseEntity<Any> {
-        val (user, sessionContext) = extractUserAndContext() ?: return unauthorized()
-        val authentication = SecurityContextHolder.getContext().authentication ?: return unauthorized()
+        val (user, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
+        val authentication = SecurityContextHolder.getContext().authentication ?: return authContext.unauthorized()
         val creatorPermissions = authentication.authorities.mapNotNull { it.authority }.toSet()
 
         return try {
@@ -66,7 +68,7 @@ class ApiKeyController(
     @GetMapping
     @PreAuthorize("hasAuthority('apikey:manage')")
     fun listApiKeys(): ResponseEntity<Any> {
-        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         val keys =
             apiKeyService.listApiKeys(sessionContext.organizationId).map { key ->
@@ -90,7 +92,7 @@ class ApiKeyController(
     fun revokeApiKey(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         return try {
             apiKeyService.revokeApiKey(id, sessionContext.organizationId)
@@ -106,9 +108,4 @@ class ApiKeyController(
         val sessionContext = authentication.details as? SessionContext ?: return null
         return user to sessionContext
     }
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -41,7 +41,7 @@ class BillController(
     fun createBill(
         @Valid @RequestBody request: CreateBillRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -60,7 +60,7 @@ class BillController(
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) vendorId: String?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         val billStatus =
             if (status != null) {
@@ -84,7 +84,7 @@ class BillController(
     fun getBill(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val bill = billService.getBill(id, orgId)
@@ -101,7 +101,7 @@ class BillController(
     fun approveBill(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -126,7 +126,7 @@ class BillController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidBillRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -151,7 +151,7 @@ class BillController(
         @PathVariable id: String,
         @Valid @RequestBody request: RecordPaymentRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -175,7 +175,7 @@ class BillController(
     fun listPayments(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val payments = billService.getPayments(id, orgId)
@@ -192,7 +192,7 @@ class BillController(
     fun getAgingReport(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
         return ResponseEntity.ok(report)
     }
@@ -256,9 +256,4 @@ class BillController(
             createdBy = createdBy,
             createdAt = createdAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
@@ -33,7 +33,7 @@ class CustomerController(
     fun createCustomer(
         @Valid @RequestBody request: CreateCustomerRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val customer = customerService.createCustomer(request, orgId)
@@ -46,7 +46,7 @@ class CustomerController(
     @GetMapping
     @PreAuthorize("hasAuthority('ar:read')")
     fun listCustomers(): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val customers = customerService.listCustomers(orgId)
         return ResponseEntity.ok(customers.map { it.toResponse() })
     }
@@ -56,7 +56,7 @@ class CustomerController(
     fun getCustomer(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val customer = customerService.getCustomer(id, orgId)
@@ -74,7 +74,7 @@ class CustomerController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateCustomerRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val customer = customerService.updateCustomer(id, request, orgId)
@@ -93,7 +93,7 @@ class CustomerController(
     fun deleteCustomer(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val customer = customerService.deleteCustomer(id, orgId)
@@ -121,9 +121,4 @@ class CustomerController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -32,7 +32,7 @@ class FiscalYearController(
     fun createFiscalYear(
         @Valid @RequestBody request: CreateFiscalYearRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val fiscalYear = fiscalYearService.createFiscalYear(request, orgId)
@@ -45,7 +45,7 @@ class FiscalYearController(
     @GetMapping
     @PreAuthorize("hasAuthority('fiscal:read')")
     fun listFiscalYears(): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val fiscalYears = fiscalYearService.listFiscalYears(orgId)
         return ResponseEntity.ok(fiscalYears.map { it.toSummaryResponse() })
     }
@@ -55,7 +55,7 @@ class FiscalYearController(
     fun getFiscalYear(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
@@ -73,7 +73,7 @@ class FiscalYearController(
         @PathVariable id: String,
         @PathVariable periodId: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -93,7 +93,7 @@ class FiscalYearController(
         @PathVariable id: String,
         @PathVariable periodId: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -112,7 +112,7 @@ class FiscalYearController(
     fun closeYear(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -172,9 +172,4 @@ class FiscalYearController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
@@ -7,6 +7,7 @@ import com.froilan.synectix.dto.CreateInvitationRequest
 import com.froilan.synectix.dto.InvitationResponse
 import com.froilan.synectix.dto.ValidateInvitationRequest
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.InvitationService
 import jakarta.validation.Valid
@@ -27,13 +28,14 @@ import org.springframework.web.bind.annotation.RestController
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class InvitationController(
     private val invitationService: InvitationService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('invitation:write')")
     fun createInvitation(
         @Valid @RequestBody request: CreateInvitationRequest,
     ): ResponseEntity<Any> {
-        val (user, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (user, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         return try {
             val token = invitationService.invite(request, user, sessionContext.organizationId)
@@ -48,7 +50,7 @@ class InvitationController(
     @GetMapping
     @PreAuthorize("hasAuthority('invitation:read')")
     fun listInvitations(): ResponseEntity<Any> {
-        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         val invitations =
             invitationService.listInvitations(sessionContext.organizationId).map { invitation ->
@@ -92,7 +94,7 @@ class InvitationController(
     fun revokeInvitation(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         return try {
             invitationService.revokeInvitation(id, sessionContext.organizationId)
@@ -108,9 +110,4 @@ class InvitationController(
         val sessionContext = authentication.details as? SessionContext ?: return null
         return user to sessionContext
     }
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
@@ -41,7 +41,7 @@ class InvoiceController(
     fun createInvoice(
         @Valid @RequestBody request: CreateInvoiceRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -60,7 +60,7 @@ class InvoiceController(
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) customerId: String?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         val invoiceStatus =
             if (status != null) {
@@ -84,7 +84,7 @@ class InvoiceController(
     fun getInvoice(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val invoice = invoiceService.getInvoice(id, orgId)
@@ -101,7 +101,7 @@ class InvoiceController(
     fun approveInvoice(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -126,7 +126,7 @@ class InvoiceController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidInvoiceRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -151,7 +151,7 @@ class InvoiceController(
         @PathVariable id: String,
         @Valid @RequestBody request: RecordReceiptRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -175,7 +175,7 @@ class InvoiceController(
     fun listReceipts(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val receipts = invoiceService.getReceipts(id, orgId)
@@ -192,7 +192,7 @@ class InvoiceController(
     fun getAgingReport(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val report = invoiceService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
         return ResponseEntity.ok(report)
     }
@@ -256,9 +256,4 @@ class InvoiceController(
             createdBy = createdBy,
             createdAt = createdAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
@@ -36,7 +36,7 @@ class JournalEntryController(
     fun createJournalEntry(
         @Valid @RequestBody request: CreateJournalEntryRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -54,7 +54,7 @@ class JournalEntryController(
         @RequestParam(required = false) startDate: LocalDate?,
         @RequestParam(required = false) endDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         val entryStatus =
             if (status != null) {
@@ -78,7 +78,7 @@ class JournalEntryController(
     fun getJournalEntry(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val entry = journalEntryService.getJournalEntry(id, orgId)
@@ -93,7 +93,7 @@ class JournalEntryController(
     fun postJournalEntry(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val entry = journalEntryService.postJournalEntry(id, orgId)
@@ -110,7 +110,7 @@ class JournalEntryController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidJournalEntryRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val entry = journalEntryService.voidJournalEntry(id, orgId, request.reason)
@@ -126,7 +126,7 @@ class JournalEntryController(
     fun getTrialBalance(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val trialBalance = journalEntryService.getTrialBalance(orgId, asOfDate)
         return ResponseEntity.ok(trialBalance)
     }
@@ -159,9 +159,4 @@ class JournalEntryController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.dto.SessionResponse
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/auth/sessions")
 class SessionController(
     private val authService: AuthService,
+    private val authContext: AuthenticationContext,
 ) {
     @GetMapping
     @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('session:read')")
@@ -26,7 +28,7 @@ class SessionController(
     ): ResponseEntity<Any> {
         val (user, currentToken) =
             extractUserAndToken(authHeader)
-                ?: return unauthorized()
+                ?: return authContext.unauthorized()
 
         val sessions = authService.listSessions(user.uuid)
         val response =
@@ -51,7 +53,7 @@ class SessionController(
     ): ResponseEntity<Any> {
         val (user, currentToken) =
             extractUserAndToken(authHeader)
-                ?: return unauthorized()
+                ?: return authContext.unauthorized()
 
         return try {
             authService.revokeSession(user.uuid, sessionId, currentToken)
@@ -74,7 +76,7 @@ class SessionController(
     ): ResponseEntity<Any> {
         val (user, currentToken) =
             extractUserAndToken(authHeader)
-                ?: return unauthorized()
+                ?: return authContext.unauthorized()
 
         authService.revokeOtherSessions(user.uuid, currentToken)
         return ResponseEntity.ok(mapOf("message" to "All other sessions revoked"))
@@ -90,9 +92,4 @@ class SessionController(
         if (!authHeader.startsWith("Bearer ")) return null
         return user to authHeader.substring(7)
     }
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -33,7 +33,7 @@ class VendorController(
     fun createVendor(
         @Valid @RequestBody request: CreateVendorRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val vendor = vendorService.createVendor(request, orgId)
@@ -46,7 +46,7 @@ class VendorController(
     @GetMapping
     @PreAuthorize("hasAuthority('ap:read')")
     fun listVendors(): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val vendors = vendorService.listVendors(orgId)
         return ResponseEntity.ok(vendors.map { it.toResponse() })
     }
@@ -56,7 +56,7 @@ class VendorController(
     fun getVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val vendor = vendorService.getVendor(id, orgId)
@@ -74,7 +74,7 @@ class VendorController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateVendorRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val vendor = vendorService.updateVendor(id, request, orgId)
@@ -93,7 +93,7 @@ class VendorController(
     fun deleteVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val vendor = vendorService.deleteVendor(id, orgId)
@@ -121,9 +121,4 @@ class VendorController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/security/AuthenticationContext.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/AuthenticationContext.kt
@@ -1,6 +1,8 @@
 package com.froilan.synectix.security
 
 import com.froilan.synectix.model.User
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
@@ -19,4 +21,9 @@ class AuthenticationContext {
         val authentication = SecurityContextHolder.getContext().authentication ?: return null
         return (authentication.principal as? User)?.uuid
     }
+
+    fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
@@ -11,6 +11,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
@@ -70,6 +71,9 @@ class ApiKeyControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
@@ -73,6 +74,9 @@ class InvitationControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
 
     @MockitoBean
     private lateinit var apiKeyService: ApiKeyService

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -10,6 +10,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.ApiKeyService
@@ -72,6 +73,9 @@ class SessionControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
@@ -91,9 +91,12 @@ class AuthenticationContextTest {
     }
 
     @Test
+    @Suppress("UNCHECKED_CAST")
     fun `unauthorized should return 401 with error message`() {
         val response = authContext.unauthorized()
 
         assertThat(response.statusCode.value()).isEqualTo(401)
+        val body = response.body as Map<String, String>
+        assertThat(body["error"]).isEqualTo("Authentication required")
     }
 }

--- a/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
@@ -89,4 +89,11 @@ class AuthenticationContextTest {
 
         assertThat(authContext.userId()).isNull()
     }
+
+    @Test
+    fun `unauthorized should return 401 with error message`() {
+        val response = authContext.unauthorized()
+
+        assertThat(response.statusCode.value()).isEqualTo(401)
+    }
 }


### PR DESCRIPTION
## Summary
- Move duplicated `private fun unauthorized()` from all 10 controllers into `AuthenticationContext.unauthorized()`
- Controllers now call `authContext.unauthorized()` instead of a local private method
- Inject `AuthenticationContext` into 3 auth controllers that didn't have it yet (ApiKey, Invitation, Session)
- Add `@MockitoBean` for `AuthenticationContext` in corresponding controller tests
- Add unit test for `unauthorized()` response

## Files changed
- **Modified:** `AuthenticationContext.kt` — add `unauthorized()` method
- **Modified:** 10 controllers — remove private `unauthorized()`, use `authContext.unauthorized()`
- **Modified:** 3 controller tests — add `@MockitoBean` for `AuthenticationContext`
- **Modified:** `AuthenticationContextTest.kt` — add `unauthorized()` test

## Test plan
- [x] 273/274 tests pass (1 pre-existing MongoDB context load failure)
- [x] ktlintCheck passes
- [x] No functional changes — pure refactor