### PR TITLE
Release: AR module, AuthenticationContext, and centralized exception handling

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -61,6 +61,11 @@ class RoleSeeder(
                             Permissions.AP_APPROVE,
                             Permissions.AP_PAY,
                             Permissions.AP_VOID,
+                            Permissions.AR_CREATE,
+                            Permissions.AR_READ,
+                            Permissions.AR_APPROVE,
+                            Permissions.AR_RECEIVE,
+                            Permissions.AR_VOID,
                         ),
                 ),
                 Role(
@@ -91,6 +96,10 @@ class RoleSeeder(
                             Permissions.AP_READ,
                             Permissions.AP_APPROVE,
                             Permissions.AP_PAY,
+                            Permissions.AR_CREATE,
+                            Permissions.AR_READ,
+                            Permissions.AR_APPROVE,
+                            Permissions.AR_RECEIVE,
                         ),
                 ),
                 Role(
@@ -110,6 +119,8 @@ class RoleSeeder(
                             Permissions.FISCAL_READ,
                             Permissions.AP_CREATE,
                             Permissions.AP_READ,
+                            Permissions.AR_CREATE,
+                            Permissions.AR_READ,
                         ),
                 ),
                 Role(
@@ -124,6 +135,7 @@ class RoleSeeder(
                             Permissions.JOURNAL_READ,
                             Permissions.FISCAL_READ,
                             Permissions.AP_READ,
+                            Permissions.AR_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -41,12 +41,8 @@ class AccountController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val account = accountService.createAccount(request, orgId)
-            ResponseEntity.status(HttpStatus.CREATED).body(account.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create account")))
-        }
+        val account = accountService.createAccount(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(account.toResponse())
     }
 
     @GetMapping
@@ -81,12 +77,8 @@ class AccountController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val account = accountService.getAccount(id, orgId)
-            ResponseEntity.ok(account.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (e.message ?: "Account not found")))
-        }
+        val account = accountService.getAccount(id, orgId)
+        return ResponseEntity.ok(account.toResponse())
     }
 
     @PutMapping("/{id}")
@@ -97,13 +89,8 @@ class AccountController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val account = accountService.updateAccount(id, request, orgId)
-            ResponseEntity.ok(account.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status = if (e.message == "Account not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to update account")))
-        }
+        val account = accountService.updateAccount(id, request, orgId)
+        return ResponseEntity.ok(account.toResponse())
     }
 
     @DeleteMapping("/{id}")
@@ -113,13 +100,8 @@ class AccountController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            accountService.deleteAccount(id, orgId)
-            ResponseEntity.ok(mapOf("message" to "Account deactivated"))
-        } catch (e: IllegalArgumentException) {
-            val status = if (e.message == "Account not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to delete account")))
-        }
+        accountService.deleteAccount(id, orgId)
+        return ResponseEntity.ok(mapOf("message" to "Account deactivated"))
     }
 
     @GetMapping("/{id}/balance")
@@ -130,12 +112,8 @@ class AccountController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val balance = journalEntryService.getAccountBalance(id, orgId, asOfDate)
-            ResponseEntity.ok(balance)
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (e.message ?: "Account not found")))
-        }
+        val balance = journalEntryService.getAccountBalance(id, orgId, asOfDate)
+        return ResponseEntity.ok(balance)
     }
 
     private fun Account.toResponse() =

--- a/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AccountController.kt
@@ -39,7 +39,7 @@ class AccountController(
     fun createAccount(
         @Valid @RequestBody request: CreateAccountRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val account = accountService.createAccount(request, orgId)
@@ -55,7 +55,7 @@ class AccountController(
         @RequestParam(required = false) type: String?,
         @RequestParam(required = false) parentId: String?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         val accountType =
             if (type != null) {
@@ -79,7 +79,7 @@ class AccountController(
     fun getAccount(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val account = accountService.getAccount(id, orgId)
@@ -95,7 +95,7 @@ class AccountController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateAccountRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val account = accountService.updateAccount(id, request, orgId)
@@ -111,7 +111,7 @@ class AccountController(
     fun deleteAccount(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             accountService.deleteAccount(id, orgId)
@@ -128,7 +128,7 @@ class AccountController(
         @PathVariable id: String,
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val balance = journalEntryService.getAccountBalance(id, orgId, asOfDate)
@@ -152,9 +152,4 @@ class AccountController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
@@ -6,6 +6,7 @@ import com.froilan.synectix.dto.ApiKeyCreatedResponse
 import com.froilan.synectix.dto.ApiKeyResponse
 import com.froilan.synectix.dto.CreateApiKeyRequest
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.ApiKeyService
 import jakarta.validation.Valid
@@ -26,14 +27,15 @@ import org.springframework.web.bind.annotation.RestController
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class ApiKeyController(
     private val apiKeyService: ApiKeyService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('apikey:manage')")
     fun createApiKey(
         @Valid @RequestBody request: CreateApiKeyRequest,
     ): ResponseEntity<Any> {
-        val (user, sessionContext) = extractUserAndContext() ?: return unauthorized()
-        val authentication = SecurityContextHolder.getContext().authentication ?: return unauthorized()
+        val (user, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
+        val authentication = SecurityContextHolder.getContext().authentication ?: return authContext.unauthorized()
         val creatorPermissions = authentication.authorities.mapNotNull { it.authority }.toSet()
 
         return try {
@@ -66,7 +68,7 @@ class ApiKeyController(
     @GetMapping
     @PreAuthorize("hasAuthority('apikey:manage')")
     fun listApiKeys(): ResponseEntity<Any> {
-        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         val keys =
             apiKeyService.listApiKeys(sessionContext.organizationId).map { key ->
@@ -90,7 +92,7 @@ class ApiKeyController(
     fun revokeApiKey(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         return try {
             apiKeyService.revokeApiKey(id, sessionContext.organizationId)
@@ -106,9 +108,4 @@ class ApiKeyController(
         val sessionContext = authentication.details as? SessionContext ?: return null
         return user to sessionContext
     }
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/ApiKeyController.kt
@@ -38,31 +38,27 @@ class ApiKeyController(
         val authentication = SecurityContextHolder.getContext().authentication ?: return authContext.unauthorized()
         val creatorPermissions = authentication.authorities.mapNotNull { it.authority }.toSet()
 
-        return try {
-            val (apiKey, rawKey) =
-                apiKeyService.createApiKey(
-                    name = request.name,
-                    permissions = request.permissions,
-                    organizationId = sessionContext.organizationId,
-                    createdBy = user.uuid,
-                    creatorPermissions = creatorPermissions,
-                    expiresAt = request.expiresAt,
-                )
-            ResponseEntity.status(HttpStatus.CREATED).body(
-                ApiKeyCreatedResponse(
-                    id = apiKey.id,
-                    name = apiKey.name,
-                    rawKey = rawKey,
-                    keyPrefix = apiKey.keyPrefix,
-                    permissions = apiKey.permissions,
-                    organizationId = apiKey.organizationId,
-                    expiresAt = apiKey.expiresAt?.toString(),
-                    createdAt = apiKey.createdAt?.toString(),
-                ),
+        val (apiKey, rawKey) =
+            apiKeyService.createApiKey(
+                name = request.name,
+                permissions = request.permissions,
+                organizationId = sessionContext.organizationId,
+                createdBy = user.uuid,
+                creatorPermissions = creatorPermissions,
+                expiresAt = request.expiresAt,
             )
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create API key")))
-        }
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ApiKeyCreatedResponse(
+                id = apiKey.id,
+                name = apiKey.name,
+                rawKey = rawKey,
+                keyPrefix = apiKey.keyPrefix,
+                permissions = apiKey.permissions,
+                organizationId = apiKey.organizationId,
+                expiresAt = apiKey.expiresAt?.toString(),
+                createdAt = apiKey.createdAt?.toString(),
+            ),
+        )
     }
 
     @GetMapping
@@ -94,12 +90,8 @@ class ApiKeyController(
     ): ResponseEntity<Any> {
         val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
-        return try {
-            apiKeyService.revokeApiKey(id, sessionContext.organizationId)
-            ResponseEntity.ok(mapOf("message" to "API key revoked"))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to revoke API key")))
-        }
+        apiKeyService.revokeApiKey(id, sessionContext.organizationId)
+        return ResponseEntity.ok(mapOf("message" to "API key revoked"))
     }
 
     private fun extractUserAndContext(): Pair<User, SessionContext>? {

--- a/src/main/kotlin/com/froilan/synectix/controller/AuthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/AuthController.kt
@@ -9,6 +9,7 @@ import com.froilan.synectix.dto.RefreshRequest
 import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.dto.ResetPasswordRequest
 import com.froilan.synectix.dto.SwitchOrganizationRequest
+import com.froilan.synectix.exception.AuthenticationException
 import com.froilan.synectix.model.User
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.AuthService
@@ -68,13 +69,10 @@ class AuthController(
     @PostMapping("/signup")
     fun register(
         @Valid @RequestBody request: RegisterRequest,
-    ): ResponseEntity<Any> =
-        try {
-            val user = authService.register(request)
-            ResponseEntity.status(HttpStatus.CREATED).body(mapOf("message" to "User registered successfully", "userId" to user.uuid))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to e.message))
-        }
+    ): ResponseEntity<Any> {
+        val user = authService.register(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(mapOf("message" to "User registered successfully", "userId" to user.uuid))
+    }
 
     @PostMapping("/signin")
     fun login(
@@ -100,7 +98,7 @@ class AuthController(
                 )
             resetAttempts(clientIp)
             ResponseEntity.ok(response)
-        } catch (e: IllegalArgumentException) {
+        } catch (e: AuthenticationException) {
             if (e.message != "User account is inactive") {
                 recordFailedAttempt(clientIp)
             }
@@ -113,15 +111,10 @@ class AuthController(
     @PostMapping("/refresh")
     fun refresh(
         @Valid @RequestBody request: RefreshRequest,
-    ): ResponseEntity<Any> =
-        try {
-            val response = authService.refresh(request.refreshToken)
-            ResponseEntity.ok(response)
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
-                .body(mapOf("error" to (e.message ?: "Invalid or expired refresh token")))
-        }
+    ): ResponseEntity<Any> {
+        val response = authService.refresh(request.refreshToken)
+        return ResponseEntity.ok(response)
+    }
 
     @PostMapping("/change-password")
     fun changePassword(
@@ -134,12 +127,8 @@ class AuthController(
                     .status(HttpStatus.UNAUTHORIZED)
                     .body(mapOf("error" to "Authentication required"))
 
-        return try {
-            authService.changePassword(user, request.currentPassword, request.newPassword)
-            ResponseEntity.ok(mapOf("message" to "Password changed successfully"))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Password change failed")))
-        }
+        authService.changePassword(user, request.currentPassword, request.newPassword)
+        return ResponseEntity.ok(mapOf("message" to "Password changed successfully"))
     }
 
     @PostMapping("/forgot-password")
@@ -167,13 +156,10 @@ class AuthController(
     @PostMapping("/reset-password")
     fun resetPassword(
         @Valid @RequestBody request: ResetPasswordRequest,
-    ): ResponseEntity<Any> =
-        try {
-            authService.resetPassword(request.token, request.newPassword)
-            ResponseEntity.ok(mapOf("message" to "Password has been reset successfully"))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Password reset failed")))
-        }
+    ): ResponseEntity<Any> {
+        authService.resetPassword(request.token, request.newPassword)
+        return ResponseEntity.ok(mapOf("message" to "Password has been reset successfully"))
+    }
 
     @GetMapping("/organizations")
     fun listOrganizations(): ResponseEntity<Any> {
@@ -205,18 +191,14 @@ class AuthController(
                     .status(HttpStatus.UNAUTHORIZED)
                     .body(mapOf("error" to "Authentication required"))
 
-        return try {
-            val response =
-                authService.switchOrganization(
-                    user = user,
-                    targetOrgId = request.organizationId,
-                    ipAddress = httpRequest.remoteAddr?.take(MAX_IP_LENGTH),
-                    userAgent = httpRequest.getHeader("User-Agent")?.take(MAX_USER_AGENT_LENGTH),
-                )
-            ResponseEntity.ok(response)
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Organization switch failed")))
-        }
+        val response =
+            authService.switchOrganization(
+                user = user,
+                targetOrgId = request.organizationId,
+                ipAddress = httpRequest.remoteAddr?.take(MAX_IP_LENGTH),
+                userAgent = httpRequest.getHeader("User-Agent")?.take(MAX_USER_AGENT_LENGTH),
+            )
+        return ResponseEntity.ok(response)
     }
 
     @PostMapping("/logout")

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -44,14 +44,8 @@ class BillController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
-        return try {
-            val bill = billService.createBill(request, orgId, createdBy)
-            ResponseEntity.status(HttpStatus.CREATED).body(bill.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .badRequest()
-                .body(mapOf("error" to (e.message ?: "Failed to create bill")))
-        }
+        val bill = billService.createBill(request, orgId, createdBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(bill.toResponse())
     }
 
     @GetMapping
@@ -86,14 +80,8 @@ class BillController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val bill = billService.getBill(id, orgId)
-            ResponseEntity.ok(bill.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Bill not found")))
-        }
+        val bill = billService.getBill(id, orgId)
+        return ResponseEntity.ok(bill.toResponse())
     }
 
     @PostMapping("/{id}/approve")
@@ -104,20 +92,8 @@ class BillController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
-        return try {
-            val bill = billService.approveBill(id, orgId, userId)
-            ResponseEntity.ok(bill.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
-        } catch (e: IllegalStateException) {
-            ResponseEntity
-                .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
-        }
+        val bill = billService.approveBill(id, orgId, userId)
+        return ResponseEntity.ok(bill.toResponse())
     }
 
     @PostMapping("/{id}/void")
@@ -129,20 +105,8 @@ class BillController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
-        return try {
-            val bill = billService.voidBill(id, orgId, request.reason, userId)
-            ResponseEntity.ok(bill.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to void bill")))
-        } catch (e: IllegalStateException) {
-            ResponseEntity
-                .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to void bill")))
-        }
+        val bill = billService.voidBill(id, orgId, request.reason, userId)
+        return ResponseEntity.ok(bill.toResponse())
     }
 
     @PostMapping("/{id}/payments")
@@ -154,20 +118,8 @@ class BillController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
-        return try {
-            val payment = billService.recordPayment(id, request, orgId, createdBy)
-            ResponseEntity.status(HttpStatus.CREATED).body(payment.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to record payment")))
-        } catch (e: IllegalStateException) {
-            ResponseEntity
-                .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to record payment")))
-        }
+        val payment = billService.recordPayment(id, request, orgId, createdBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(payment.toResponse())
     }
 
     @GetMapping("/{id}/payments")
@@ -177,14 +129,8 @@ class BillController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val payments = billService.getPayments(id, orgId)
-            ResponseEntity.ok(payments.map { it.toResponse() })
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Bill not found")))
-        }
+        val payments = billService.getPayments(id, orgId)
+        return ResponseEntity.ok(payments.map { it.toResponse() })
     }
 
     @GetMapping("/aging")

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -41,7 +41,7 @@ class BillController(
     fun createBill(
         @Valid @RequestBody request: CreateBillRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -60,7 +60,7 @@ class BillController(
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) vendorId: String?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         val billStatus =
             if (status != null) {
@@ -84,7 +84,7 @@ class BillController(
     fun getBill(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val bill = billService.getBill(id, orgId)
@@ -101,7 +101,7 @@ class BillController(
     fun approveBill(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -126,7 +126,7 @@ class BillController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidBillRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -151,7 +151,7 @@ class BillController(
         @PathVariable id: String,
         @Valid @RequestBody request: RecordPaymentRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -175,7 +175,7 @@ class BillController(
     fun listPayments(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val payments = billService.getPayments(id, orgId)
@@ -192,7 +192,7 @@ class BillController(
     fun getAgingReport(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
         return ResponseEntity.ok(report)
     }
@@ -256,9 +256,4 @@ class BillController(
             createdBy = createdBy,
             createdAt = createdAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
@@ -35,12 +35,8 @@ class CustomerController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val customer = customerService.createCustomer(request, orgId)
-            ResponseEntity.status(HttpStatus.CREATED).body(customer.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create customer")))
-        }
+        val customer = customerService.createCustomer(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(customer.toResponse())
     }
 
     @GetMapping
@@ -58,14 +54,8 @@ class CustomerController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val customer = customerService.getCustomer(id, orgId)
-            ResponseEntity.ok(customer.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Customer not found")))
-        }
+        val customer = customerService.getCustomer(id, orgId)
+        return ResponseEntity.ok(customer.toResponse())
     }
 
     @PutMapping("/{id}")
@@ -76,16 +66,8 @@ class CustomerController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val customer = customerService.updateCustomer(id, request, orgId)
-            ResponseEntity.ok(customer.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Customer not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to update customer")))
-        }
+        val customer = customerService.updateCustomer(id, request, orgId)
+        return ResponseEntity.ok(customer.toResponse())
     }
 
     @DeleteMapping("/{id}")
@@ -95,16 +77,8 @@ class CustomerController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val customer = customerService.deleteCustomer(id, orgId)
-            ResponseEntity.ok(customer.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Customer not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to delete customer")))
-        }
+        val customer = customerService.deleteCustomer(id, orgId)
+        return ResponseEntity.ok(customer.toResponse())
     }
 
     private fun Customer.toResponse() =

--- a/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
@@ -1,0 +1,129 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateCustomerRequest
+import com.froilan.synectix.dto.CustomerResponse
+import com.froilan.synectix.dto.UpdateCustomerRequest
+import com.froilan.synectix.model.Customer
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.CustomerService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/finance/ar/customers")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class CustomerController(
+    private val customerService: CustomerService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('ar:create')")
+    fun createCustomer(
+        @Valid @RequestBody request: CreateCustomerRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val customer = customerService.createCustomer(request, orgId)
+            ResponseEntity.status(HttpStatus.CREATED).body(customer.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create customer")))
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun listCustomers(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+        val customers = customerService.listCustomers(orgId)
+        return ResponseEntity.ok(customers.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun getCustomer(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val customer = customerService.getCustomer(id, orgId)
+            ResponseEntity.ok(customer.toResponse())
+        } catch (e: IllegalArgumentException) {
+            ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(mapOf("error" to (e.message ?: "Customer not found")))
+        }
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('ar:create')")
+    fun updateCustomer(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateCustomerRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val customer = customerService.updateCustomer(id, request, orgId)
+            ResponseEntity.ok(customer.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Customer not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to update customer")))
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('ar:create')")
+    fun deleteCustomer(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return unauthorized()
+
+        return try {
+            val customer = customerService.deleteCustomer(id, orgId)
+            ResponseEntity.ok(customer.toResponse())
+        } catch (e: IllegalArgumentException) {
+            val status =
+                if (e.message == "Customer not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+            ResponseEntity
+                .status(status)
+                .body(mapOf("error" to (e.message ?: "Failed to delete customer")))
+        }
+    }
+
+    private fun Customer.toResponse() =
+        CustomerResponse(
+            id = id,
+            name = name,
+            contactName = contactName,
+            contactEmail = contactEmail,
+            contactPhone = contactPhone,
+            paymentTermDays = paymentTermDays,
+            defaultRevenueAccountId = defaultRevenueAccountId,
+            organizationId = organizationId,
+            isActive = isActive,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/CustomerController.kt
@@ -33,7 +33,7 @@ class CustomerController(
     fun createCustomer(
         @Valid @RequestBody request: CreateCustomerRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val customer = customerService.createCustomer(request, orgId)
@@ -46,7 +46,7 @@ class CustomerController(
     @GetMapping
     @PreAuthorize("hasAuthority('ar:read')")
     fun listCustomers(): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val customers = customerService.listCustomers(orgId)
         return ResponseEntity.ok(customers.map { it.toResponse() })
     }
@@ -56,7 +56,7 @@ class CustomerController(
     fun getCustomer(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val customer = customerService.getCustomer(id, orgId)
@@ -74,7 +74,7 @@ class CustomerController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateCustomerRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val customer = customerService.updateCustomer(id, request, orgId)
@@ -93,7 +93,7 @@ class CustomerController(
     fun deleteCustomer(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val customer = customerService.deleteCustomer(id, orgId)
@@ -121,9 +121,4 @@ class CustomerController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -34,12 +34,8 @@ class FiscalYearController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val fiscalYear = fiscalYearService.createFiscalYear(request, orgId)
-            ResponseEntity.status(HttpStatus.CREATED).body(fiscalYear.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create fiscal year")))
-        }
+        val fiscalYear = fiscalYearService.createFiscalYear(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(fiscalYear.toResponse())
     }
 
     @GetMapping
@@ -57,14 +53,8 @@ class FiscalYearController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
-            ResponseEntity.ok(fiscalYear.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Fiscal year not found")))
-        }
+        val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
+        return ResponseEntity.ok(fiscalYear.toResponse())
     }
 
     @PostMapping("/{id}/periods/{periodId}/close")
@@ -76,15 +66,8 @@ class FiscalYearController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
-        return try {
-            val fiscalYear = fiscalYearService.closePeriod(id, periodId, orgId, userId)
-            ResponseEntity.ok(fiscalYear.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status = if (e.message == "Fiscal period not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to close period")))
-        }
+        val fiscalYear = fiscalYearService.closePeriod(id, periodId, orgId, userId)
+        return ResponseEntity.ok(fiscalYear.toResponse())
     }
 
     @PostMapping("/{id}/periods/{periodId}/reopen")
@@ -96,15 +79,8 @@ class FiscalYearController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
-        return try {
-            val fiscalYear = fiscalYearService.reopenPeriod(id, periodId, orgId, userId)
-            ResponseEntity.ok(fiscalYear.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status = if (e.message == "Fiscal period not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to reopen period")))
-        }
+        val fiscalYear = fiscalYearService.reopenPeriod(id, periodId, orgId, userId)
+        return ResponseEntity.ok(fiscalYear.toResponse())
     }
 
     @PostMapping("/{id}/close")
@@ -115,20 +91,8 @@ class FiscalYearController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
-        return try {
-            val fiscalYear = fiscalYearService.closeYear(id, orgId, userId)
-            ResponseEntity.ok(fiscalYear.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Fiscal year not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to close fiscal year")))
-        } catch (e: IllegalStateException) {
-            ResponseEntity
-                .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to generate closing entry")))
-        }
+        val fiscalYear = fiscalYearService.closeYear(id, orgId, userId)
+        return ResponseEntity.ok(fiscalYear.toResponse())
     }
 
     private fun FiscalYear.toResponse() =

--- a/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FiscalYearController.kt
@@ -32,7 +32,7 @@ class FiscalYearController(
     fun createFiscalYear(
         @Valid @RequestBody request: CreateFiscalYearRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val fiscalYear = fiscalYearService.createFiscalYear(request, orgId)
@@ -45,7 +45,7 @@ class FiscalYearController(
     @GetMapping
     @PreAuthorize("hasAuthority('fiscal:read')")
     fun listFiscalYears(): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val fiscalYears = fiscalYearService.listFiscalYears(orgId)
         return ResponseEntity.ok(fiscalYears.map { it.toSummaryResponse() })
     }
@@ -55,7 +55,7 @@ class FiscalYearController(
     fun getFiscalYear(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val fiscalYear = fiscalYearService.getFiscalYear(id, orgId)
@@ -73,7 +73,7 @@ class FiscalYearController(
         @PathVariable id: String,
         @PathVariable periodId: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -93,7 +93,7 @@ class FiscalYearController(
         @PathVariable id: String,
         @PathVariable periodId: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -112,7 +112,7 @@ class FiscalYearController(
     fun closeYear(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -172,9 +172,4 @@ class FiscalYearController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
@@ -37,14 +37,10 @@ class InvitationController(
     ): ResponseEntity<Any> {
         val (user, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
-        return try {
-            val token = invitationService.invite(request, user, sessionContext.organizationId)
-            ResponseEntity.status(HttpStatus.CREATED).body(
-                mapOf("message" to "Invitation created", "token" to token),
-            )
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation request")))
-        }
+        val token = invitationService.invite(request, user, sessionContext.organizationId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            mapOf("message" to "Invitation created", "token" to token),
+        )
     }
 
     @GetMapping
@@ -70,24 +66,18 @@ class InvitationController(
     @PostMapping("/validate")
     fun validateInvitation(
         @Valid @RequestBody request: ValidateInvitationRequest,
-    ): ResponseEntity<Any> =
-        try {
-            val result = invitationService.validateInvitation(request.token)
-            ResponseEntity.ok(result)
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation token")))
-        }
+    ): ResponseEntity<Any> {
+        val result = invitationService.validateInvitation(request.token)
+        return ResponseEntity.ok(result)
+    }
 
     @PostMapping("/accept")
     fun acceptInvitation(
         @Valid @RequestBody request: AcceptInvitationRequest,
-    ): ResponseEntity<Any> =
-        try {
-            invitationService.acceptInvitation(request)
-            ResponseEntity.ok(mapOf("message" to "Invitation accepted successfully"))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation token")))
-        }
+    ): ResponseEntity<Any> {
+        invitationService.acceptInvitation(request)
+        return ResponseEntity.ok(mapOf("message" to "Invitation accepted successfully"))
+    }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('invitation:write')")
@@ -96,12 +86,8 @@ class InvitationController(
     ): ResponseEntity<Any> {
         val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
-        return try {
-            invitationService.revokeInvitation(id, sessionContext.organizationId)
-            ResponseEntity.ok(mapOf("message" to "Invitation revoked"))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Invalid invitation operation")))
-        }
+        invitationService.revokeInvitation(id, sessionContext.organizationId)
+        return ResponseEntity.ok(mapOf("message" to "Invitation revoked"))
     }
 
     private fun extractUserAndContext(): Pair<User, SessionContext>? {

--- a/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvitationController.kt
@@ -7,6 +7,7 @@ import com.froilan.synectix.dto.CreateInvitationRequest
 import com.froilan.synectix.dto.InvitationResponse
 import com.froilan.synectix.dto.ValidateInvitationRequest
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.service.InvitationService
 import jakarta.validation.Valid
@@ -27,13 +28,14 @@ import org.springframework.web.bind.annotation.RestController
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class InvitationController(
     private val invitationService: InvitationService,
+    private val authContext: AuthenticationContext,
 ) {
     @PostMapping
     @PreAuthorize("hasAuthority('invitation:write')")
     fun createInvitation(
         @Valid @RequestBody request: CreateInvitationRequest,
     ): ResponseEntity<Any> {
-        val (user, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (user, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         return try {
             val token = invitationService.invite(request, user, sessionContext.organizationId)
@@ -48,7 +50,7 @@ class InvitationController(
     @GetMapping
     @PreAuthorize("hasAuthority('invitation:read')")
     fun listInvitations(): ResponseEntity<Any> {
-        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         val invitations =
             invitationService.listInvitations(sessionContext.organizationId).map { invitation ->
@@ -92,7 +94,7 @@ class InvitationController(
     fun revokeInvitation(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val (_, sessionContext) = extractUserAndContext() ?: return unauthorized()
+        val (_, sessionContext) = extractUserAndContext() ?: return authContext.unauthorized()
 
         return try {
             invitationService.revokeInvitation(id, sessionContext.organizationId)
@@ -108,9 +110,4 @@ class InvitationController(
         val sessionContext = authentication.details as? SessionContext ?: return null
         return user to sessionContext
     }
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
@@ -44,14 +44,8 @@ class InvoiceController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
-        return try {
-            val invoice = invoiceService.createInvoice(request, orgId, createdBy)
-            ResponseEntity.status(HttpStatus.CREATED).body(invoice.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .badRequest()
-                .body(mapOf("error" to (e.message ?: "Failed to create invoice")))
-        }
+        val invoice = invoiceService.createInvoice(request, orgId, createdBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(invoice.toResponse())
     }
 
     @GetMapping
@@ -86,14 +80,8 @@ class InvoiceController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val invoice = invoiceService.getInvoice(id, orgId)
-            ResponseEntity.ok(invoice.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Invoice not found")))
-        }
+        val invoice = invoiceService.getInvoice(id, orgId)
+        return ResponseEntity.ok(invoice.toResponse())
     }
 
     @PostMapping("/{id}/approve")
@@ -104,20 +92,8 @@ class InvoiceController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
-        return try {
-            val invoice = invoiceService.approveInvoice(id, orgId, userId)
-            ResponseEntity.ok(invoice.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to approve invoice")))
-        } catch (e: IllegalStateException) {
-            ResponseEntity
-                .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to approve invoice")))
-        }
+        val invoice = invoiceService.approveInvoice(id, orgId, userId)
+        return ResponseEntity.ok(invoice.toResponse())
     }
 
     @PostMapping("/{id}/void")
@@ -129,20 +105,8 @@ class InvoiceController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
-        return try {
-            val invoice = invoiceService.voidInvoice(id, orgId, request.reason, userId)
-            ResponseEntity.ok(invoice.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to void invoice")))
-        } catch (e: IllegalStateException) {
-            ResponseEntity
-                .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to void invoice")))
-        }
+        val invoice = invoiceService.voidInvoice(id, orgId, request.reason, userId)
+        return ResponseEntity.ok(invoice.toResponse())
     }
 
     @PostMapping("/{id}/receipts")
@@ -154,20 +118,8 @@ class InvoiceController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
-        return try {
-            val receipt = invoiceService.recordReceipt(id, request, orgId, createdBy)
-            ResponseEntity.status(HttpStatus.CREATED).body(receipt.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to record receipt")))
-        } catch (e: IllegalStateException) {
-            ResponseEntity
-                .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to record receipt")))
-        }
+        val receipt = invoiceService.recordReceipt(id, request, orgId, createdBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(receipt.toResponse())
     }
 
     @GetMapping("/{id}/receipts")
@@ -177,14 +129,8 @@ class InvoiceController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val receipts = invoiceService.getReceipts(id, orgId)
-            ResponseEntity.ok(receipts.map { it.toResponse() })
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Invoice not found")))
-        }
+        val receipts = invoiceService.getReceipts(id, orgId)
+        return ResponseEntity.ok(receipts.map { it.toResponse() })
     }
 
     @GetMapping("/aging")

--- a/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
@@ -41,7 +41,7 @@ class InvoiceController(
     fun createInvoice(
         @Valid @RequestBody request: CreateInvoiceRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -60,7 +60,7 @@ class InvoiceController(
         @RequestParam(required = false) status: String?,
         @RequestParam(required = false) customerId: String?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         val invoiceStatus =
             if (status != null) {
@@ -84,7 +84,7 @@ class InvoiceController(
     fun getInvoice(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val invoice = invoiceService.getInvoice(id, orgId)
@@ -101,7 +101,7 @@ class InvoiceController(
     fun approveInvoice(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -126,7 +126,7 @@ class InvoiceController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidInvoiceRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
@@ -151,7 +151,7 @@ class InvoiceController(
         @PathVariable id: String,
         @Valid @RequestBody request: RecordReceiptRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -175,7 +175,7 @@ class InvoiceController(
     fun listReceipts(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val receipts = invoiceService.getReceipts(id, orgId)
@@ -192,7 +192,7 @@ class InvoiceController(
     fun getAgingReport(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val report = invoiceService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
         return ResponseEntity.ok(report)
     }
@@ -256,9 +256,4 @@ class InvoiceController(
             createdBy = createdBy,
             createdAt = createdAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
@@ -2,18 +2,18 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.annotation.LogLevel
 import com.froilan.synectix.annotation.Loggable
-import com.froilan.synectix.dto.BillLineResponse
-import com.froilan.synectix.dto.BillPaymentResponse
-import com.froilan.synectix.dto.BillResponse
-import com.froilan.synectix.dto.BillSummaryResponse
-import com.froilan.synectix.dto.CreateBillRequest
-import com.froilan.synectix.dto.RecordPaymentRequest
-import com.froilan.synectix.dto.VoidBillRequest
-import com.froilan.synectix.model.Bill
-import com.froilan.synectix.model.BillPayment
-import com.froilan.synectix.model.BillStatus
+import com.froilan.synectix.dto.CreateInvoiceRequest
+import com.froilan.synectix.dto.InvoiceLineResponse
+import com.froilan.synectix.dto.InvoiceReceiptResponse
+import com.froilan.synectix.dto.InvoiceResponse
+import com.froilan.synectix.dto.InvoiceSummaryResponse
+import com.froilan.synectix.dto.RecordReceiptRequest
+import com.froilan.synectix.dto.VoidInvoiceRequest
+import com.froilan.synectix.model.Invoice
+import com.froilan.synectix.model.InvoiceReceipt
+import com.froilan.synectix.model.InvoiceStatus
 import com.froilan.synectix.security.AuthenticationContext
-import com.froilan.synectix.service.BillService
+import com.froilan.synectix.service.InvoiceService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -30,42 +30,42 @@ import java.time.ZoneOffset
 import java.util.Locale
 
 @RestController
-@RequestMapping("/finance/ap/bills")
+@RequestMapping("/finance/ar/invoices")
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
-class BillController(
-    private val billService: BillService,
+class InvoiceController(
+    private val invoiceService: InvoiceService,
     private val authContext: AuthenticationContext,
 ) {
     @PostMapping
-    @PreAuthorize("hasAuthority('ap:create')")
-    fun createBill(
-        @Valid @RequestBody request: CreateBillRequest,
+    @PreAuthorize("hasAuthority('ar:create')")
+    fun createInvoice(
+        @Valid @RequestBody request: CreateInvoiceRequest,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
-            val bill = billService.createBill(request, orgId, createdBy)
-            ResponseEntity.status(HttpStatus.CREATED).body(bill.toResponse())
+            val invoice = invoiceService.createInvoice(request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(invoice.toResponse())
         } catch (e: IllegalArgumentException) {
             ResponseEntity
                 .badRequest()
-                .body(mapOf("error" to (e.message ?: "Failed to create bill")))
+                .body(mapOf("error" to (e.message ?: "Failed to create invoice")))
         }
     }
 
     @GetMapping
-    @PreAuthorize("hasAuthority('ap:read')")
-    fun listBills(
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun listInvoices(
         @RequestParam(required = false) status: String?,
-        @RequestParam(required = false) vendorId: String?,
+        @RequestParam(required = false) customerId: String?,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return unauthorized()
 
-        val billStatus =
+        val invoiceStatus =
             if (status != null) {
                 try {
-                    BillStatus.valueOf(status.uppercase(Locale.ROOT))
+                    InvoiceStatus.valueOf(status.uppercase(Locale.ROOT))
                 } catch (e: IllegalArgumentException) {
                     return ResponseEntity
                         .badRequest()
@@ -75,134 +75,134 @@ class BillController(
                 null
             }
 
-        val bills = billService.listBills(orgId, billStatus, vendorId)
-        return ResponseEntity.ok(bills.map { it.toSummaryResponse() })
+        val invoices = invoiceService.listInvoices(orgId, invoiceStatus, customerId)
+        return ResponseEntity.ok(invoices.map { it.toSummaryResponse() })
     }
 
     @GetMapping("/{id}")
-    @PreAuthorize("hasAuthority('ap:read')")
-    fun getBill(
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun getInvoice(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
-            val bill = billService.getBill(id, orgId)
-            ResponseEntity.ok(bill.toResponse())
+            val invoice = invoiceService.getInvoice(id, orgId)
+            ResponseEntity.ok(invoice.toResponse())
         } catch (e: IllegalArgumentException) {
             ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Bill not found")))
+                .body(mapOf("error" to (e.message ?: "Invoice not found")))
         }
     }
 
     @PostMapping("/{id}/approve")
-    @PreAuthorize("hasAuthority('ap:approve')")
-    fun approveBill(
+    @PreAuthorize("hasAuthority('ar:approve')")
+    fun approveInvoice(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
-            val bill = billService.approveBill(id, orgId, userId)
-            ResponseEntity.ok(bill.toResponse())
+            val invoice = invoiceService.approveInvoice(id, orgId, userId)
+            ResponseEntity.ok(invoice.toResponse())
         } catch (e: IllegalArgumentException) {
             val status =
-                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
             ResponseEntity
                 .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
+                .body(mapOf("error" to (e.message ?: "Failed to approve invoice")))
         } catch (e: IllegalStateException) {
             ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to approve bill")))
+                .body(mapOf("error" to (e.message ?: "Failed to approve invoice")))
         }
     }
 
     @PostMapping("/{id}/void")
-    @PreAuthorize("hasAuthority('ap:void')")
-    fun voidBill(
+    @PreAuthorize("hasAuthority('ar:void')")
+    fun voidInvoice(
         @PathVariable id: String,
-        @Valid @RequestBody request: VoidBillRequest,
+        @Valid @RequestBody request: VoidInvoiceRequest,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return unauthorized()
         val userId = authContext.userId() ?: "api-key"
 
         return try {
-            val bill = billService.voidBill(id, orgId, request.reason, userId)
-            ResponseEntity.ok(bill.toResponse())
+            val invoice = invoiceService.voidInvoice(id, orgId, request.reason, userId)
+            ResponseEntity.ok(invoice.toResponse())
         } catch (e: IllegalArgumentException) {
             val status =
-                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
             ResponseEntity
                 .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to void bill")))
+                .body(mapOf("error" to (e.message ?: "Failed to void invoice")))
         } catch (e: IllegalStateException) {
             ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to void bill")))
+                .body(mapOf("error" to (e.message ?: "Failed to void invoice")))
         }
     }
 
-    @PostMapping("/{id}/payments")
-    @PreAuthorize("hasAuthority('ap:pay')")
-    fun recordPayment(
+    @PostMapping("/{id}/receipts")
+    @PreAuthorize("hasAuthority('ar:receive')")
+    fun recordReceipt(
         @PathVariable id: String,
-        @Valid @RequestBody request: RecordPaymentRequest,
+        @Valid @RequestBody request: RecordReceiptRequest,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
-            val payment = billService.recordPayment(id, request, orgId, createdBy)
-            ResponseEntity.status(HttpStatus.CREATED).body(payment.toResponse())
+            val receipt = invoiceService.recordReceipt(id, request, orgId, createdBy)
+            ResponseEntity.status(HttpStatus.CREATED).body(receipt.toResponse())
         } catch (e: IllegalArgumentException) {
             val status =
-                if (e.message == "Bill not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
+                if (e.message == "Invoice not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
             ResponseEntity
                 .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to record payment")))
+                .body(mapOf("error" to (e.message ?: "Failed to record receipt")))
         } catch (e: IllegalStateException) {
             ResponseEntity
                 .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(mapOf("error" to (e.message ?: "Failed to record payment")))
+                .body(mapOf("error" to (e.message ?: "Failed to record receipt")))
         }
     }
 
-    @GetMapping("/{id}/payments")
-    @PreAuthorize("hasAuthority('ap:read')")
-    fun listPayments(
+    @GetMapping("/{id}/receipts")
+    @PreAuthorize("hasAuthority('ar:read')")
+    fun listReceipts(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return unauthorized()
 
         return try {
-            val payments = billService.getPayments(id, orgId)
-            ResponseEntity.ok(payments.map { it.toResponse() })
+            val receipts = invoiceService.getReceipts(id, orgId)
+            ResponseEntity.ok(receipts.map { it.toResponse() })
         } catch (e: IllegalArgumentException) {
             ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Bill not found")))
+                .body(mapOf("error" to (e.message ?: "Invoice not found")))
         }
     }
 
     @GetMapping("/aging")
-    @PreAuthorize("hasAuthority('ap:read')")
+    @PreAuthorize("hasAuthority('ar:read')")
     fun getAgingReport(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return unauthorized()
-        val report = billService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
+        val report = invoiceService.getAgingReport(orgId, asOfDate ?: LocalDate.now(ZoneOffset.UTC))
         return ResponseEntity.ok(report)
     }
 
-    private fun Bill.toResponse() =
-        BillResponse(
+    private fun Invoice.toResponse() =
+        InvoiceResponse(
             id = id,
-            billNumber = billNumber,
-            vendorId = vendorId,
-            vendorName = vendorName,
+            invoiceNumber = invoiceNumber,
+            customerId = customerId,
+            customerName = customerName,
             date = date.toString(),
             dueDate = dueDate.toString(),
             referenceNumber = referenceNumber,
@@ -210,7 +210,7 @@ class BillController(
             status = status.name,
             lines =
                 lines.map { line ->
-                    BillLineResponse(
+                    InvoiceLineResponse(
                         accountId = line.accountId,
                         accountCode = line.accountCode,
                         accountName = line.accountName,
@@ -219,7 +219,7 @@ class BillController(
                     )
                 },
             totalAmount = totalAmount,
-            amountPaid = amountPaid,
+            amountReceived = amountReceived,
             journalEntryId = journalEntryId,
             createdBy = createdBy,
             approvedAt = approvedAt?.toString(),
@@ -232,23 +232,23 @@ class BillController(
             updatedAt = updatedAt?.toString(),
         )
 
-    private fun Bill.toSummaryResponse() =
-        BillSummaryResponse(
+    private fun Invoice.toSummaryResponse() =
+        InvoiceSummaryResponse(
             id = id,
-            billNumber = billNumber,
-            vendorName = vendorName,
+            invoiceNumber = invoiceNumber,
+            customerName = customerName,
             date = date.toString(),
             dueDate = dueDate.toString(),
             status = status.name,
             totalAmount = totalAmount,
-            amountPaid = amountPaid,
+            amountReceived = amountReceived,
         )
 
-    private fun BillPayment.toResponse() =
-        BillPaymentResponse(
+    private fun InvoiceReceipt.toResponse() =
+        InvoiceReceiptResponse(
             id = id,
-            billId = billId,
-            paymentDate = paymentDate.toString(),
+            invoiceId = invoiceId,
+            receiptDate = receiptDate.toString(),
             amount = amount,
             paymentMethod = paymentMethod.name,
             referenceNumber = referenceNumber,

--- a/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
@@ -36,7 +36,7 @@ class JournalEntryController(
     fun createJournalEntry(
         @Valid @RequestBody request: CreateJournalEntryRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
         return try {
@@ -54,7 +54,7 @@ class JournalEntryController(
         @RequestParam(required = false) startDate: LocalDate?,
         @RequestParam(required = false) endDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         val entryStatus =
             if (status != null) {
@@ -78,7 +78,7 @@ class JournalEntryController(
     fun getJournalEntry(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val entry = journalEntryService.getJournalEntry(id, orgId)
@@ -93,7 +93,7 @@ class JournalEntryController(
     fun postJournalEntry(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val entry = journalEntryService.postJournalEntry(id, orgId)
@@ -110,7 +110,7 @@ class JournalEntryController(
         @PathVariable id: String,
         @Valid @RequestBody request: VoidJournalEntryRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val entry = journalEntryService.voidJournalEntry(id, orgId, request.reason)
@@ -126,7 +126,7 @@ class JournalEntryController(
     fun getTrialBalance(
         @RequestParam(required = false) asOfDate: LocalDate?,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val trialBalance = journalEntryService.getTrialBalance(orgId, asOfDate)
         return ResponseEntity.ok(trialBalance)
     }
@@ -159,9 +159,4 @@ class JournalEntryController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/JournalEntryController.kt
@@ -39,12 +39,8 @@ class JournalEntryController(
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val createdBy = authContext.userId() ?: "api-key"
 
-        return try {
-            val entry = journalEntryService.createJournalEntry(request, orgId, createdBy)
-            ResponseEntity.status(HttpStatus.CREATED).body(entry.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create journal entry")))
-        }
+        val entry = journalEntryService.createJournalEntry(request, orgId, createdBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(entry.toResponse())
     }
 
     @GetMapping
@@ -80,12 +76,8 @@ class JournalEntryController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val entry = journalEntryService.getJournalEntry(id, orgId)
-            ResponseEntity.ok(entry.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to (e.message ?: "Journal entry not found")))
-        }
+        val entry = journalEntryService.getJournalEntry(id, orgId)
+        return ResponseEntity.ok(entry.toResponse())
     }
 
     @PostMapping("/{id}/post")
@@ -95,13 +87,8 @@ class JournalEntryController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val entry = journalEntryService.postJournalEntry(id, orgId)
-            ResponseEntity.ok(entry.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status = if (e.message == "Journal entry not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to post journal entry")))
-        }
+        val entry = journalEntryService.postJournalEntry(id, orgId)
+        return ResponseEntity.ok(entry.toResponse())
     }
 
     @PostMapping("/{id}/void")
@@ -112,13 +99,8 @@ class JournalEntryController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
-        return try {
-            val entry = journalEntryService.voidJournalEntry(id, orgId, request.reason)
-            ResponseEntity.ok(entry.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status = if (e.message == "Journal entry not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity.status(status).body(mapOf("error" to (e.message ?: "Failed to void journal entry")))
-        }
+        val entry = journalEntryService.voidJournalEntry(id, orgId, request.reason)
+        return ResponseEntity.ok(entry.toResponse())
     }
 
     @GetMapping("/trial-balance")

--- a/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.dto.SessionResponse
 import com.froilan.synectix.model.User
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/auth/sessions")
 class SessionController(
     private val authService: AuthService,
+    private val authContext: AuthenticationContext,
 ) {
     @GetMapping
     @PreAuthorize("hasRole('SUPER_ADMIN') or hasAuthority('session:read')")
@@ -26,7 +28,7 @@ class SessionController(
     ): ResponseEntity<Any> {
         val (user, currentToken) =
             extractUserAndToken(authHeader)
-                ?: return unauthorized()
+                ?: return authContext.unauthorized()
 
         val sessions = authService.listSessions(user.uuid)
         val response =
@@ -51,7 +53,7 @@ class SessionController(
     ): ResponseEntity<Any> {
         val (user, currentToken) =
             extractUserAndToken(authHeader)
-                ?: return unauthorized()
+                ?: return authContext.unauthorized()
 
         return try {
             authService.revokeSession(user.uuid, sessionId, currentToken)
@@ -74,7 +76,7 @@ class SessionController(
     ): ResponseEntity<Any> {
         val (user, currentToken) =
             extractUserAndToken(authHeader)
-                ?: return unauthorized()
+                ?: return authContext.unauthorized()
 
         authService.revokeOtherSessions(user.uuid, currentToken)
         return ResponseEntity.ok(mapOf("message" to "All other sessions revoked"))
@@ -90,9 +92,4 @@ class SessionController(
         if (!authHeader.startsWith("Bearer ")) return null
         return user to authHeader.substring(7)
     }
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/SessionController.kt
@@ -4,7 +4,6 @@ import com.froilan.synectix.dto.SessionResponse
 import com.froilan.synectix.model.User
 import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.service.AuthService
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
@@ -55,18 +54,8 @@ class SessionController(
             extractUserAndToken(authHeader)
                 ?: return authContext.unauthorized()
 
-        return try {
-            authService.revokeSession(user.uuid, sessionId, currentToken)
-            ResponseEntity.ok(mapOf("message" to "Session revoked"))
-        } catch (e: IllegalStateException) {
-            ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(mapOf("error" to (e.message ?: "Cannot revoke the current session")))
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Session not found")))
-        }
+        authService.revokeSession(user.uuid, sessionId, currentToken)
+        return ResponseEntity.ok(mapOf("message" to "Session revoked"))
     }
 
     @DeleteMapping

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -34,13 +34,8 @@ class VendorController(
         @Valid @RequestBody request: CreateVendorRequest,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
-
-        return try {
-            val vendor = vendorService.createVendor(request, orgId)
-            ResponseEntity.status(HttpStatus.CREATED).body(vendor.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity.badRequest().body(mapOf("error" to (e.message ?: "Failed to create vendor")))
-        }
+        val vendor = vendorService.createVendor(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(vendor.toResponse())
     }
 
     @GetMapping
@@ -57,15 +52,8 @@ class VendorController(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
-
-        return try {
-            val vendor = vendorService.getVendor(id, orgId)
-            ResponseEntity.ok(vendor.toResponse())
-        } catch (e: IllegalArgumentException) {
-            ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(mapOf("error" to (e.message ?: "Vendor not found")))
-        }
+        val vendor = vendorService.getVendor(id, orgId)
+        return ResponseEntity.ok(vendor.toResponse())
     }
 
     @PutMapping("/{id}")
@@ -75,17 +63,8 @@ class VendorController(
         @Valid @RequestBody request: UpdateVendorRequest,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
-
-        return try {
-            val vendor = vendorService.updateVendor(id, request, orgId)
-            ResponseEntity.ok(vendor.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Vendor not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to update vendor")))
-        }
+        val vendor = vendorService.updateVendor(id, request, orgId)
+        return ResponseEntity.ok(vendor.toResponse())
     }
 
     @DeleteMapping("/{id}")
@@ -94,17 +73,8 @@ class VendorController(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
-
-        return try {
-            val vendor = vendorService.deleteVendor(id, orgId)
-            ResponseEntity.ok(vendor.toResponse())
-        } catch (e: IllegalArgumentException) {
-            val status =
-                if (e.message == "Vendor not found") HttpStatus.NOT_FOUND else HttpStatus.BAD_REQUEST
-            ResponseEntity
-                .status(status)
-                .body(mapOf("error" to (e.message ?: "Failed to delete vendor")))
-        }
+        val vendor = vendorService.deleteVendor(id, orgId)
+        return ResponseEntity.ok(vendor.toResponse())
     }
 
     private fun Vendor.toResponse() =

--- a/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/VendorController.kt
@@ -33,7 +33,7 @@ class VendorController(
     fun createVendor(
         @Valid @RequestBody request: CreateVendorRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val vendor = vendorService.createVendor(request, orgId)
@@ -46,7 +46,7 @@ class VendorController(
     @GetMapping
     @PreAuthorize("hasAuthority('ap:read')")
     fun listVendors(): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         val vendors = vendorService.listVendors(orgId)
         return ResponseEntity.ok(vendors.map { it.toResponse() })
     }
@@ -56,7 +56,7 @@ class VendorController(
     fun getVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val vendor = vendorService.getVendor(id, orgId)
@@ -74,7 +74,7 @@ class VendorController(
         @PathVariable id: String,
         @Valid @RequestBody request: UpdateVendorRequest,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val vendor = vendorService.updateVendor(id, request, orgId)
@@ -93,7 +93,7 @@ class VendorController(
     fun deleteVendor(
         @PathVariable id: String,
     ): ResponseEntity<Any> {
-        val orgId = authContext.organizationId() ?: return unauthorized()
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
 
         return try {
             val vendor = vendorService.deleteVendor(id, orgId)
@@ -121,9 +121,4 @@ class VendorController(
             createdAt = createdAt?.toString(),
             updatedAt = updatedAt?.toString(),
         )
-
-    private fun unauthorized(): ResponseEntity<Any> =
-        ResponseEntity
-            .status(HttpStatus.UNAUTHORIZED)
-            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/dto/CustomerDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/CustomerDtos.kt
@@ -1,0 +1,42 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+data class CreateCustomerRequest(
+    @field:NotBlank(message = "Customer name is required")
+    val name: String,
+    val contactName: String? = null,
+    @field:Email(message = "Invalid email format")
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    @field:Min(value = 0, message = "Payment term days must be zero or positive")
+    val paymentTermDays: Int = 30,
+    val defaultRevenueAccountId: String? = null,
+)
+
+data class UpdateCustomerRequest(
+    val name: String? = null,
+    val contactName: String? = null,
+    @field:Email(message = "Invalid email format")
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    @field:Min(value = 0, message = "Payment term days must be zero or positive")
+    val paymentTermDays: Int? = null,
+    val defaultRevenueAccountId: String? = null,
+)
+
+data class CustomerResponse(
+    val id: String,
+    val name: String,
+    val contactName: String?,
+    val contactEmail: String?,
+    val contactPhone: String?,
+    val paymentTermDays: Int,
+    val defaultRevenueAccountId: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/dto/InvoiceDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InvoiceDtos.kt
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Positive
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class BillLineRequest(
+data class InvoiceLineRequest(
     @field:NotBlank(message = "Account ID is required")
     val accountId: String,
     @field:Positive(message = "Amount must be positive")
@@ -16,31 +16,31 @@ data class BillLineRequest(
     val description: String? = null,
 )
 
-data class CreateBillRequest(
-    @field:NotBlank(message = "Vendor ID is required")
-    val vendorId: String,
+data class CreateInvoiceRequest(
+    @field:NotBlank(message = "Customer ID is required")
+    val customerId: String,
     val date: LocalDate,
     val dueDate: LocalDate,
     val referenceNumber: String? = null,
     @field:NotEmpty(message = "At least one line item is required")
     @field:Valid
-    val lines: List<BillLineRequest>,
+    val lines: List<InvoiceLineRequest>,
 )
 
-data class VoidBillRequest(
+data class VoidInvoiceRequest(
     @field:NotBlank(message = "Void reason is required")
     val reason: String,
 )
 
-data class RecordPaymentRequest(
-    val paymentDate: LocalDate,
-    @field:Positive(message = "Payment amount must be positive")
+data class RecordReceiptRequest(
+    val receiptDate: LocalDate,
+    @field:Positive(message = "Receipt amount must be positive")
     val amount: BigDecimal,
     val paymentMethod: PaymentMethod,
     val referenceNumber: String? = null,
 )
 
-data class BillLineResponse(
+data class InvoiceLineResponse(
     val accountId: String,
     val accountCode: String,
     val accountName: String,
@@ -48,19 +48,19 @@ data class BillLineResponse(
     val description: String?,
 )
 
-data class BillResponse(
+data class InvoiceResponse(
     val id: String,
-    val billNumber: String,
-    val vendorId: String,
-    val vendorName: String,
+    val invoiceNumber: String,
+    val customerId: String,
+    val customerName: String,
     val date: String,
     val dueDate: String,
     val referenceNumber: String?,
     val organizationId: String,
     val status: String,
-    val lines: List<BillLineResponse>,
+    val lines: List<InvoiceLineResponse>,
     val totalAmount: BigDecimal,
-    val amountPaid: BigDecimal,
+    val amountReceived: BigDecimal,
     val journalEntryId: String?,
     val createdBy: String,
     val approvedAt: String?,
@@ -73,21 +73,21 @@ data class BillResponse(
     val updatedAt: String?,
 )
 
-data class BillSummaryResponse(
+data class InvoiceSummaryResponse(
     val id: String,
-    val billNumber: String,
-    val vendorName: String,
+    val invoiceNumber: String,
+    val customerName: String,
     val date: String,
     val dueDate: String,
     val status: String,
     val totalAmount: BigDecimal,
-    val amountPaid: BigDecimal,
+    val amountReceived: BigDecimal,
 )
 
-data class BillPaymentResponse(
+data class InvoiceReceiptResponse(
     val id: String,
-    val billId: String,
-    val paymentDate: String,
+    val invoiceId: String,
+    val receiptDate: String,
     val amount: BigDecimal,
     val paymentMethod: String,
     val referenceNumber: String?,
@@ -96,23 +96,14 @@ data class BillPaymentResponse(
     val createdAt: String?,
 )
 
-data class AgingBucket(
-    val current: BigDecimal,
-    val days1to30: BigDecimal,
-    val days31to60: BigDecimal,
-    val days61to90: BigDecimal,
-    val days90plus: BigDecimal,
-    val total: BigDecimal,
-)
-
-data class VendorAgingResponse(
-    val vendorId: String,
-    val vendorName: String,
+data class CustomerAgingResponse(
+    val customerId: String,
+    val customerName: String,
     val aging: AgingBucket,
 )
 
-data class ApAgingReportResponse(
+data class ArAgingReportResponse(
     val asOfDate: String,
-    val vendors: List<VendorAgingResponse>,
+    val customers: List<CustomerAgingResponse>,
     val totals: AgingBucket,
 )

--- a/src/main/kotlin/com/froilan/synectix/exception/AuthenticationException.kt
+++ b/src/main/kotlin/com/froilan/synectix/exception/AuthenticationException.kt
@@ -1,0 +1,5 @@
+package com.froilan.synectix.exception
+
+class AuthenticationException(
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/com/froilan/synectix/exception/BusinessRuleException.kt
+++ b/src/main/kotlin/com/froilan/synectix/exception/BusinessRuleException.kt
@@ -1,0 +1,6 @@
+package com.froilan.synectix.exception
+
+class BusinessRuleException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/src/main/kotlin/com/froilan/synectix/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/froilan/synectix/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,39 @@
+package com.froilan.synectix.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(ResourceNotFoundException::class)
+    fun handleNotFound(e: ResourceNotFoundException): ResponseEntity<Map<String, String>> =
+        ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(mapOf("error" to (e.message ?: "Resource not found")))
+
+    @ExceptionHandler(BusinessRuleException::class)
+    fun handleBusinessRule(e: BusinessRuleException): ResponseEntity<Map<String, String>> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(mapOf("error" to (e.message ?: "Invalid request")))
+
+    @ExceptionHandler(AuthenticationException::class)
+    fun handleAuthentication(e: AuthenticationException): ResponseEntity<Map<String, String>> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to (e.message ?: "Authentication failed")))
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleBadRequest(e: IllegalArgumentException): ResponseEntity<Map<String, String>> =
+        ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(mapOf("error" to (e.message ?: "Invalid request")))
+
+    @ExceptionHandler(IllegalStateException::class)
+    fun handleUnprocessable(e: IllegalStateException): ResponseEntity<Map<String, String>> =
+        ResponseEntity
+            .status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .body(mapOf("error" to (e.message ?: "Unable to process request")))
+}

--- a/src/main/kotlin/com/froilan/synectix/exception/ResourceNotFoundException.kt
+++ b/src/main/kotlin/com/froilan/synectix/exception/ResourceNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.froilan.synectix.exception
+
+class ResourceNotFoundException(
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/com/froilan/synectix/model/Customer.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Customer.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "customers")
+@CompoundIndex(
+    name = "unique_name_per_org",
+    def = "{'organizationId': 1, 'name': 1}",
+    unique = true,
+)
+data class Customer(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val contactName: String? = null,
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
+    val paymentTermDays: Int = 30,
+    val defaultRevenueAccountId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Invoice.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Invoice.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
-enum class BillStatus {
+enum class InvoiceStatus {
     DRAFT,
     APPROVED,
     PARTIALLY_PAID,
@@ -19,15 +19,7 @@ enum class BillStatus {
     VOID,
 }
 
-enum class PaymentMethod {
-    CASH,
-    CHECK,
-    BANK_TRANSFER,
-    CREDIT_CARD,
-    OTHER,
-}
-
-data class BillLine(
+data class InvoiceLine(
     val accountId: String,
     val accountCode: String,
     val accountName: String,
@@ -35,29 +27,29 @@ data class BillLine(
     val description: String? = null,
 )
 
-@Document(collection = "bills")
+@Document(collection = "invoices")
 @CompoundIndex(
-    name = "unique_bill_number_per_org",
-    def = "{'organizationId': 1, 'billNumber': 1}",
+    name = "unique_invoice_number_per_org",
+    def = "{'organizationId': 1, 'invoiceNumber': 1}",
     unique = true,
 )
 @CompoundIndex(name = "org_status", def = "{'organizationId': 1, 'status': 1}")
-@CompoundIndex(name = "org_vendor", def = "{'organizationId': 1, 'vendorId': 1}")
-data class Bill(
+@CompoundIndex(name = "org_customer", def = "{'organizationId': 1, 'customerId': 1}")
+data class Invoice(
     @Id
     val id: String = UUID.randomUUID().toString(),
-    val billNumber: String,
-    val vendorId: String,
-    val vendorName: String,
+    val invoiceNumber: String,
+    val customerId: String,
+    val customerName: String,
     val date: LocalDate,
     val dueDate: LocalDate,
     val referenceNumber: String? = null,
     @Indexed
     val organizationId: String,
-    val status: BillStatus = BillStatus.DRAFT,
-    val lines: List<BillLine>,
+    val status: InvoiceStatus = InvoiceStatus.DRAFT,
+    val lines: List<InvoiceLine>,
     val totalAmount: BigDecimal,
-    val amountPaid: BigDecimal = BigDecimal.ZERO,
+    val amountReceived: BigDecimal = BigDecimal.ZERO,
     val journalEntryId: String? = null,
     val createdBy: String,
     val approvedAt: LocalDateTime? = null,

--- a/src/main/kotlin/com/froilan/synectix/model/InvoiceReceipt.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/InvoiceReceipt.kt
@@ -1,0 +1,33 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "invoice_receipts")
+@CompoundIndex(
+    name = "org_invoice_receipt",
+    def = "{'organizationId': 1, 'invoiceId': 1}",
+)
+data class InvoiceReceipt(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    @Indexed
+    val invoiceId: String,
+    val receiptDate: LocalDate,
+    val amount: BigDecimal,
+    val paymentMethod: PaymentMethod,
+    val referenceNumber: String? = null,
+    val journalEntryId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val createdBy: String,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/CustomerRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/CustomerRepository.kt
@@ -1,0 +1,13 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Customer
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CustomerRepository : MongoRepository<Customer, String> {
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Customer>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/InvoiceReceiptRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvoiceReceiptRepository.kt
@@ -1,0 +1,15 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.InvoiceReceipt
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface InvoiceReceiptRepository : MongoRepository<InvoiceReceipt, String> {
+    fun findByInvoiceIdAndOrganizationId(
+        invoiceId: String,
+        organizationId: String,
+    ): List<InvoiceReceipt>
+
+    fun findByOrganizationId(organizationId: String): List<InvoiceReceipt>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/InvoiceRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InvoiceRepository.kt
@@ -1,0 +1,34 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Invoice
+import com.froilan.synectix.model.InvoiceStatus
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface InvoiceRepository : MongoRepository<Invoice, String> {
+    fun findByOrganizationId(organizationId: String): List<Invoice>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: InvoiceStatus,
+    ): List<Invoice>
+
+    fun findByOrganizationIdAndCustomerId(
+        organizationId: String,
+        customerId: String,
+    ): List<Invoice>
+
+    fun findByOrganizationIdAndStatusAndCustomerId(
+        organizationId: String,
+        status: InvoiceStatus,
+        customerId: String,
+    ): List<Invoice>
+
+    fun findByOrganizationIdAndStatusIn(
+        organizationId: String,
+        statuses: List<InvoiceStatus>,
+    ): List<Invoice>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/froilan/synectix/security/AuthenticationContext.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/AuthenticationContext.kt
@@ -1,6 +1,8 @@
 package com.froilan.synectix.security
 
 import com.froilan.synectix.model.User
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
@@ -19,4 +21,9 @@ class AuthenticationContext {
         val authentication = SecurityContextHolder.getContext().authentication ?: return null
         return (authentication.principal as? User)?.uuid
     }
+
+    fun unauthorized(): ResponseEntity<Any> =
+        ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(mapOf("error" to "Authentication required"))
 }

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -39,6 +39,12 @@ object Permissions {
     const val AP_PAY = "ap:pay"
     const val AP_VOID = "ap:void"
 
+    const val AR_CREATE = "ar:create"
+    const val AR_READ = "ar:read"
+    const val AR_APPROVE = "ar:approve"
+    const val AR_RECEIVE = "ar:receive"
+    const val AR_VOID = "ar:void"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -69,5 +75,10 @@ object Permissions {
             AP_APPROVE,
             AP_PAY,
             AP_VOID,
+            AR_CREATE,
+            AR_READ,
+            AR_APPROVE,
+            AR_RECEIVE,
+            AR_VOID,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateAccountRequest
 import com.froilan.synectix.dto.UpdateAccountRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.repository.AccountRepository
@@ -26,7 +28,7 @@ class AccountService(
             try {
                 AccountType.valueOf(request.type.uppercase(Locale.ROOT))
             } catch (e: IllegalArgumentException) {
-                throw IllegalArgumentException(
+                throw BusinessRuleException(
                     "Invalid account type '${request.type}'. Must be one of: ${AccountType.entries.joinToString()}",
                 )
             }
@@ -34,13 +36,13 @@ class AccountService(
         if (request.parentId != null) {
             val parent =
                 accountRepository.findById(request.parentId).orElseThrow {
-                    IllegalArgumentException("Parent account not found")
+                    BusinessRuleException("Parent account not found")
                 }
             if (parent.organizationId != organizationId) {
-                throw IllegalArgumentException("Parent account not found")
+                throw BusinessRuleException("Parent account not found")
             }
             if (parent.type != type) {
-                throw IllegalArgumentException("Parent account must be the same type")
+                throw BusinessRuleException("Parent account must be the same type")
             }
         }
 
@@ -56,7 +58,7 @@ class AccountService(
         return try {
             accountRepository.save(account)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException("Account code '${request.code}' already exists in this organization", e)
+            throw BusinessRuleException("Account code '${request.code}' already exists in this organization", e)
         }
     }
 
@@ -68,13 +70,13 @@ class AccountService(
     ): Account {
         val account =
             accountRepository.findById(accountId).orElseThrow {
-                IllegalArgumentException("Account not found")
+                ResourceNotFoundException("Account not found")
             }
         if (account.organizationId != organizationId) {
-            throw IllegalArgumentException("Account not found")
+            throw ResourceNotFoundException("Account not found")
         }
         if (request.name != null && request.name.isBlank()) {
-            throw IllegalArgumentException("Account name must not be blank")
+            throw BusinessRuleException("Account name must not be blank")
         }
 
         val updated =
@@ -91,10 +93,10 @@ class AccountService(
     ): Account {
         val account =
             accountRepository.findById(accountId).orElseThrow {
-                IllegalArgumentException("Account not found")
+                ResourceNotFoundException("Account not found")
             }
         if (account.organizationId != organizationId) {
-            throw IllegalArgumentException("Account not found")
+            throw ResourceNotFoundException("Account not found")
         }
         return account
     }
@@ -119,16 +121,16 @@ class AccountService(
     ) {
         val account =
             accountRepository.findById(accountId).orElseThrow {
-                IllegalArgumentException("Account not found")
+                ResourceNotFoundException("Account not found")
             }
         if (account.organizationId != organizationId) {
-            throw IllegalArgumentException("Account not found")
+            throw ResourceNotFoundException("Account not found")
         }
         if (account.isSystemAccount) {
-            throw IllegalArgumentException("System accounts cannot be deleted")
+            throw BusinessRuleException("System accounts cannot be deleted")
         }
         if (accountRepository.existsByOrganizationIdAndParentIdAndIsActive(organizationId, accountId, true)) {
-            throw IllegalArgumentException("Cannot delete account with child accounts")
+            throw BusinessRuleException("Cannot delete account with child accounts")
         }
         accountRepository.save(account.copy(isActive = false))
     }

--- a/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ApiKeyService.kt
@@ -1,5 +1,7 @@
 package com.froilan.synectix.service
 
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.ApiKey
 import com.froilan.synectix.repository.ApiKeyRepository
 import com.froilan.synectix.security.Permissions
@@ -30,14 +32,14 @@ class ApiKeyService(
     ): Pair<ApiKey, String> {
         val invalidPermissions = permissions.filter { it !in Permissions.ALL_PERMISSIONS }
         if (invalidPermissions.isNotEmpty()) {
-            throw IllegalArgumentException("Invalid permissions: ${invalidPermissions.joinToString()}")
+            throw BusinessRuleException("Invalid permissions: ${invalidPermissions.joinToString()}")
         }
         if (permissions.isEmpty()) {
-            throw IllegalArgumentException("At least one permission is required")
+            throw BusinessRuleException("At least one permission is required")
         }
         val escalatedPermissions = permissions.filter { it !in creatorPermissions }
         if (escalatedPermissions.isNotEmpty()) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Cannot grant permissions you do not have: ${escalatedPermissions.joinToString()}",
             )
         }
@@ -66,13 +68,13 @@ class ApiKeyService(
     ) {
         val apiKey =
             apiKeyRepository.findById(keyId).orElseThrow {
-                IllegalArgumentException("API key not found")
+                ResourceNotFoundException("API key not found")
             }
         if (apiKey.organizationId != organizationId) {
-            throw IllegalArgumentException("API key not found")
+            throw ResourceNotFoundException("API key not found")
         }
         if (!apiKey.isActive) {
-            throw IllegalArgumentException("API key is already revoked")
+            throw BusinessRuleException("API key is already revoked")
         }
         apiKeyRepository.save(apiKey.copy(isActive = false))
     }

--- a/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AuthService.kt
@@ -4,6 +4,9 @@ import com.froilan.synectix.dto.AuthResponse
 import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.dto.UserOrganizationResponse
+import com.froilan.synectix.exception.AuthenticationException
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Organizations
 import com.froilan.synectix.model.PasswordResetToken
 import com.froilan.synectix.model.RefreshToken
@@ -84,15 +87,15 @@ class AuthService(
             val errorMessage = e.message ?: ""
             when {
                 errorMessage.contains("username", ignoreCase = true) ->
-                    throw IllegalArgumentException("Username already exists", e)
+                    throw BusinessRuleException("Username already exists", e)
                 errorMessage.contains("email", ignoreCase = true) ->
-                    throw IllegalArgumentException("Email already exists", e)
+                    throw BusinessRuleException("Email already exists", e)
                 errorMessage.contains("orgSlug", ignoreCase = true) ->
-                    throw IllegalArgumentException("Organization slug already exists", e)
+                    throw BusinessRuleException("Organization slug already exists", e)
                 errorMessage.contains("name", ignoreCase = true) ->
-                    throw IllegalArgumentException("Organization name already exists", e)
+                    throw BusinessRuleException("Organization name already exists", e)
                 else ->
-                    throw IllegalArgumentException("Registration failed due to a conflict", e)
+                    throw BusinessRuleException("Registration failed due to a conflict", e)
             }
         }
     }
@@ -106,14 +109,14 @@ class AuthService(
         val user =
             userRepository
                 .findByUsername(request.username)
-                .orElseThrow { IllegalArgumentException("Invalid username or password") }
+                .orElseThrow { AuthenticationException("Invalid username or password") }
 
         if (!user.isActive) {
-            throw IllegalArgumentException("User account is inactive")
+            throw AuthenticationException("User account is inactive")
         }
 
         if (!passwordEncoder.matches(request.password, user.passwordHash)) {
-            throw IllegalArgumentException("Invalid username or password")
+            throw AuthenticationException("Invalid username or password")
         }
 
         val accessTokenStr = generateToken()
@@ -161,19 +164,19 @@ class AuthService(
         val existing =
             refreshTokenRepository
                 .findByTokenHash(refreshTokenHash)
-                .orElseThrow { IllegalArgumentException("Invalid or expired refresh token") }
+                .orElseThrow { AuthenticationException("Invalid or expired refresh token") }
 
         if (!existing.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
-            throw IllegalArgumentException("Invalid or expired refresh token")
+            throw AuthenticationException("Invalid or expired refresh token")
         }
 
         val user =
             userRepository
                 .findById(existing.userId)
-                .orElseThrow { IllegalArgumentException("Invalid or expired refresh token") }
+                .orElseThrow { AuthenticationException("Invalid or expired refresh token") }
 
         if (!user.isActive) {
-            throw IllegalArgumentException("User account is inactive")
+            throw AuthenticationException("User account is inactive")
         }
 
         val oldSession = sessionTokenRepository.findById(existing.sessionTokenId).orElse(null)
@@ -212,7 +215,7 @@ class AuthService(
         if (consumed == null) {
             refreshTokenRepository.deleteByTokenHash(newRefreshTokenHash)
             sessionTokenRepository.deleteById(savedSession.id)
-            throw IllegalArgumentException("Invalid or expired refresh token")
+            throw AuthenticationException("Invalid or expired refresh token")
         }
 
         sessionTokenRepository.deleteById(existing.sessionTokenId)
@@ -236,10 +239,10 @@ class AuthService(
         newPassword: String,
     ) {
         if (!passwordEncoder.matches(currentPassword, user.passwordHash)) {
-            throw IllegalArgumentException("Current password is incorrect")
+            throw BusinessRuleException("Current password is incorrect")
         }
         if (currentPassword == newPassword) {
-            throw IllegalArgumentException("New password must be different from current password")
+            throw BusinessRuleException("New password must be different from current password")
         }
         val updatedUser = user.copy(passwordHash = passwordEncoder.encode(newPassword) as String)
         userRepository.save(updatedUser)
@@ -281,23 +284,23 @@ class AuthService(
         val existing =
             passwordResetTokenRepository
                 .findByTokenHash(tokenHash)
-                .orElseThrow { IllegalArgumentException("Invalid or expired reset token") }
+                .orElseThrow { BusinessRuleException("Invalid or expired reset token") }
 
         if (!existing.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
             passwordResetTokenRepository.deleteById(existing.id)
-            throw IllegalArgumentException("Invalid or expired reset token")
+            throw BusinessRuleException("Invalid or expired reset token")
         }
 
         val resetToken =
             mongoTemplate.findAndRemove(
                 Query.query(Criteria.where("tokenHash").`is`(tokenHash)),
                 PasswordResetToken::class.java,
-            ) ?: throw IllegalArgumentException("Invalid or expired reset token")
+            ) ?: throw BusinessRuleException("Invalid or expired reset token")
 
         val user =
             userRepository
                 .findById(resetToken.userId)
-                .orElseThrow { IllegalArgumentException("Invalid or expired reset token") }
+                .orElseThrow { BusinessRuleException("Invalid or expired reset token") }
 
         val updatedUser = user.copy(passwordHash = passwordEncoder.encode(newPassword) as String)
         userRepository.save(updatedUser)
@@ -318,13 +321,13 @@ class AuthService(
     ) {
         val session =
             sessionTokenRepository.findById(sessionId).orElseThrow {
-                IllegalArgumentException("Session not found")
+                ResourceNotFoundException("Session not found")
             }
         if (session.userId != userId) {
-            throw IllegalArgumentException("Session not found")
+            throw ResourceNotFoundException("Session not found")
         }
         if (session.token == currentToken) {
-            throw IllegalStateException("Cannot revoke the current session")
+            throw BusinessRuleException("Cannot revoke the current session")
         }
         refreshTokenRepository.deleteBySessionTokenId(session.id)
         sessionTokenRepository.deleteById(session.id)
@@ -352,15 +355,15 @@ class AuthService(
     ): AuthResponse {
         val orgRoles = user.orgRoleNames(targetOrgId)
         if (orgRoles.isEmpty()) {
-            throw IllegalArgumentException("You do not have access to this organization")
+            throw BusinessRuleException("You do not have access to this organization")
         }
 
         val org =
             organizationRepository.findById(targetOrgId).orElseThrow {
-                IllegalArgumentException("Organization not found")
+                ResourceNotFoundException("Organization not found")
             }
         if (!org.isActive) {
-            throw IllegalArgumentException("Organization is not active")
+            throw BusinessRuleException("Organization is not active")
         }
 
         val accessTokenStr = generateToken()

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -5,6 +5,8 @@ import com.froilan.synectix.dto.ApAgingReportResponse
 import com.froilan.synectix.dto.CreateBillRequest
 import com.froilan.synectix.dto.RecordPaymentRequest
 import com.froilan.synectix.dto.VendorAgingResponse
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.Bill
 import com.froilan.synectix.model.BillLine
@@ -40,20 +42,20 @@ class BillService(
     ): Bill {
         val vendor = vendorService.getVendor(request.vendorId, organizationId)
         if (!vendor.isActive) {
-            throw IllegalArgumentException("Cannot create bill for inactive vendor")
+            throw BusinessRuleException("Cannot create bill for inactive vendor")
         }
 
         if (request.date.isAfter(request.dueDate)) {
-            throw IllegalArgumentException("Due date must be on or after bill date")
+            throw BusinessRuleException("Due date must be on or after bill date")
         }
 
         if (request.lines.isEmpty()) {
-            throw IllegalArgumentException("At least one line item is required")
+            throw BusinessRuleException("At least one line item is required")
         }
 
         request.lines.forEach { line ->
             if (line.amount <= BigDecimal.ZERO) {
-                throw IllegalArgumentException("Line item amounts must be positive")
+                throw BusinessRuleException("Line item amounts must be positive")
             }
         }
 
@@ -62,15 +64,15 @@ class BillService(
 
         val missingAccounts = accountIds.filter { it !in accounts }
         if (missingAccounts.isNotEmpty()) {
-            throw IllegalArgumentException("Accounts not found: ${missingAccounts.joinToString(", ")}")
+            throw BusinessRuleException("Accounts not found: ${missingAccounts.joinToString(", ")}")
         }
 
         accounts.values.forEach { account ->
             if (account.organizationId != organizationId) {
-                throw IllegalArgumentException("Account '${account.id}' not found")
+                throw BusinessRuleException("Account '${account.id}' not found")
             }
             if (!account.isActive) {
-                throw IllegalArgumentException("Account '${account.code}' is inactive")
+                throw BusinessRuleException("Account '${account.code}' is inactive")
             }
         }
 
@@ -110,10 +112,10 @@ class BillService(
     ): Bill {
         val bill =
             billRepository.findById(billId).orElseThrow {
-                IllegalArgumentException("Bill not found")
+                ResourceNotFoundException("Bill not found")
             }
         if (bill.organizationId != organizationId) {
-            throw IllegalArgumentException("Bill not found")
+            throw ResourceNotFoundException("Bill not found")
         }
         return bill
     }
@@ -143,7 +145,7 @@ class BillService(
         val bill = getBill(billId, organizationId)
 
         if (bill.status != BillStatus.DRAFT) {
-            throw IllegalArgumentException("Only draft bills can be approved")
+            throw BusinessRuleException("Only draft bills can be approved")
         }
 
         val apAccount = getApAccount(organizationId)
@@ -199,7 +201,7 @@ class BillService(
         val bill = getBill(billId, organizationId)
 
         if (bill.status == BillStatus.VOID) {
-            throw IllegalArgumentException("Bill is already voided")
+            throw BusinessRuleException("Bill is already voided")
         }
         val now = LocalDateTime.now(ZoneOffset.UTC)
 
@@ -215,7 +217,7 @@ class BillService(
             )
         }
         if (bill.amountPaid.compareTo(BigDecimal.ZERO) != 0) {
-            throw IllegalArgumentException("Cannot void a bill with recorded payments")
+            throw BusinessRuleException("Cannot void a bill with recorded payments")
         }
 
         if (bill.journalEntryId != null) {
@@ -246,16 +248,16 @@ class BillService(
         val bill = getBill(billId, organizationId)
 
         if (bill.status != BillStatus.APPROVED && bill.status != BillStatus.PARTIALLY_PAID) {
-            throw IllegalArgumentException("Bill must be approved or partially paid to record payment")
+            throw BusinessRuleException("Bill must be approved or partially paid to record payment")
         }
 
         if (request.amount <= BigDecimal.ZERO) {
-            throw IllegalArgumentException("Payment amount must be positive")
+            throw BusinessRuleException("Payment amount must be positive")
         }
 
         val remaining = bill.totalAmount.subtract(bill.amountPaid)
         if (request.amount.compareTo(remaining) > 0) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Payment amount exceeds remaining balance of $remaining",
             )
         }
@@ -434,7 +436,7 @@ class BillService(
                 IllegalStateException("Accounts Payable account (2000) not found")
             }
         if (!account.isActive) {
-            throw IllegalArgumentException("Accounts Payable account (2000) is inactive")
+            throw BusinessRuleException("Accounts Payable account (2000) is inactive")
         }
         return account
     }
@@ -445,7 +447,7 @@ class BillService(
                 IllegalStateException("Cash account (1000) not found")
             }
         if (!account.isActive) {
-            throw IllegalArgumentException("Cash account (1000) is inactive")
+            throw BusinessRuleException("Cash account (1000) is inactive")
         }
         return account
     }

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -209,6 +209,7 @@ class BillService(
                 bill.copy(
                     status = BillStatus.VOID,
                     voidedAt = now,
+                    voidedBy = voidedBy,
                     voidReason = reason,
                 ),
             )
@@ -229,6 +230,7 @@ class BillService(
             bill.copy(
                 status = BillStatus.VOID,
                 voidedAt = now,
+                voidedBy = voidedBy,
                 voidReason = reason,
             ),
         )

--- a/src/main/kotlin/com/froilan/synectix/service/CustomerService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/CustomerService.kt
@@ -1,0 +1,106 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateCustomerRequest
+import com.froilan.synectix.dto.UpdateCustomerRequest
+import com.froilan.synectix.model.Customer
+import com.froilan.synectix.repository.CustomerRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CustomerService(
+    private val customerRepository: CustomerRepository,
+) {
+    @Transactional
+    fun createCustomer(
+        request: CreateCustomerRequest,
+        organizationId: String,
+    ): Customer {
+        val customer =
+            Customer(
+                name = request.name,
+                contactName = request.contactName,
+                contactEmail = request.contactEmail,
+                contactPhone = request.contactPhone,
+                paymentTermDays = request.paymentTermDays,
+                defaultRevenueAccountId = request.defaultRevenueAccountId,
+                organizationId = organizationId,
+            )
+
+        return try {
+            customerRepository.save(customer)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Customer '${request.name}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    fun getCustomer(
+        customerId: String,
+        organizationId: String,
+    ): Customer {
+        val customer =
+            customerRepository.findById(customerId).orElseThrow {
+                IllegalArgumentException("Customer not found")
+            }
+        if (customer.organizationId != organizationId) {
+            throw IllegalArgumentException("Customer not found")
+        }
+        return customer
+    }
+
+    fun listCustomers(organizationId: String): List<Customer> = customerRepository.findByOrganizationIdAndIsActive(organizationId, true)
+
+    @Transactional
+    fun updateCustomer(
+        customerId: String,
+        request: UpdateCustomerRequest,
+        organizationId: String,
+    ): Customer {
+        val customer = getCustomer(customerId, organizationId)
+
+        if (!customer.isActive) {
+            throw IllegalArgumentException("Cannot update inactive customer")
+        }
+
+        if (request.name != null && request.name.isBlank()) {
+            throw IllegalArgumentException("Customer name cannot be blank")
+        }
+
+        val updated =
+            customer.copy(
+                name = request.name ?: customer.name,
+                contactName = request.contactName ?: customer.contactName,
+                contactEmail = request.contactEmail ?: customer.contactEmail,
+                contactPhone = request.contactPhone ?: customer.contactPhone,
+                paymentTermDays = request.paymentTermDays ?: customer.paymentTermDays,
+                defaultRevenueAccountId = request.defaultRevenueAccountId ?: customer.defaultRevenueAccountId,
+            )
+
+        return try {
+            customerRepository.save(updated)
+        } catch (e: DuplicateKeyException) {
+            throw IllegalArgumentException(
+                "Customer '${updated.name}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    @Transactional
+    fun deleteCustomer(
+        customerId: String,
+        organizationId: String,
+    ): Customer {
+        val customer = getCustomer(customerId, organizationId)
+
+        if (!customer.isActive) {
+            throw IllegalArgumentException("Customer is already inactive")
+        }
+
+        return customerRepository.save(customer.copy(isActive = false))
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/CustomerService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/CustomerService.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateCustomerRequest
 import com.froilan.synectix.dto.UpdateCustomerRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Customer
 import com.froilan.synectix.repository.CustomerRepository
 import org.springframework.dao.DuplicateKeyException
@@ -31,7 +33,7 @@ class CustomerService(
         return try {
             customerRepository.save(customer)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Customer '${request.name}' already exists in this organization",
                 e,
             )
@@ -44,10 +46,10 @@ class CustomerService(
     ): Customer {
         val customer =
             customerRepository.findById(customerId).orElseThrow {
-                IllegalArgumentException("Customer not found")
+                ResourceNotFoundException("Customer not found")
             }
         if (customer.organizationId != organizationId) {
-            throw IllegalArgumentException("Customer not found")
+            throw ResourceNotFoundException("Customer not found")
         }
         return customer
     }
@@ -63,11 +65,11 @@ class CustomerService(
         val customer = getCustomer(customerId, organizationId)
 
         if (!customer.isActive) {
-            throw IllegalArgumentException("Cannot update inactive customer")
+            throw BusinessRuleException("Cannot update inactive customer")
         }
 
         if (request.name != null && request.name.isBlank()) {
-            throw IllegalArgumentException("Customer name cannot be blank")
+            throw BusinessRuleException("Customer name cannot be blank")
         }
 
         val updated =
@@ -83,7 +85,7 @@ class CustomerService(
         return try {
             customerRepository.save(updated)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Customer '${updated.name}' already exists in this organization",
                 e,
             )
@@ -98,7 +100,7 @@ class CustomerService(
         val customer = getCustomer(customerId, organizationId)
 
         if (!customer.isActive) {
-            throw IllegalArgumentException("Customer is already inactive")
+            throw BusinessRuleException("Customer is already inactive")
         }
 
         return customerRepository.save(customer.copy(isActive = false))

--- a/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FiscalYearService.kt
@@ -1,6 +1,8 @@
 package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateFiscalYearRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.FiscalPeriod
 import com.froilan.synectix.model.FiscalPeriodStatus
@@ -36,21 +38,21 @@ class FiscalYearService(
         organizationId: String,
     ): FiscalYear {
         if (!request.startDate.isBefore(request.endDate)) {
-            throw IllegalArgumentException("Start date must be before end date")
+            throw BusinessRuleException("Start date must be before end date")
         }
 
         val existing = fiscalYearRepository.findByOrganizationId(organizationId)
 
         val activeFiscalYear = existing.firstOrNull { it.status == FiscalYearStatus.ACTIVE }
         if (activeFiscalYear != null) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "An active fiscal year '${activeFiscalYear.name}' already exists in this organization",
             )
         }
 
         existing.forEach { fy ->
             if (!request.startDate.isAfter(fy.endDate) && !request.endDate.isBefore(fy.startDate)) {
-                throw IllegalArgumentException(
+                throw BusinessRuleException(
                     "Date range overlaps with existing fiscal year '${fy.name}'",
                 )
             }
@@ -70,7 +72,7 @@ class FiscalYearService(
         return try {
             fiscalYearRepository.save(fiscalYear)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Fiscal year '${request.name}' already exists in this organization",
                 e,
             )
@@ -94,17 +96,17 @@ class FiscalYearService(
         val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
 
         if (fiscalYear.status == FiscalYearStatus.CLOSED) {
-            throw IllegalArgumentException("Fiscal year is already closed")
+            throw BusinessRuleException("Fiscal year is already closed")
         }
 
         val periodIndex = fiscalYear.periods.indexOfFirst { it.id == periodId }
         if (periodIndex == -1) {
-            throw IllegalArgumentException("Fiscal period not found")
+            throw ResourceNotFoundException("Fiscal period not found")
         }
 
         val period = fiscalYear.periods[periodIndex]
         if (period.status == FiscalPeriodStatus.CLOSED) {
-            throw IllegalArgumentException("Fiscal period is already closed")
+            throw BusinessRuleException("Fiscal period is already closed")
         }
 
         val precedingOpen =
@@ -112,7 +114,7 @@ class FiscalYearService(
                 .take(periodIndex)
                 .any { it.status != FiscalPeriodStatus.CLOSED }
         if (precedingOpen) {
-            throw IllegalArgumentException("All preceding periods must be closed first")
+            throw BusinessRuleException("All preceding periods must be closed first")
         }
 
         val updatedPeriods = fiscalYear.periods.toMutableList()
@@ -138,17 +140,17 @@ class FiscalYearService(
         val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
 
         if (fiscalYear.status == FiscalYearStatus.CLOSED) {
-            throw IllegalArgumentException("Cannot reopen period in a closed fiscal year")
+            throw BusinessRuleException("Cannot reopen period in a closed fiscal year")
         }
 
         val periodIndex = fiscalYear.periods.indexOfFirst { it.id == periodId }
         if (periodIndex == -1) {
-            throw IllegalArgumentException("Fiscal period not found")
+            throw ResourceNotFoundException("Fiscal period not found")
         }
 
         val period = fiscalYear.periods[periodIndex]
         if (period.status != FiscalPeriodStatus.CLOSED) {
-            throw IllegalArgumentException("Only closed periods can be reopened")
+            throw BusinessRuleException("Only closed periods can be reopened")
         }
 
         val subsequentOpen =
@@ -156,7 +158,7 @@ class FiscalYearService(
                 .drop(periodIndex + 1)
                 .any { it.status != FiscalPeriodStatus.CLOSED }
         if (subsequentOpen) {
-            throw IllegalArgumentException("All subsequent periods must be closed first")
+            throw BusinessRuleException("All subsequent periods must be closed first")
         }
 
         val updatedPeriods = fiscalYear.periods.toMutableList()
@@ -181,12 +183,12 @@ class FiscalYearService(
         val fiscalYear = findFiscalYear(fiscalYearId, organizationId)
 
         if (fiscalYear.status == FiscalYearStatus.CLOSED) {
-            throw IllegalArgumentException("Fiscal year is already closed")
+            throw BusinessRuleException("Fiscal year is already closed")
         }
 
         val allPeriodsClosed = fiscalYear.periods.all { it.status == FiscalPeriodStatus.CLOSED }
         if (!allPeriodsClosed) {
-            throw IllegalArgumentException("All periods must be closed before closing the fiscal year")
+            throw BusinessRuleException("All periods must be closed before closing the fiscal year")
         }
 
         val closingEntry = createClosingEntry(fiscalYear, organizationId, closedBy)
@@ -225,10 +227,10 @@ class FiscalYearService(
         when (val result = findPeriodForDate(organizationId, date)) {
             is PeriodLookupResult.NoFiscalYears -> return
             is PeriodLookupResult.NotFound ->
-                throw IllegalArgumentException("No fiscal period covers the date $date")
+                throw BusinessRuleException("No fiscal period covers the date $date")
             is PeriodLookupResult.Found -> {
                 if (result.period.status == FiscalPeriodStatus.CLOSED) {
-                    throw IllegalArgumentException("Fiscal period '${result.period.name}' is closed")
+                    throw BusinessRuleException("Fiscal period '${result.period.name}' is closed")
                 }
             }
         }
@@ -251,7 +253,7 @@ class FiscalYearService(
     ): JournalEntry? {
         val sourceRef = "YEAR-END-CLOSE-${fiscalYear.id}"
         if (journalEntryRepository.existsByOrganizationIdAndSourceReference(organizationId, sourceRef)) {
-            throw IllegalArgumentException("Year-end closing entry already exists for this fiscal year")
+            throw BusinessRuleException("Year-end closing entry already exists for this fiscal year")
         }
 
         val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
@@ -404,10 +406,10 @@ class FiscalYearService(
     ): FiscalYear {
         val fiscalYear =
             fiscalYearRepository.findById(fiscalYearId).orElseThrow {
-                IllegalArgumentException("Fiscal year not found")
+                ResourceNotFoundException("Fiscal year not found")
             }
         if (fiscalYear.organizationId != organizationId) {
-            throw IllegalArgumentException("Fiscal year not found")
+            throw ResourceNotFoundException("Fiscal year not found")
         }
         return fiscalYear
     }

--- a/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvitationService.kt
@@ -3,6 +3,8 @@ package com.froilan.synectix.service
 import com.froilan.synectix.dto.AcceptInvitationRequest
 import com.froilan.synectix.dto.CreateInvitationRequest
 import com.froilan.synectix.dto.ValidateInvitationResponse
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Invitation
 import com.froilan.synectix.model.InvitationStatus
 import com.froilan.synectix.model.RoleAssignment
@@ -47,10 +49,10 @@ class InvitationService(
 
         val role =
             roleRepository.findByName(request.role).orElseThrow {
-                IllegalArgumentException("Role '${request.role}' does not exist")
+                BusinessRuleException("Role '${request.role}' does not exist")
             }
         if (role.level != RoleLevel.ORGANIZATION) {
-            throw IllegalArgumentException("Cannot invite with system-level role")
+            throw BusinessRuleException("Cannot invite with system-level role")
         }
 
         val existing =
@@ -62,7 +64,7 @@ class InvitationService(
         if (existing.isPresent) {
             val pendingInvitation = existing.get()
             if (pendingInvitation.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
-                throw IllegalArgumentException("An invitation has already been sent to this email")
+                throw BusinessRuleException("An invitation has already been sent to this email")
             }
             invitationRepository.save(pendingInvitation.copy(status = InvitationStatus.EXPIRED))
         }
@@ -80,7 +82,7 @@ class InvitationService(
         try {
             invitationRepository.save(invitation)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException("An invitation has already been sent to this email", e)
+            throw BusinessRuleException("An invitation has already been sent to this email", e)
         }
 
         return rawToken
@@ -90,10 +92,10 @@ class InvitationService(
         val tokenHash = tokenHasher.hash(token)
         val invitation =
             invitationRepository.findByTokenHash(tokenHash).orElseThrow {
-                IllegalArgumentException("Invalid or expired invitation token")
+                BusinessRuleException("Invalid or expired invitation token")
             }
         if (invitation.status != InvitationStatus.PENDING || !invitation.expiryAt.isAfter(LocalDateTime.now(ZoneOffset.UTC))) {
-            throw IllegalArgumentException("Invalid or expired invitation token")
+            throw BusinessRuleException("Invalid or expired invitation token")
         }
         val existingUser = userRepository.findByEmail(invitation.email).isPresent
         return ValidateInvitationResponse(
@@ -122,7 +124,7 @@ class InvitationService(
                 Update.update("status", InvitationStatus.ACCEPTED),
                 FindAndModifyOptions.options().returnNew(true),
                 Invitation::class.java,
-            ) ?: throw IllegalArgumentException("Invalid or expired invitation token")
+            ) ?: throw BusinessRuleException("Invalid or expired invitation token")
 
         val existingUser = userRepository.findByEmail(accepted.email)
         if (existingUser.isPresent) {
@@ -151,7 +153,7 @@ class InvitationService(
             request.firstName.isNullOrBlank() ||
             request.lastName.isNullOrBlank()
         ) {
-            throw IllegalArgumentException("Username, password, first name, and last name are required for new users")
+            throw BusinessRuleException("Username, password, first name, and last name are required for new users")
         }
 
         val newUser =
@@ -176,11 +178,11 @@ class InvitationService(
             val errorMessage = e.message ?: ""
             when {
                 errorMessage.contains("username", ignoreCase = true) ->
-                    throw IllegalArgumentException("Username already exists", e)
+                    throw BusinessRuleException("Username already exists", e)
                 errorMessage.contains("email", ignoreCase = true) ->
-                    throw IllegalArgumentException("Email already exists", e)
+                    throw BusinessRuleException("Email already exists", e)
                 else ->
-                    throw IllegalArgumentException("Account could not be created", e)
+                    throw BusinessRuleException("Account could not be created", e)
             }
         }
     }
@@ -192,13 +194,13 @@ class InvitationService(
     ) {
         val invitation =
             invitationRepository.findById(invitationId).orElseThrow {
-                IllegalArgumentException("Invitation not found")
+                ResourceNotFoundException("Invitation not found")
             }
         if (invitation.organizationId != activeOrgId) {
-            throw IllegalArgumentException("Invitation not found")
+            throw ResourceNotFoundException("Invitation not found")
         }
         if (invitation.status != InvitationStatus.PENDING) {
-            throw IllegalArgumentException("Invitation is not pending")
+            throw BusinessRuleException("Invitation is not pending")
         }
         invitationRepository.save(invitation.copy(status = InvitationStatus.REVOKED))
     }

--- a/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
@@ -5,6 +5,8 @@ import com.froilan.synectix.dto.ArAgingReportResponse
 import com.froilan.synectix.dto.CreateInvoiceRequest
 import com.froilan.synectix.dto.CustomerAgingResponse
 import com.froilan.synectix.dto.RecordReceiptRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.Invoice
 import com.froilan.synectix.model.InvoiceLine
@@ -40,20 +42,20 @@ class InvoiceService(
     ): Invoice {
         val customer = customerService.getCustomer(request.customerId, organizationId)
         if (!customer.isActive) {
-            throw IllegalArgumentException("Cannot create invoice for inactive customer")
+            throw BusinessRuleException("Cannot create invoice for inactive customer")
         }
 
         if (request.date.isAfter(request.dueDate)) {
-            throw IllegalArgumentException("Due date must be on or after invoice date")
+            throw BusinessRuleException("Due date must be on or after invoice date")
         }
 
         if (request.lines.isEmpty()) {
-            throw IllegalArgumentException("At least one line item is required")
+            throw BusinessRuleException("At least one line item is required")
         }
 
         request.lines.forEach { line ->
             if (line.amount <= BigDecimal.ZERO) {
-                throw IllegalArgumentException("Line item amounts must be positive")
+                throw BusinessRuleException("Line item amounts must be positive")
             }
         }
 
@@ -62,15 +64,15 @@ class InvoiceService(
 
         val missingAccounts = accountIds.filter { it !in accounts }
         if (missingAccounts.isNotEmpty()) {
-            throw IllegalArgumentException("Accounts not found: ${missingAccounts.joinToString(", ")}")
+            throw BusinessRuleException("Accounts not found: ${missingAccounts.joinToString(", ")}")
         }
 
         accounts.values.forEach { account ->
             if (account.organizationId != organizationId) {
-                throw IllegalArgumentException("Account '${account.id}' not found")
+                throw BusinessRuleException("Account '${account.id}' not found")
             }
             if (!account.isActive) {
-                throw IllegalArgumentException("Account '${account.code}' is inactive")
+                throw BusinessRuleException("Account '${account.code}' is inactive")
             }
         }
 
@@ -110,10 +112,10 @@ class InvoiceService(
     ): Invoice {
         val invoice =
             invoiceRepository.findById(invoiceId).orElseThrow {
-                IllegalArgumentException("Invoice not found")
+                ResourceNotFoundException("Invoice not found")
             }
         if (invoice.organizationId != organizationId) {
-            throw IllegalArgumentException("Invoice not found")
+            throw ResourceNotFoundException("Invoice not found")
         }
         return invoice
     }
@@ -143,7 +145,7 @@ class InvoiceService(
         val invoice = getInvoice(invoiceId, organizationId)
 
         if (invoice.status != InvoiceStatus.DRAFT) {
-            throw IllegalArgumentException("Only draft invoices can be approved")
+            throw BusinessRuleException("Only draft invoices can be approved")
         }
 
         val arAccount = getArAccount(organizationId)
@@ -199,7 +201,7 @@ class InvoiceService(
         val invoice = getInvoice(invoiceId, organizationId)
 
         if (invoice.status == InvoiceStatus.VOID) {
-            throw IllegalArgumentException("Invoice is already voided")
+            throw BusinessRuleException("Invoice is already voided")
         }
 
         val now = LocalDateTime.now(ZoneOffset.UTC)
@@ -217,7 +219,7 @@ class InvoiceService(
         }
 
         if (invoice.amountReceived.compareTo(BigDecimal.ZERO) != 0) {
-            throw IllegalArgumentException("Cannot void an invoice with recorded receipts")
+            throw BusinessRuleException("Cannot void an invoice with recorded receipts")
         }
 
         if (invoice.journalEntryId != null) {
@@ -247,16 +249,16 @@ class InvoiceService(
         val invoice = getInvoice(invoiceId, organizationId)
 
         if (invoice.status != InvoiceStatus.APPROVED && invoice.status != InvoiceStatus.PARTIALLY_PAID) {
-            throw IllegalArgumentException("Invoice must be approved or partially paid to record receipt")
+            throw BusinessRuleException("Invoice must be approved or partially paid to record receipt")
         }
 
         if (request.amount <= BigDecimal.ZERO) {
-            throw IllegalArgumentException("Receipt amount must be positive")
+            throw BusinessRuleException("Receipt amount must be positive")
         }
 
         val remaining = invoice.totalAmount.subtract(invoice.amountReceived)
         if (request.amount.compareTo(remaining) > 0) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Receipt amount exceeds remaining balance of $remaining",
             )
         }
@@ -416,7 +418,7 @@ class InvoiceService(
                 IllegalStateException("Accounts Receivable account (1100) not found")
             }
         if (!account.isActive) {
-            throw IllegalArgumentException("Accounts Receivable account (1100) is inactive")
+            throw BusinessRuleException("Accounts Receivable account (1100) is inactive")
         }
         return account
     }
@@ -427,7 +429,7 @@ class InvoiceService(
                 IllegalStateException("Cash account (1000) not found")
             }
         if (!account.isActive) {
-            throw IllegalArgumentException("Cash account (1000) is inactive")
+            throw BusinessRuleException("Cash account (1000) is inactive")
         }
         return account
     }

--- a/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
@@ -234,6 +234,7 @@ class InvoiceService(
             invoice.copy(
                 status = InvoiceStatus.VOID,
                 voidedAt = now,
+                voidedBy = voidedBy,
                 voidReason = reason,
             ),
         )

--- a/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
@@ -1,0 +1,453 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AgingBucket
+import com.froilan.synectix.dto.ArAgingReportResponse
+import com.froilan.synectix.dto.CreateInvoiceRequest
+import com.froilan.synectix.dto.CustomerAgingResponse
+import com.froilan.synectix.dto.RecordReceiptRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.Invoice
+import com.froilan.synectix.model.InvoiceLine
+import com.froilan.synectix.model.InvoiceReceipt
+import com.froilan.synectix.model.InvoiceStatus
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.InvoiceReceiptRepository
+import com.froilan.synectix.repository.InvoiceRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+@Service
+class InvoiceService(
+    private val invoiceRepository: InvoiceRepository,
+    private val invoiceReceiptRepository: InvoiceReceiptRepository,
+    private val accountRepository: AccountRepository,
+    private val customerService: CustomerService,
+    private val journalEntryService: JournalEntryService,
+) {
+    @Transactional
+    fun createInvoice(
+        request: CreateInvoiceRequest,
+        organizationId: String,
+        createdBy: String,
+    ): Invoice {
+        val customer = customerService.getCustomer(request.customerId, organizationId)
+        if (!customer.isActive) {
+            throw IllegalArgumentException("Cannot create invoice for inactive customer")
+        }
+
+        if (request.date.isAfter(request.dueDate)) {
+            throw IllegalArgumentException("Due date must be on or after invoice date")
+        }
+
+        if (request.lines.isEmpty()) {
+            throw IllegalArgumentException("At least one line item is required")
+        }
+
+        request.lines.forEach { line ->
+            if (line.amount <= BigDecimal.ZERO) {
+                throw IllegalArgumentException("Line item amounts must be positive")
+            }
+        }
+
+        val accountIds = request.lines.map { it.accountId }.distinct()
+        val accounts = accountRepository.findAllById(accountIds).associateBy { it.id }
+
+        val missingAccounts = accountIds.filter { it !in accounts }
+        if (missingAccounts.isNotEmpty()) {
+            throw IllegalArgumentException("Accounts not found: ${missingAccounts.joinToString(", ")}")
+        }
+
+        accounts.values.forEach { account ->
+            if (account.organizationId != organizationId) {
+                throw IllegalArgumentException("Account '${account.id}' not found")
+            }
+            if (!account.isActive) {
+                throw IllegalArgumentException("Account '${account.code}' is inactive")
+            }
+        }
+
+        val lines =
+            request.lines.map { lineReq ->
+                val account = accounts.getValue(lineReq.accountId)
+                InvoiceLine(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    amount = lineReq.amount,
+                    description = lineReq.description,
+                )
+            }
+
+        val totalAmount = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.amount) }
+
+        return saveInvoiceWithRetry(organizationId) { invoiceNumber ->
+            Invoice(
+                invoiceNumber = invoiceNumber,
+                customerId = customer.id,
+                customerName = customer.name,
+                date = request.date,
+                dueDate = request.dueDate,
+                referenceNumber = request.referenceNumber,
+                organizationId = organizationId,
+                lines = lines,
+                totalAmount = totalAmount,
+                createdBy = createdBy,
+            )
+        }
+    }
+
+    fun getInvoice(
+        invoiceId: String,
+        organizationId: String,
+    ): Invoice {
+        val invoice =
+            invoiceRepository.findById(invoiceId).orElseThrow {
+                IllegalArgumentException("Invoice not found")
+            }
+        if (invoice.organizationId != organizationId) {
+            throw IllegalArgumentException("Invoice not found")
+        }
+        return invoice
+    }
+
+    fun listInvoices(
+        organizationId: String,
+        status: InvoiceStatus? = null,
+        customerId: String? = null,
+    ): List<Invoice> =
+        when {
+            status != null && customerId != null ->
+                invoiceRepository.findByOrganizationIdAndStatusAndCustomerId(organizationId, status, customerId)
+            status != null ->
+                invoiceRepository.findByOrganizationIdAndStatus(organizationId, status)
+            customerId != null ->
+                invoiceRepository.findByOrganizationIdAndCustomerId(organizationId, customerId)
+            else ->
+                invoiceRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun approveInvoice(
+        invoiceId: String,
+        organizationId: String,
+        approvedBy: String,
+    ): Invoice {
+        val invoice = getInvoice(invoiceId, organizationId)
+
+        if (invoice.status != InvoiceStatus.DRAFT) {
+            throw IllegalArgumentException("Only draft invoices can be approved")
+        }
+
+        val arAccount = getArAccount(organizationId)
+
+        val journalLines =
+            invoice.lines.map { line ->
+                JournalEntryLine(
+                    accountId = line.accountId,
+                    accountCode = line.accountCode,
+                    accountName = line.accountName,
+                    debit = BigDecimal.ZERO,
+                    credit = line.amount,
+                    description = line.description,
+                )
+            } +
+                JournalEntryLine(
+                    accountId = arAccount.id,
+                    accountCode = arAccount.code,
+                    accountName = arAccount.name,
+                    debit = invoice.totalAmount,
+                    credit = BigDecimal.ZERO,
+                    description = "AR - ${invoice.customerName} - ${invoice.invoiceNumber}",
+                )
+
+        val journalEntry =
+            journalEntryService.createSystemEntry(
+                date = invoice.date,
+                description = "Invoice ${invoice.invoiceNumber} - ${invoice.customerName}",
+                organizationId = organizationId,
+                lines = journalLines,
+                sourceReference = "INVOICE-APPROVE-${invoice.id}",
+                createdBy = approvedBy,
+            )
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        return invoiceRepository.save(
+            invoice.copy(
+                status = InvoiceStatus.APPROVED,
+                journalEntryId = journalEntry.id,
+                approvedAt = now,
+                approvedBy = approvedBy,
+            ),
+        )
+    }
+
+    @Transactional
+    fun voidInvoice(
+        invoiceId: String,
+        organizationId: String,
+        reason: String,
+        voidedBy: String,
+    ): Invoice {
+        val invoice = getInvoice(invoiceId, organizationId)
+
+        if (invoice.status == InvoiceStatus.VOID) {
+            throw IllegalArgumentException("Invoice is already voided")
+        }
+
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+
+        // Draft voids skip fiscal validation — no GL entries are posted
+        if (invoice.status == InvoiceStatus.DRAFT) {
+            return invoiceRepository.save(
+                invoice.copy(
+                    status = InvoiceStatus.VOID,
+                    voidedAt = now,
+                    voidedBy = voidedBy,
+                    voidReason = reason,
+                ),
+            )
+        }
+
+        if (invoice.amountReceived.compareTo(BigDecimal.ZERO) != 0) {
+            throw IllegalArgumentException("Cannot void an invoice with recorded receipts")
+        }
+
+        if (invoice.journalEntryId != null) {
+            journalEntryService.voidJournalEntry(
+                invoice.journalEntryId,
+                organizationId,
+                reason,
+            )
+        }
+
+        return invoiceRepository.save(
+            invoice.copy(
+                status = InvoiceStatus.VOID,
+                voidedAt = now,
+                voidReason = reason,
+            ),
+        )
+    }
+
+    @Transactional
+    fun recordReceipt(
+        invoiceId: String,
+        request: RecordReceiptRequest,
+        organizationId: String,
+        createdBy: String,
+    ): InvoiceReceipt {
+        val invoice = getInvoice(invoiceId, organizationId)
+
+        if (invoice.status != InvoiceStatus.APPROVED && invoice.status != InvoiceStatus.PARTIALLY_PAID) {
+            throw IllegalArgumentException("Invoice must be approved or partially paid to record receipt")
+        }
+
+        if (request.amount <= BigDecimal.ZERO) {
+            throw IllegalArgumentException("Receipt amount must be positive")
+        }
+
+        val remaining = invoice.totalAmount.subtract(invoice.amountReceived)
+        if (request.amount.compareTo(remaining) > 0) {
+            throw IllegalArgumentException(
+                "Receipt amount exceeds remaining balance of $remaining",
+            )
+        }
+
+        val arAccount = getArAccount(organizationId)
+        val cashAccount = getCashAccount(organizationId)
+
+        val receiptId = UUID.randomUUID().toString()
+
+        val journalEntry =
+            journalEntryService.createSystemEntry(
+                date = request.receiptDate,
+                description = "Receipt for invoice ${invoice.invoiceNumber} - ${invoice.customerName}",
+                organizationId = organizationId,
+                lines =
+                    listOf(
+                        JournalEntryLine(
+                            accountId = cashAccount.id,
+                            accountCode = cashAccount.code,
+                            accountName = cashAccount.name,
+                            debit = request.amount,
+                            credit = BigDecimal.ZERO,
+                            description = "Receipt - ${invoice.customerName}",
+                        ),
+                        JournalEntryLine(
+                            accountId = arAccount.id,
+                            accountCode = arAccount.code,
+                            accountName = arAccount.name,
+                            debit = BigDecimal.ZERO,
+                            credit = request.amount,
+                            description = "Receipt - ${invoice.customerName}",
+                        ),
+                    ),
+                sourceReference = "INVOICE-RECEIPT-$receiptId",
+                createdBy = createdBy,
+            )
+
+        val receipt =
+            invoiceReceiptRepository.save(
+                InvoiceReceipt(
+                    id = receiptId,
+                    invoiceId = invoice.id,
+                    receiptDate = request.receiptDate,
+                    amount = request.amount,
+                    paymentMethod = request.paymentMethod,
+                    referenceNumber = request.referenceNumber,
+                    journalEntryId = journalEntry.id,
+                    organizationId = organizationId,
+                    createdBy = createdBy,
+                ),
+            )
+
+        val newAmountReceived = invoice.amountReceived.add(request.amount)
+        val fullyPaid = newAmountReceived.compareTo(invoice.totalAmount) >= 0
+        val newStatus = if (fullyPaid) InvoiceStatus.PAID else InvoiceStatus.PARTIALLY_PAID
+
+        invoiceRepository.save(
+            invoice.copy(
+                amountReceived = newAmountReceived,
+                status = newStatus,
+                paidAt = if (fullyPaid) LocalDateTime.now(ZoneOffset.UTC) else null,
+            ),
+        )
+
+        return receipt
+    }
+
+    fun getReceipts(
+        invoiceId: String,
+        organizationId: String,
+    ): List<InvoiceReceipt> {
+        getInvoice(invoiceId, organizationId)
+        return invoiceReceiptRepository.findByInvoiceIdAndOrganizationId(invoiceId, organizationId)
+    }
+
+    fun getAgingReport(
+        organizationId: String,
+        asOfDate: LocalDate = LocalDate.now(ZoneOffset.UTC),
+    ): ArAgingReportResponse {
+        val outstandingStatuses =
+            listOf(InvoiceStatus.APPROVED, InvoiceStatus.PARTIALLY_PAID)
+        val invoices = invoiceRepository.findByOrganizationIdAndStatusIn(organizationId, outstandingStatuses)
+
+        val customerInvoices = invoices.groupBy { it.customerId }
+
+        val customerAgingList =
+            customerInvoices.map { (_, invoiceList) ->
+                val customerName = invoiceList.first().customerName
+                val customerId = invoiceList.first().customerId
+                val bucket = calculateAgingBucket(invoiceList, asOfDate)
+                CustomerAgingResponse(
+                    customerId = customerId,
+                    customerName = customerName,
+                    aging = bucket,
+                )
+            }
+
+        val totals =
+            AgingBucket(
+                current = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.current) },
+                days1to30 = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.days1to30) },
+                days31to60 = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.days31to60) },
+                days61to90 = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.days61to90) },
+                days90plus = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.days90plus) },
+                total = customerAgingList.fold(BigDecimal.ZERO) { sum, c -> sum.add(c.aging.total) },
+            )
+
+        return ArAgingReportResponse(
+            asOfDate = asOfDate.toString(),
+            customers = customerAgingList,
+            totals = totals,
+        )
+    }
+
+    private fun calculateAgingBucket(
+        invoices: List<Invoice>,
+        asOfDate: LocalDate,
+    ): AgingBucket {
+        var current = BigDecimal.ZERO
+        var days1to30 = BigDecimal.ZERO
+        var days31to60 = BigDecimal.ZERO
+        var days61to90 = BigDecimal.ZERO
+        var days90plus = BigDecimal.ZERO
+
+        invoices.forEach { invoice ->
+            val outstanding = invoice.totalAmount.subtract(invoice.amountReceived)
+            val daysOverdue = ChronoUnit.DAYS.between(invoice.dueDate, asOfDate)
+
+            when {
+                daysOverdue <= 0 -> current = current.add(outstanding)
+                daysOverdue <= 30 -> days1to30 = days1to30.add(outstanding)
+                daysOverdue <= 60 -> days31to60 = days31to60.add(outstanding)
+                daysOverdue <= 90 -> days61to90 = days61to90.add(outstanding)
+                else -> days90plus = days90plus.add(outstanding)
+            }
+        }
+
+        val total =
+            current
+                .add(days1to30)
+                .add(days31to60)
+                .add(days61to90)
+                .add(days90plus)
+        return AgingBucket(
+            current = current,
+            days1to30 = days1to30,
+            days31to60 = days31to60,
+            days61to90 = days61to90,
+            days90plus = days90plus,
+            total = total,
+        )
+    }
+
+    private fun getArAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "1100").orElseThrow {
+                IllegalStateException("Accounts Receivable account (1100) not found")
+            }
+        if (!account.isActive) {
+            throw IllegalArgumentException("Accounts Receivable account (1100) is inactive")
+        }
+        return account
+    }
+
+    private fun getCashAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "1000").orElseThrow {
+                IllegalStateException("Cash account (1000) not found")
+            }
+        if (!account.isActive) {
+            throw IllegalArgumentException("Cash account (1000) is inactive")
+        }
+        return account
+    }
+
+    private fun saveInvoiceWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        buildInvoice: (String) -> Invoice,
+    ): Invoice {
+        repeat(maxRetries) {
+            val count = invoiceRepository.countByOrganizationId(organizationId)
+            val invoiceNumber = "INV-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return invoiceRepository.save(buildInvoice(invoiceNumber))
+            } catch (e: DuplicateKeyException) {
+                if (it == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique invoice number: $invoiceNumber", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique invoice number")
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -3,6 +3,8 @@ package com.froilan.synectix.service
 import com.froilan.synectix.dto.AccountBalanceResponse
 import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.TrialBalanceResponse
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
@@ -31,27 +33,27 @@ class JournalEntryService(
         createdBy: String,
     ): JournalEntry {
         if (request.lines.size < 2) {
-            throw IllegalArgumentException("Journal entry must have at least 2 line items")
+            throw BusinessRuleException("Journal entry must have at least 2 line items")
         }
 
         request.lines.forEach { line ->
             if (line.debit.compareTo(BigDecimal.ZERO) < 0 || line.credit.compareTo(BigDecimal.ZERO) < 0) {
-                throw IllegalArgumentException("Debit and credit amounts must not be negative")
+                throw BusinessRuleException("Debit and credit amounts must not be negative")
             }
             val hasDebit = line.debit.compareTo(BigDecimal.ZERO) > 0
             val hasCredit = line.credit.compareTo(BigDecimal.ZERO) > 0
             if (hasDebit && hasCredit) {
-                throw IllegalArgumentException("A line item cannot have both debit and credit")
+                throw BusinessRuleException("A line item cannot have both debit and credit")
             }
             if (!hasDebit && !hasCredit) {
-                throw IllegalArgumentException("A line item must have either a debit or credit amount")
+                throw BusinessRuleException("A line item must have either a debit or credit amount")
             }
         }
 
         val totalDebits = request.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
         val totalCredits = request.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
         if (totalDebits.compareTo(totalCredits) != 0) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Journal entry must balance: debits ($totalDebits) != credits ($totalCredits)",
             )
         }
@@ -63,12 +65,12 @@ class JournalEntryService(
             request.lines.map { line ->
                 val account =
                     accounts[line.accountId]
-                        ?: throw IllegalArgumentException("Account '${line.accountId}' not found")
+                        ?: throw BusinessRuleException("Account '${line.accountId}' not found")
                 if (account.organizationId != organizationId) {
-                    throw IllegalArgumentException("Account '${line.accountId}' not found")
+                    throw BusinessRuleException("Account '${line.accountId}' not found")
                 }
                 if (!account.isActive) {
-                    throw IllegalArgumentException("Account '${account.code}' is inactive")
+                    throw BusinessRuleException("Account '${account.code}' is inactive")
                 }
                 JournalEntryLine(
                     accountId = account.id,
@@ -105,27 +107,27 @@ class JournalEntryService(
         createdBy: String,
     ): JournalEntry {
         if (lines.isEmpty()) {
-            throw IllegalArgumentException("System journal entry must have at least one line item")
+            throw BusinessRuleException("System journal entry must have at least one line item")
         }
 
         lines.forEach { line ->
             if (line.debit.compareTo(BigDecimal.ZERO) < 0 || line.credit.compareTo(BigDecimal.ZERO) < 0) {
-                throw IllegalArgumentException("Debit and credit amounts must not be negative")
+                throw BusinessRuleException("Debit and credit amounts must not be negative")
             }
             val hasDebit = line.debit.compareTo(BigDecimal.ZERO) > 0
             val hasCredit = line.credit.compareTo(BigDecimal.ZERO) > 0
             if (hasDebit && hasCredit) {
-                throw IllegalArgumentException("A line item cannot have both debit and credit")
+                throw BusinessRuleException("A line item cannot have both debit and credit")
             }
             if (!hasDebit && !hasCredit) {
-                throw IllegalArgumentException("A line item must have either a debit or credit amount")
+                throw BusinessRuleException("A line item must have either a debit or credit amount")
             }
         }
 
         val totalDebits = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
         val totalCredits = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
         if (totalDebits.compareTo(totalCredits) != 0) {
-            throw IllegalArgumentException("System journal entry is not balanced")
+            throw BusinessRuleException("System journal entry is not balanced")
         }
 
         validateFiscalPeriodOpen(organizationId, date)
@@ -154,13 +156,13 @@ class JournalEntryService(
     ): JournalEntry {
         val entry = findEntry(entryId, organizationId)
         if (entry.status != JournalEntryStatus.DRAFT) {
-            throw IllegalArgumentException("Only draft entries can be posted")
+            throw BusinessRuleException("Only draft entries can be posted")
         }
 
         val totalDebits = entry.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.debit) }
         val totalCredits = entry.lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.credit) }
         if (totalDebits.compareTo(totalCredits) != 0) {
-            throw IllegalArgumentException("Journal entry is not balanced")
+            throw BusinessRuleException("Journal entry is not balanced")
         }
 
         validateFiscalPeriodOpen(organizationId, entry.date)
@@ -181,7 +183,7 @@ class JournalEntryService(
     ): JournalEntry {
         val entry = findEntry(entryId, organizationId)
         if (entry.status != JournalEntryStatus.POSTED) {
-            throw IllegalArgumentException("Only posted entries can be voided")
+            throw BusinessRuleException("Only posted entries can be voided")
         }
 
         val reversalDate = LocalDate.now(ZoneOffset.UTC)
@@ -257,10 +259,10 @@ class JournalEntryService(
     ): AccountBalanceResponse {
         val account =
             accountRepository.findById(accountId).orElseThrow {
-                IllegalArgumentException("Account not found")
+                ResourceNotFoundException("Account not found")
             }
         if (account.organizationId != organizationId) {
-            throw IllegalArgumentException("Account not found")
+            throw ResourceNotFoundException("Account not found")
         }
 
         val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
@@ -371,10 +373,10 @@ class JournalEntryService(
     ): JournalEntry {
         val entry =
             journalEntryRepository.findById(entryId).orElseThrow {
-                IllegalArgumentException("Journal entry not found")
+                ResourceNotFoundException("Journal entry not found")
             }
         if (entry.organizationId != organizationId) {
-            throw IllegalArgumentException("Journal entry not found")
+            throw ResourceNotFoundException("Journal entry not found")
         }
         return entry
     }

--- a/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/VendorService.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateVendorRequest
 import com.froilan.synectix.dto.UpdateVendorRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Vendor
 import com.froilan.synectix.repository.VendorRepository
 import org.springframework.dao.DuplicateKeyException
@@ -31,7 +33,7 @@ class VendorService(
         return try {
             vendorRepository.save(vendor)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Vendor '${request.name}' already exists in this organization",
                 e,
             )
@@ -44,10 +46,10 @@ class VendorService(
     ): Vendor {
         val vendor =
             vendorRepository.findById(vendorId).orElseThrow {
-                IllegalArgumentException("Vendor not found")
+                ResourceNotFoundException("Vendor not found")
             }
         if (vendor.organizationId != organizationId) {
-            throw IllegalArgumentException("Vendor not found")
+            throw ResourceNotFoundException("Vendor not found")
         }
         return vendor
     }
@@ -63,11 +65,11 @@ class VendorService(
         val vendor = getVendor(vendorId, organizationId)
 
         if (!vendor.isActive) {
-            throw IllegalArgumentException("Cannot update inactive vendor")
+            throw BusinessRuleException("Cannot update inactive vendor")
         }
 
         if (request.name != null && request.name.isBlank()) {
-            throw IllegalArgumentException("Vendor name cannot be blank")
+            throw BusinessRuleException("Vendor name cannot be blank")
         }
 
         val updated =
@@ -83,7 +85,7 @@ class VendorService(
         return try {
             vendorRepository.save(updated)
         } catch (e: DuplicateKeyException) {
-            throw IllegalArgumentException(
+            throw BusinessRuleException(
                 "Vendor '${updated.name}' already exists in this organization",
                 e,
             )
@@ -98,7 +100,7 @@ class VendorService(
         val vendor = getVendor(vendorId, organizationId)
 
         if (!vendor.isActive) {
-            throw IllegalArgumentException("Vendor is already inactive")
+            throw BusinessRuleException("Vendor is already inactive")
         }
 
         return vendorRepository.save(vendor.copy(isActive = false))

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -81,6 +81,11 @@ class RoleSeederTest {
                         Permissions.AP_APPROVE,
                         Permissions.AP_PAY,
                         Permissions.AP_VOID,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
+                        Permissions.AR_APPROVE,
+                        Permissions.AR_RECEIVE,
+                        Permissions.AR_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -154,6 +159,11 @@ class RoleSeederTest {
                         Permissions.AP_APPROVE,
                         Permissions.AP_PAY,
                         Permissions.AP_VOID,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
+                        Permissions.AR_APPROVE,
+                        Permissions.AR_RECEIVE,
+                        Permissions.AR_VOID,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -254,6 +264,11 @@ class RoleSeederTest {
                         Permissions.AP_APPROVE,
                         Permissions.AP_PAY,
                         Permissions.AP_VOID,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
+                        Permissions.AR_APPROVE,
+                        Permissions.AR_RECEIVE,
+                        Permissions.AR_VOID,
                     ),
             )
         val admin =
@@ -285,6 +300,10 @@ class RoleSeederTest {
                         Permissions.AP_READ,
                         Permissions.AP_APPROVE,
                         Permissions.AP_PAY,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
+                        Permissions.AR_APPROVE,
+                        Permissions.AR_RECEIVE,
                     ),
             )
         val member =
@@ -305,6 +324,8 @@ class RoleSeederTest {
                         Permissions.FISCAL_READ,
                         Permissions.AP_CREATE,
                         Permissions.AP_READ,
+                        Permissions.AR_CREATE,
+                        Permissions.AR_READ,
                     ),
             )
         val viewer =
@@ -320,6 +341,7 @@ class RoleSeederTest {
                         Permissions.JOURNAL_READ,
                         Permissions.FISCAL_READ,
                         Permissions.AP_READ,
+                        Permissions.AR_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AccountControllerTest.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.aspect.LoggingAspect
 import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.RoleAssignment
@@ -158,7 +160,7 @@ class AccountControllerTest {
     @Test
     fun `POST accounts should return 400 when duplicate code`() {
         `when`(accountService.createAccount(any(), any()))
-            .thenThrow(IllegalArgumentException("Account with code '1000' already exists"))
+            .thenThrow(BusinessRuleException("Account with code '1000' already exists"))
 
         mockMvc
             .perform(
@@ -201,7 +203,7 @@ class AccountControllerTest {
     @Test
     fun `GET accounts by id should return 404 when not found`() {
         `when`(accountService.getAccount(any(), any()))
-            .thenThrow(IllegalArgumentException("Account not found"))
+            .thenThrow(ResourceNotFoundException("Account not found"))
 
         mockMvc
             .perform(get("/finance/accounts/nonexistent"))
@@ -235,7 +237,7 @@ class AccountControllerTest {
     @Test
     fun `DELETE accounts should return 400 for system account`() {
         `when`(accountService.deleteAccount(any(), any()))
-            .thenThrow(IllegalArgumentException("System accounts cannot be deleted"))
+            .thenThrow(BusinessRuleException("System accounts cannot be deleted"))
 
         mockMvc
             .perform(delete("/finance/accounts/acc-123"))

--- a/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ApiKeyControllerTest.kt
@@ -11,6 +11,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
@@ -70,6 +71,9 @@ class ApiKeyControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/AuthControllerTest.kt
@@ -6,6 +6,8 @@ import com.froilan.synectix.dto.AuthResponse
 import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RegisterRequest
 import com.froilan.synectix.dto.UserOrganizationResponse
+import com.froilan.synectix.exception.AuthenticationException
+import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.User
 import com.froilan.synectix.repository.OrganizationRepository
@@ -145,7 +147,7 @@ class AuthControllerTest {
             """.trimIndent()
 
         `when`(authService.register(any<RegisterRequest>()))
-            .thenThrow(IllegalArgumentException("Username already exists"))
+            .thenThrow(BusinessRuleException("Username already exists"))
 
         mockMvc
             .perform(
@@ -177,7 +179,7 @@ class AuthControllerTest {
             """.trimIndent()
 
         `when`(authService.register(any<RegisterRequest>()))
-            .thenThrow(IllegalArgumentException("Email already exists"))
+            .thenThrow(BusinessRuleException("Email already exists"))
 
         mockMvc
             .perform(
@@ -318,7 +320,7 @@ class AuthControllerTest {
             """.trimIndent()
 
         `when`(authService.login(any<LoginRequest>(), anyOrNull(), anyOrNull()))
-            .thenThrow(IllegalArgumentException("Invalid username or password"))
+            .thenThrow(AuthenticationException("Invalid username or password"))
 
         mockMvc
             .perform(
@@ -376,7 +378,7 @@ class AuthControllerTest {
             """.trimIndent()
 
         `when`(authService.login(any<LoginRequest>(), anyOrNull(), anyOrNull()))
-            .thenThrow(IllegalArgumentException("User account is inactive"))
+            .thenThrow(AuthenticationException("User account is inactive"))
 
         mockMvc
             .perform(
@@ -429,7 +431,7 @@ class AuthControllerTest {
             """.trimIndent()
 
         `when`(authService.refresh(any<String>()))
-            .thenThrow(IllegalArgumentException("Invalid or expired refresh token"))
+            .thenThrow(AuthenticationException("Invalid or expired refresh token"))
 
         mockMvc
             .perform(
@@ -607,7 +609,7 @@ class AuthControllerTest {
             """.trimIndent()
 
         `when`(authService.resetPassword(any<String>(), any<String>()))
-            .thenThrow(IllegalArgumentException("Invalid or expired reset token"))
+            .thenThrow(BusinessRuleException("Invalid or expired reset token"))
 
         mockMvc
             .perform(
@@ -734,7 +736,7 @@ class AuthControllerTest {
         setupAuth(user, session)
 
         `when`(authService.switchOrganization(any(), any(), anyOrNull(), anyOrNull()))
-            .thenThrow(IllegalArgumentException("You do not have access to this organization"))
+            .thenThrow(BusinessRuleException("You do not have access to this organization"))
 
         mockMvc
             .perform(

--- a/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InvitationControllerTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SessionContext
 import com.froilan.synectix.security.SynectixPermissionEvaluator
@@ -73,6 +74,9 @@ class InvitationControllerTest {
 
     @MockitoBean
     private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
 
     @MockitoBean
     private lateinit var apiKeyService: ApiKeyService

--- a/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/JournalEntryControllerTest.kt
@@ -4,6 +4,8 @@ import com.froilan.synectix.aspect.LoggingAspect
 import com.froilan.synectix.config.TestSecurityConfig
 import com.froilan.synectix.dto.AccountBalanceResponse
 import com.froilan.synectix.dto.TrialBalanceResponse
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
@@ -178,7 +180,7 @@ class JournalEntryControllerTest {
     @Test
     fun `POST journal-entries should return 400 when unbalanced`() {
         `when`(journalEntryService.createJournalEntry(any(), any(), any()))
-            .thenThrow(IllegalArgumentException("Journal entry must balance: debits (100.00) != credits (50.00)"))
+            .thenThrow(BusinessRuleException("Journal entry must balance: debits (100.00) != credits (50.00)"))
 
         mockMvc
             .perform(
@@ -233,7 +235,7 @@ class JournalEntryControllerTest {
     @Test
     fun `GET journal-entries by id should return 404 when not found`() {
         `when`(journalEntryService.getJournalEntry(any(), any()))
-            .thenThrow(IllegalArgumentException("Journal entry not found"))
+            .thenThrow(ResourceNotFoundException("Journal entry not found"))
 
         mockMvc
             .perform(get("/finance/journal/nonexistent"))

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.controller
 
 import com.froilan.synectix.aspect.LoggingAspect
 import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.RoleAssignment
 import com.froilan.synectix.model.SessionToken
 import com.froilan.synectix.model.User
@@ -164,7 +166,7 @@ class SessionControllerTest {
     @Test
     fun `DELETE session by id should return 404 for non-owned session`() {
         `when`(authService.revokeSession(any(), any(), any()))
-            .thenThrow(IllegalArgumentException("Session not found"))
+            .thenThrow(ResourceNotFoundException("Session not found"))
 
         mockMvc
             .perform(
@@ -177,7 +179,7 @@ class SessionControllerTest {
     @Test
     fun `DELETE session by id should return 400 when revoking the current session`() {
         `when`(authService.revokeSession(any(), any(), any()))
-            .thenThrow(IllegalStateException("Cannot revoke the current session"))
+            .thenThrow(BusinessRuleException("Cannot revoke the current session"))
 
         mockMvc
             .perform(

--- a/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/SessionControllerTest.kt
@@ -10,6 +10,7 @@ import com.froilan.synectix.repository.PasswordResetTokenRepository
 import com.froilan.synectix.repository.RefreshTokenRepository
 import com.froilan.synectix.repository.SessionTokenRepository
 import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
 import com.froilan.synectix.security.RolePermissionCache
 import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.ApiKeyService
@@ -72,6 +73,9 @@ class SessionControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
 
     private val testUser =
         User(

--- a/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/security/AuthenticationContextTest.kt
@@ -89,4 +89,14 @@ class AuthenticationContextTest {
 
         assertThat(authContext.userId()).isNull()
     }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `unauthorized should return 401 with error message`() {
+        val response = authContext.unauthorized()
+
+        assertThat(response.statusCode.value()).isEqualTo(401)
+        val body = response.body as Map<String, String>
+        assertThat(body["error"]).isEqualTo("Authentication required")
+    }
 }

--- a/src/test/kotlin/com/froilan/synectix/service/AccountServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AccountServiceTest.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateAccountRequest
 import com.froilan.synectix.dto.UpdateAccountRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.repository.AccountRepository
@@ -70,7 +72,7 @@ class AccountServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 accountService.createAccount(request, "org-123")
             }
         assertThat(exception.message).contains("Account code '1000' already exists")
@@ -88,7 +90,7 @@ class AccountServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 accountService.createAccount(request, "org-123")
             }
         assertThat(exception.message).contains("Invalid account type")
@@ -109,7 +111,7 @@ class AccountServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 accountService.createAccount(request, "org-123")
             }
         assertThat(exception.message).isEqualTo("Parent account not found")
@@ -135,7 +137,7 @@ class AccountServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 accountService.createAccount(request, "org-123")
             }
         assertThat(exception.message).isEqualTo("Parent account must be the same type")
@@ -161,7 +163,7 @@ class AccountServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 accountService.createAccount(request, "org-123")
             }
         assertThat(exception.message).isEqualTo("Parent account not found")
@@ -195,7 +197,7 @@ class AccountServiceTest {
         val request = UpdateAccountRequest(name = "New Name")
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 accountService.updateAccount("acc-999", request, "org-123")
             }
         assertThat(exception.message).isEqualTo("Account not found")
@@ -209,7 +211,7 @@ class AccountServiceTest {
         val request = UpdateAccountRequest(name = "New Name")
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 accountService.updateAccount("acc-1", request, "org-123")
             }
         assertThat(exception.message).isEqualTo("Account not found")
@@ -232,7 +234,7 @@ class AccountServiceTest {
         `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 accountService.getAccount("acc-1", "org-123")
             }
         assertThat(exception.message).isEqualTo("Account not found")
@@ -315,7 +317,7 @@ class AccountServiceTest {
         `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 accountService.deleteAccount("acc-1", "org-123")
             }
         assertThat(exception.message).isEqualTo("System accounts cannot be deleted")
@@ -328,7 +330,7 @@ class AccountServiceTest {
         `when`(accountRepository.existsByOrganizationIdAndParentIdAndIsActive("org-123", "acc-1", true)).thenReturn(true)
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 accountService.deleteAccount("acc-1", "org-123")
             }
         assertThat(exception.message).isEqualTo("Cannot delete account with child accounts")

--- a/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ApiKeyServiceTest.kt
@@ -1,5 +1,7 @@
 package com.froilan.synectix.service
 
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.ApiKey
 import com.froilan.synectix.repository.ApiKeyRepository
 import com.froilan.synectix.util.TokenHasher
@@ -68,7 +70,7 @@ class ApiKeyServiceTest {
     @Test
     fun `createApiKey should throw when permissions are invalid`() {
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 apiKeyService.createApiKey(
                     name = "Bad Key",
                     permissions = listOf("session:read", "nonexistent:permission"),
@@ -83,7 +85,7 @@ class ApiKeyServiceTest {
     @Test
     fun `createApiKey should throw when permissions are empty`() {
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 apiKeyService.createApiKey(
                     name = "Empty Key",
                     permissions = emptyList(),
@@ -98,7 +100,7 @@ class ApiKeyServiceTest {
     @Test
     fun `createApiKey should throw when requesting permissions creator does not have`() {
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 apiKeyService.createApiKey(
                     name = "Escalated Key",
                     permissions = listOf("session:read", "user:delete"),
@@ -179,7 +181,7 @@ class ApiKeyServiceTest {
         `when`(apiKeyRepository.findById(apiKey.id)).thenReturn(Optional.of(apiKey))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 apiKeyService.revokeApiKey(apiKey.id, "org-123")
             }
         assertThat(exception.message).isEqualTo("API key not found")
@@ -191,7 +193,7 @@ class ApiKeyServiceTest {
         `when`(apiKeyRepository.findById(apiKey.id)).thenReturn(Optional.of(apiKey))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 apiKeyService.revokeApiKey(apiKey.id, "org-123")
             }
         assertThat(exception.message).isEqualTo("API key is already revoked")

--- a/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AuthServiceTest.kt
@@ -2,6 +2,9 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.LoginRequest
 import com.froilan.synectix.dto.RegisterRequest
+import com.froilan.synectix.exception.AuthenticationException
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Organizations
 import com.froilan.synectix.model.PasswordResetToken
 import com.froilan.synectix.model.RefreshToken
@@ -137,7 +140,7 @@ class AuthServiceTest {
             .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.users index: username"))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.register(request)
             }
         assertThat(exception.message).isEqualTo("Username already exists")
@@ -153,7 +156,7 @@ class AuthServiceTest {
             .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.users index: email"))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.register(request)
             }
         assertThat(exception.message).isEqualTo("Email already exists")
@@ -166,7 +169,7 @@ class AuthServiceTest {
             .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.organizations index: orgSlug"))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.register(request)
             }
         assertThat(exception.message).isEqualTo("Organization slug already exists")
@@ -180,7 +183,7 @@ class AuthServiceTest {
             .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.organizations index: name"))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.register(request)
             }
         assertThat(exception.message).isEqualTo("Organization name already exists")
@@ -268,7 +271,7 @@ class AuthServiceTest {
         `when`(userRepository.findByUsername(request.username)).thenReturn(Optional.empty())
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<AuthenticationException> {
                 authService.login(request)
             }
         assertThat(exception.message).isEqualTo("Invalid username or password")
@@ -283,7 +286,7 @@ class AuthServiceTest {
         `when`(passwordEncoder.matches(request.password, user.passwordHash)).thenReturn(false)
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<AuthenticationException> {
                 authService.login(request)
             }
         assertThat(exception.message).isEqualTo("Invalid username or password")
@@ -338,7 +341,7 @@ class AuthServiceTest {
         `when`(userRepository.findByUsername(request.username)).thenReturn(Optional.of(inactiveUser))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<AuthenticationException> {
                 authService.login(request)
             }
         assertThat(exception.message).isEqualTo("User account is inactive")
@@ -390,7 +393,7 @@ class AuthServiceTest {
         `when`(refreshTokenRepository.findByTokenHash(expiredTokenHash)).thenReturn(Optional.of(expiredRefreshToken))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<AuthenticationException> {
                 authService.refresh(expiredTokenStr)
             }
         assertThat(exception.message).isEqualTo("Invalid or expired refresh token")
@@ -404,7 +407,7 @@ class AuthServiceTest {
         `when`(refreshTokenRepository.findByTokenHash(invalidTokenHash)).thenReturn(Optional.empty())
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<AuthenticationException> {
                 authService.refresh(invalidTokenStr)
             }
         assertThat(exception.message).isEqualTo("Invalid or expired refresh token")
@@ -427,7 +430,7 @@ class AuthServiceTest {
         `when`(userRepository.findById(inactiveUser.uuid)).thenReturn(Optional.of(inactiveUser))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<AuthenticationException> {
                 authService.refresh(refreshTokenStr)
             }
         assertThat(exception.message).isEqualTo("User account is inactive")
@@ -493,7 +496,7 @@ class AuthServiceTest {
         `when`(sessionTokenRepository.findById("s1")).thenReturn(Optional.of(session))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 authService.revokeSession("user-123", "s1", "other-token")
             }
         assertThat(exception.message).isEqualTo("Session not found")
@@ -509,7 +512,7 @@ class AuthServiceTest {
         `when`(sessionTokenRepository.findById("s1")).thenReturn(Optional.of(session))
 
         val exception =
-            assertThrows<IllegalStateException> {
+            assertThrows<BusinessRuleException> {
                 authService.revokeSession(userId, "s1", currentToken)
             }
         assertThat(exception.message).isEqualTo("Cannot revoke the current session")
@@ -553,7 +556,7 @@ class AuthServiceTest {
         `when`(passwordEncoder.matches("wrongPass", user.passwordHash)).thenReturn(false)
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.changePassword(user, "wrongPass", "NewSecurePass123!")
             }
         assertThat(exception.message).isEqualTo("Current password is incorrect")
@@ -565,7 +568,7 @@ class AuthServiceTest {
         `when`(passwordEncoder.matches("samePass", user.passwordHash)).thenReturn(true)
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.changePassword(user, "samePass", "samePass")
             }
         assertThat(exception.message).isEqualTo("New password must be different from current password")
@@ -633,7 +636,7 @@ class AuthServiceTest {
         `when`(passwordResetTokenRepository.findByTokenHash(any())).thenReturn(Optional.empty())
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.resetPassword("invalid-token", "NewPassword123!")
             }
         assertThat(exception.message).isEqualTo("Invalid or expired reset token")
@@ -652,7 +655,7 @@ class AuthServiceTest {
             .thenReturn(Optional.of(expiredToken))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.resetPassword("expired-token", "NewPassword123!")
             }
         assertThat(exception.message).isEqualTo("Invalid or expired reset token")
@@ -710,7 +713,7 @@ class AuthServiceTest {
         val user = createMockUser()
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.switchOrganization(user, "org-999")
             }
         assertThat(exception.message).isEqualTo("You do not have access to this organization")
@@ -730,7 +733,7 @@ class AuthServiceTest {
         `when`(organizationRepository.findById("org-missing")).thenReturn(Optional.empty())
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 authService.switchOrganization(user, "org-missing")
             }
         assertThat(exception.message).isEqualTo("Organization not found")
@@ -751,7 +754,7 @@ class AuthServiceTest {
         `when`(organizationRepository.findById("org-inactive")).thenReturn(Optional.of(inactiveOrg))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 authService.switchOrganization(user, "org-inactive")
             }
         assertThat(exception.message).isEqualTo("Organization is not active")

--- a/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
@@ -3,6 +3,7 @@ package com.froilan.synectix.service
 import com.froilan.synectix.dto.BillLineRequest
 import com.froilan.synectix.dto.CreateBillRequest
 import com.froilan.synectix.dto.RecordPaymentRequest
+import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.Bill
@@ -107,7 +108,7 @@ class BillServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 billService.createBill(request, orgId, userId)
             }
         assertThat(exception.message).contains("inactive vendor")
@@ -151,7 +152,7 @@ class BillServiceTest {
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 billService.approveBill("bill-1", orgId, userId)
             }
         assertThat(exception.message).contains("Only draft")
@@ -205,7 +206,7 @@ class BillServiceTest {
         `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 billService.voidBill("bill-1", orgId, "Cancel", userId)
             }
         assertThat(exception.message).contains("recorded payments")
@@ -291,7 +292,7 @@ class BillServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 billService.recordPayment("bill-1", request, orgId, userId)
             }
         assertThat(exception.message).contains("exceeds remaining balance")
@@ -310,7 +311,7 @@ class BillServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 billService.recordPayment("bill-1", request, orgId, userId)
             }
         assertThat(exception.message).contains("approved or partially paid")

--- a/src/test/kotlin/com/froilan/synectix/service/CustomerServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/CustomerServiceTest.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateCustomerRequest
 import com.froilan.synectix.dto.UpdateCustomerRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Customer
 import com.froilan.synectix.repository.CustomerRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -64,7 +66,7 @@ class CustomerServiceTest {
         `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 customerService.getCustomer("c-1", orgId)
             }
         assertThat(exception.message).contains("Customer not found")
@@ -98,7 +100,7 @@ class CustomerServiceTest {
         `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 customerService.updateCustomer("c-1", UpdateCustomerRequest(name = "New"), orgId)
             }
         assertThat(exception.message).contains("inactive")
@@ -110,7 +112,7 @@ class CustomerServiceTest {
         `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 customerService.updateCustomer("c-1", UpdateCustomerRequest(name = "  "), orgId)
             }
         assertThat(exception.message).contains("blank")
@@ -136,7 +138,7 @@ class CustomerServiceTest {
         `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 customerService.deleteCustomer("c-1", orgId)
             }
         assertThat(exception.message).contains("already inactive")

--- a/src/test/kotlin/com/froilan/synectix/service/CustomerServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/CustomerServiceTest.kt
@@ -1,0 +1,159 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateCustomerRequest
+import com.froilan.synectix.dto.UpdateCustomerRequest
+import com.froilan.synectix.model.Customer
+import com.froilan.synectix.repository.CustomerRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.util.Optional
+
+class CustomerServiceTest {
+    private lateinit var customerService: CustomerService
+    private lateinit var customerRepository: CustomerRepository
+
+    private val orgId = "org-123"
+
+    @BeforeEach
+    fun setup() {
+        customerRepository = mock(CustomerRepository::class.java)
+        customerService = CustomerService(customerRepository)
+    }
+
+    @Test
+    fun `create should save customer with correct fields`() {
+        `when`(customerRepository.save(any<Customer>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateCustomerRequest(
+                name = "BigCorp",
+                contactName = "Jane Doe",
+                contactEmail = "jane@bigcorp.com",
+                paymentTermDays = 45,
+            )
+
+        val result = customerService.createCustomer(request, orgId)
+
+        assertThat(result.name).isEqualTo("BigCorp")
+        assertThat(result.contactName).isEqualTo("Jane Doe")
+        assertThat(result.contactEmail).isEqualTo("jane@bigcorp.com")
+        assertThat(result.paymentTermDays).isEqualTo(45)
+        assertThat(result.organizationId).isEqualTo(orgId)
+        assertThat(result.isActive).isTrue()
+    }
+
+    @Test
+    fun `get should return customer for correct org`() {
+        val customer = createCustomer()
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val result = customerService.getCustomer("c-1", orgId)
+        assertThat(result.id).isEqualTo("c-1")
+    }
+
+    @Test
+    fun `get should throw when customer belongs to different org`() {
+        val customer = createCustomer(orgId = "other-org")
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                customerService.getCustomer("c-1", orgId)
+            }
+        assertThat(exception.message).contains("Customer not found")
+    }
+
+    @Test
+    fun `list should return active customers`() {
+        val customers = listOf(createCustomer(), createCustomer(id = "c-2", name = "SmallCo"))
+        `when`(customerRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(customers)
+
+        val result = customerService.listCustomers(orgId)
+        assertThat(result).hasSize(2)
+    }
+
+    @Test
+    fun `update should apply partial changes`() {
+        val customer = createCustomer()
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+        `when`(customerRepository.save(any<Customer>())).thenAnswer { it.arguments[0] }
+
+        val request = UpdateCustomerRequest(name = "Updated Corp")
+        val result = customerService.updateCustomer("c-1", request, orgId)
+
+        assertThat(result.name).isEqualTo("Updated Corp")
+        assertThat(result.contactName).isEqualTo("Jane Doe")
+    }
+
+    @Test
+    fun `update should reject inactive customer`() {
+        val customer = createCustomer(isActive = false)
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                customerService.updateCustomer("c-1", UpdateCustomerRequest(name = "New"), orgId)
+            }
+        assertThat(exception.message).contains("inactive")
+    }
+
+    @Test
+    fun `update should reject blank name`() {
+        val customer = createCustomer()
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                customerService.updateCustomer("c-1", UpdateCustomerRequest(name = "  "), orgId)
+            }
+        assertThat(exception.message).contains("blank")
+    }
+
+    @Test
+    fun `delete should soft delete customer`() {
+        val customer = createCustomer()
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+        `when`(customerRepository.save(any<Customer>())).thenAnswer { it.arguments[0] }
+
+        val result = customerService.deleteCustomer("c-1", orgId)
+
+        assertThat(result.isActive).isFalse()
+        val captor = argumentCaptor<Customer>()
+        verify(customerRepository).save(captor.capture())
+        assertThat(captor.firstValue.isActive).isFalse()
+    }
+
+    @Test
+    fun `delete should reject already inactive customer`() {
+        val customer = createCustomer(isActive = false)
+        `when`(customerRepository.findById("c-1")).thenReturn(Optional.of(customer))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                customerService.deleteCustomer("c-1", orgId)
+            }
+        assertThat(exception.message).contains("already inactive")
+    }
+
+    private fun createCustomer(
+        id: String = "c-1",
+        name: String = "BigCorp",
+        orgId: String = this.orgId,
+        isActive: Boolean = true,
+    ) = Customer(
+        id = id,
+        name = name,
+        contactName = "Jane Doe",
+        contactEmail = "jane@bigcorp.com",
+        paymentTermDays = 30,
+        organizationId = orgId,
+        isActive = isActive,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -1,6 +1,7 @@
 package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateFiscalYearRequest
+import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.FiscalPeriod
@@ -111,7 +112,7 @@ class FiscalYearServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 fiscalYearService.createFiscalYear(request, orgId)
             }
         assertThat(exception.message).contains("Start date must be before end date")
@@ -135,7 +136,7 @@ class FiscalYearServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 fiscalYearService.createFiscalYear(request, orgId)
             }
         assertThat(exception.message).contains("active fiscal year")
@@ -159,7 +160,7 @@ class FiscalYearServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 fiscalYearService.createFiscalYear(request, orgId)
             }
         assertThat(exception.message).contains("overlaps")
@@ -196,7 +197,7 @@ class FiscalYearServiceTest {
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 fiscalYearService.closePeriod(
                     "fy-1",
                     fiscalYear.periods[0].id,
@@ -218,7 +219,7 @@ class FiscalYearServiceTest {
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 fiscalYearService.closePeriod(
                     "fy-1",
                     fiscalYear.periods[1].id,
@@ -264,7 +265,7 @@ class FiscalYearServiceTest {
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 fiscalYearService.reopenPeriod(
                     "fy-1",
                     fiscalYear.periods[0].id,
@@ -289,7 +290,7 @@ class FiscalYearServiceTest {
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 fiscalYearService.reopenPeriod(
                     "fy-1",
                     fiscalYear.periods[0].id,
@@ -311,7 +312,7 @@ class FiscalYearServiceTest {
         `when`(fiscalYearRepository.findById("fy-1")).thenReturn(Optional.of(fiscalYear))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 fiscalYearService.closeYear("fy-1", orgId, userId)
             }
         assertThat(exception.message).contains("All periods must be closed")

--- a/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvitationServiceTest.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.AcceptInvitationRequest
 import com.froilan.synectix.dto.CreateInvitationRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Invitation
 import com.froilan.synectix.model.InvitationStatus
 import com.froilan.synectix.model.Role
@@ -96,7 +98,7 @@ class InvitationServiceTest {
 
         `when`(roleRepository.findByName("NONEXISTENT")).thenReturn(Optional.empty())
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
+        val exception = assertThrows<BusinessRuleException> { invitationService.invite(request, inviter, inviter.organizationId) }
         assertThat(exception.message).isEqualTo("Role 'NONEXISTENT' does not exist")
     }
 
@@ -108,7 +110,7 @@ class InvitationServiceTest {
 
         `when`(roleRepository.findByName("SUPER_ADMIN")).thenReturn(Optional.of(systemRole))
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
+        val exception = assertThrows<BusinessRuleException> { invitationService.invite(request, inviter, inviter.organizationId) }
         assertThat(exception.message).isEqualTo("Cannot invite with system-level role")
     }
 
@@ -128,7 +130,7 @@ class InvitationServiceTest {
             ),
         ).thenReturn(Optional.of(existingInvitation))
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.invite(request, inviter, inviter.organizationId) }
+        val exception = assertThrows<BusinessRuleException> { invitationService.invite(request, inviter, inviter.organizationId) }
         assertThat(exception.message).isEqualTo("An invitation has already been sent to this email")
     }
 
@@ -198,7 +200,7 @@ class InvitationServiceTest {
     fun `validateInvitation should throw for invalid token`() {
         `when`(invitationRepository.findByTokenHash("hashed-bad-token")).thenReturn(Optional.empty())
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.validateInvitation("bad-token") }
+        val exception = assertThrows<BusinessRuleException> { invitationService.validateInvitation("bad-token") }
         assertThat(exception.message).isEqualTo("Invalid or expired invitation token")
     }
 
@@ -278,7 +280,7 @@ class InvitationServiceTest {
         `when`(mongoTemplate.findAndModify(any(), any(), any<FindAndModifyOptions>(), eq(Invitation::class.java)))
             .thenReturn(null)
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        val exception = assertThrows<BusinessRuleException> { invitationService.acceptInvitation(request) }
         assertThat(exception.message).isEqualTo("Invalid or expired invitation token")
     }
 
@@ -291,7 +293,7 @@ class InvitationServiceTest {
             .thenReturn(invitation.copy(status = InvitationStatus.ACCEPTED))
         `when`(userRepository.findByEmail(invitation.email)).thenReturn(Optional.empty())
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        val exception = assertThrows<BusinessRuleException> { invitationService.acceptInvitation(request) }
         assertThat(exception.message).isEqualTo("Username, password, first name, and last name are required for new users")
     }
 
@@ -314,7 +316,7 @@ class InvitationServiceTest {
         `when`(userRepository.save(any<User>()))
             .thenThrow(DuplicateKeyException("E11000 duplicate key error collection: synectix.users index: username"))
 
-        val exception = assertThrows<IllegalArgumentException> { invitationService.acceptInvitation(request) }
+        val exception = assertThrows<BusinessRuleException> { invitationService.acceptInvitation(request) }
         assertThat(exception.message).isEqualTo("Username already exists")
     }
 
@@ -339,7 +341,7 @@ class InvitationServiceTest {
         `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 invitationService.revokeInvitation(invitation.id, "org-123")
             }
         assertThat(exception.message).isEqualTo("Invitation not found")
@@ -352,7 +354,7 @@ class InvitationServiceTest {
         `when`(invitationRepository.findById(invitation.id)).thenReturn(Optional.of(invitation))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 invitationService.revokeInvitation(invitation.id, "org-123")
             }
         assertThat(exception.message).isEqualTo("Invitation is not pending")

--- a/src/test/kotlin/com/froilan/synectix/service/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvoiceServiceTest.kt
@@ -1,0 +1,416 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateInvoiceRequest
+import com.froilan.synectix.dto.InvoiceLineRequest
+import com.froilan.synectix.dto.RecordReceiptRequest
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.Customer
+import com.froilan.synectix.model.Invoice
+import com.froilan.synectix.model.InvoiceLine
+import com.froilan.synectix.model.InvoiceReceipt
+import com.froilan.synectix.model.InvoiceStatus
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.model.PaymentMethod
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.InvoiceReceiptRepository
+import com.froilan.synectix.repository.InvoiceRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class InvoiceServiceTest {
+    private lateinit var invoiceService: InvoiceService
+    private lateinit var invoiceRepository: InvoiceRepository
+    private lateinit var invoiceReceiptRepository: InvoiceReceiptRepository
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var customerService: CustomerService
+    private lateinit var journalEntryService: JournalEntryService
+
+    private val orgId = "org-123"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        invoiceRepository = mock(InvoiceRepository::class.java)
+        invoiceReceiptRepository = mock(InvoiceReceiptRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        customerService = mock(CustomerService::class.java)
+        journalEntryService = mock(JournalEntryService::class.java)
+        invoiceService =
+            InvoiceService(
+                invoiceRepository = invoiceRepository,
+                invoiceReceiptRepository = invoiceReceiptRepository,
+                accountRepository = accountRepository,
+                customerService = customerService,
+                journalEntryService = journalEntryService,
+            )
+    }
+
+    @Test
+    fun `create should save invoice as DRAFT with correct total`() {
+        val customer = createCustomer()
+        val revenueAccount = createAccount("acc-1", "4100", "Service Revenue", AccountType.REVENUE)
+
+        `when`(customerService.getCustomer("c-1", orgId)).thenReturn(customer)
+        `when`(accountRepository.findAllById(listOf("acc-1")))
+            .thenReturn(listOf(revenueAccount))
+        `when`(invoiceRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateInvoiceRequest(
+                customerId = "c-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                lines =
+                    listOf(
+                        InvoiceLineRequest(accountId = "acc-1", amount = BigDecimal("2000.00")),
+                    ),
+            )
+
+        val result = invoiceService.createInvoice(request, orgId, userId)
+
+        assertThat(result.status).isEqualTo(InvoiceStatus.DRAFT)
+        assertThat(result.customerName).isEqualTo("BigCorp")
+        assertThat(result.totalAmount).isEqualByComparingTo(BigDecimal("2000.00"))
+        assertThat(result.amountReceived).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.invoiceNumber).isEqualTo("INV-0001")
+        assertThat(result.lines).hasSize(1)
+        assertThat(result.lines[0].accountCode).isEqualTo("4100")
+    }
+
+    @Test
+    fun `create should reject inactive customer`() {
+        val customer = createCustomer(isActive = false)
+        `when`(customerService.getCustomer("c-1", orgId)).thenReturn(customer)
+
+        val request =
+            CreateInvoiceRequest(
+                customerId = "c-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                lines =
+                    listOf(
+                        InvoiceLineRequest(accountId = "acc-1", amount = BigDecimal("100.00")),
+                    ),
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.createInvoice(request, orgId, userId)
+            }
+        assertThat(exception.message).contains("inactive customer")
+    }
+
+    @Test
+    fun `approve should post journal entry and update status`() {
+        val invoice = createInvoice()
+        val arAccount = createAccount("acc-ar", "1100", "Accounts Receivable", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1100"))
+            .thenReturn(Optional.of(arAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val result = invoiceService.approveInvoice("inv-1", orgId, userId)
+
+        assertThat(result.status).isEqualTo(InvoiceStatus.APPROVED)
+        assertThat(result.journalEntryId).isEqualTo("je-1")
+        assertThat(result.approvedBy).isEqualTo(userId)
+
+        verify(journalEntryService).createSystemEntry(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `approve should reject non-draft invoice`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED)
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.approveInvoice("inv-1", orgId, userId)
+            }
+        assertThat(exception.message).contains("Only draft")
+    }
+
+    @Test
+    fun `void should void journal entry for approved invoice`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED, journalEntryId = "je-1")
+        val voidedEntry = createMockJournalEntry(status = JournalEntryStatus.VOIDED)
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(journalEntryService.voidJournalEntry("je-1", orgId, "Duplicate"))
+            .thenReturn(voidedEntry)
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val result = invoiceService.voidInvoice("inv-1", orgId, "Duplicate", userId)
+
+        assertThat(result.status).isEqualTo(InvoiceStatus.VOID)
+        assertThat(result.voidReason).isEqualTo("Duplicate")
+        verify(journalEntryService).voidJournalEntry("je-1", orgId, "Duplicate")
+    }
+
+    @Test
+    fun `void should allow voiding draft without journal entry`() {
+        val invoice = createInvoice(status = InvoiceStatus.DRAFT)
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val result = invoiceService.voidInvoice("inv-1", orgId, "Not needed", userId)
+
+        assertThat(result.status).isEqualTo(InvoiceStatus.VOID)
+    }
+
+    @Test
+    fun `void should reject invoice with receipts`() {
+        val invoice =
+            createInvoice(
+                status = InvoiceStatus.PARTIALLY_PAID,
+                amountReceived = BigDecimal("500.00"),
+            )
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.voidInvoice("inv-1", orgId, "Cancel", userId)
+            }
+        assertThat(exception.message).contains("recorded receipts")
+    }
+
+    @Test
+    fun `recordReceipt should create receipt and update invoice status`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED)
+        val arAccount = createAccount("acc-ar", "1100", "Accounts Receivable", AccountType.ASSET)
+        val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1100"))
+            .thenReturn(Optional.of(arAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
+            .thenReturn(Optional.of(cashAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(invoiceReceiptRepository.save(any<InvoiceReceipt>())).thenAnswer { it.arguments[0] }
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            RecordReceiptRequest(
+                receiptDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("1000.00"),
+                paymentMethod = PaymentMethod.BANK_TRANSFER,
+            )
+
+        val receipt = invoiceService.recordReceipt("inv-1", request, orgId, userId)
+
+        assertThat(receipt.amount).isEqualByComparingTo(BigDecimal("1000.00"))
+        assertThat(receipt.paymentMethod).isEqualTo(PaymentMethod.BANK_TRANSFER)
+
+        val invoiceCaptor = argumentCaptor<Invoice>()
+        verify(invoiceRepository).save(invoiceCaptor.capture())
+        assertThat(invoiceCaptor.firstValue.status).isEqualTo(InvoiceStatus.PARTIALLY_PAID)
+        assertThat(invoiceCaptor.firstValue.amountReceived).isEqualByComparingTo(BigDecimal("1000.00"))
+    }
+
+    @Test
+    fun `recordReceipt should mark invoice as PAID when fully paid`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED)
+        val arAccount = createAccount("acc-ar", "1100", "Accounts Receivable", AccountType.ASSET)
+        val cashAccount = createAccount("acc-cash", "1000", "Cash", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1100"))
+            .thenReturn(Optional.of(arAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1000"))
+            .thenReturn(Optional.of(cashAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(invoiceReceiptRepository.save(any<InvoiceReceipt>())).thenAnswer { it.arguments[0] }
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            RecordReceiptRequest(
+                receiptDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("2000.00"),
+                paymentMethod = PaymentMethod.CHECK,
+            )
+
+        invoiceService.recordReceipt("inv-1", request, orgId, userId)
+
+        val invoiceCaptor = argumentCaptor<Invoice>()
+        verify(invoiceRepository).save(invoiceCaptor.capture())
+        assertThat(invoiceCaptor.firstValue.status).isEqualTo(InvoiceStatus.PAID)
+        assertThat(invoiceCaptor.firstValue.paidAt).isNotNull()
+    }
+
+    @Test
+    fun `recordReceipt should reject overpayment`() {
+        val invoice = createInvoice(status = InvoiceStatus.APPROVED)
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+
+        val request =
+            RecordReceiptRequest(
+                receiptDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("9999.00"),
+                paymentMethod = PaymentMethod.CASH,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.recordReceipt("inv-1", request, orgId, userId)
+            }
+        assertThat(exception.message).contains("exceeds remaining balance")
+    }
+
+    @Test
+    fun `recordReceipt should reject draft invoice`() {
+        val invoice = createInvoice(status = InvoiceStatus.DRAFT)
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+
+        val request =
+            RecordReceiptRequest(
+                receiptDate = LocalDate.of(2026, 3, 15),
+                amount = BigDecimal("100.00"),
+                paymentMethod = PaymentMethod.CASH,
+            )
+
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                invoiceService.recordReceipt("inv-1", request, orgId, userId)
+            }
+        assertThat(exception.message).contains("approved or partially paid")
+    }
+
+    @Test
+    fun `aging report should bucket invoices by overdue days`() {
+        val asOfDate = LocalDate.of(2026, 5, 1)
+        val invoices =
+            listOf(
+                createInvoice(
+                    id = "inv-1",
+                    customerId = "c-1",
+                    dueDate = LocalDate.of(2026, 5, 15),
+                    totalAmount = BigDecimal("500.00"),
+                    status = InvoiceStatus.APPROVED,
+                ),
+                createInvoice(
+                    id = "inv-2",
+                    customerId = "c-1",
+                    dueDate = LocalDate.of(2026, 4, 15),
+                    totalAmount = BigDecimal("800.00"),
+                    status = InvoiceStatus.APPROVED,
+                ),
+                createInvoice(
+                    id = "inv-3",
+                    customerId = "c-1",
+                    dueDate = LocalDate.of(2026, 2, 1),
+                    totalAmount = BigDecimal("1000.00"),
+                    status = InvoiceStatus.PARTIALLY_PAID,
+                    amountReceived = BigDecimal("200.00"),
+                ),
+            )
+
+        val outstandingStatuses = listOf(InvoiceStatus.APPROVED, InvoiceStatus.PARTIALLY_PAID)
+        `when`(invoiceRepository.findByOrganizationIdAndStatusIn(orgId, outstandingStatuses))
+            .thenReturn(invoices)
+
+        val report = invoiceService.getAgingReport(orgId, asOfDate)
+
+        assertThat(report.customers).hasSize(1)
+        val customerAging = report.customers[0]
+        assertThat(customerAging.customerName).isEqualTo("BigCorp")
+
+        // inv-1: due May 15, asOf May 1 -> not overdue -> current
+        assertThat(customerAging.aging.current).isEqualByComparingTo(BigDecimal("500.00"))
+        // inv-2: due Apr 15, asOf May 1 -> 16 days overdue -> 1-30 bucket
+        assertThat(customerAging.aging.days1to30).isEqualByComparingTo(BigDecimal("800.00"))
+        // inv-3: due Feb 1, asOf May 1 -> 89 days overdue -> 61-90 bucket, outstanding = 800
+        assertThat(customerAging.aging.days61to90).isEqualByComparingTo(BigDecimal("800.00"))
+
+        assertThat(report.totals.total).isEqualByComparingTo(BigDecimal("2100.00"))
+    }
+
+    private fun createCustomer(
+        id: String = "c-1",
+        isActive: Boolean = true,
+    ) = Customer(
+        id = id,
+        name = "BigCorp",
+        contactName = "Jane",
+        paymentTermDays = 30,
+        organizationId = orgId,
+        isActive = isActive,
+    )
+
+    private fun createAccount(
+        id: String,
+        code: String,
+        name: String,
+        type: AccountType,
+    ) = Account(
+        id = id,
+        code = code,
+        name = name,
+        type = type,
+        organizationId = orgId,
+    )
+
+    private fun createInvoice(
+        id: String = "inv-1",
+        customerId: String = "c-1",
+        status: InvoiceStatus = InvoiceStatus.DRAFT,
+        totalAmount: BigDecimal = BigDecimal("2000.00"),
+        amountReceived: BigDecimal = BigDecimal.ZERO,
+        dueDate: LocalDate = LocalDate.of(2026, 3, 31),
+        journalEntryId: String? = null,
+    ) = Invoice(
+        id = id,
+        invoiceNumber = "INV-0001",
+        customerId = customerId,
+        customerName = "BigCorp",
+        date = LocalDate.of(2026, 3, 1),
+        dueDate = dueDate,
+        organizationId = orgId,
+        status = status,
+        lines =
+            listOf(
+                InvoiceLine(
+                    accountId = "acc-1",
+                    accountCode = "4100",
+                    accountName = "Service Revenue",
+                    amount = totalAmount,
+                ),
+            ),
+        totalAmount = totalAmount,
+        amountReceived = amountReceived,
+        journalEntryId = journalEntryId,
+        createdBy = userId,
+    )
+
+    private fun createMockJournalEntry(status: JournalEntryStatus = JournalEntryStatus.POSTED) =
+        JournalEntry(
+            id = "je-1",
+            entryNumber = "JE-0001",
+            date = LocalDate.of(2026, 3, 1),
+            description = "Mock entry",
+            organizationId = orgId,
+            status = status,
+            lines = emptyList(),
+            createdBy = userId,
+        )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvoiceServiceTest.kt
@@ -3,6 +3,7 @@ package com.froilan.synectix.service
 import com.froilan.synectix.dto.CreateInvoiceRequest
 import com.froilan.synectix.dto.InvoiceLineRequest
 import com.froilan.synectix.dto.RecordReceiptRequest
+import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.Customer
@@ -107,7 +108,7 @@ class InvoiceServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 invoiceService.createInvoice(request, orgId, userId)
             }
         assertThat(exception.message).contains("inactive customer")
@@ -141,7 +142,7 @@ class InvoiceServiceTest {
         `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 invoiceService.approveInvoice("inv-1", orgId, userId)
             }
         assertThat(exception.message).contains("Only draft")
@@ -185,7 +186,7 @@ class InvoiceServiceTest {
         `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 invoiceService.voidInvoice("inv-1", orgId, "Cancel", userId)
             }
         assertThat(exception.message).contains("recorded receipts")
@@ -271,7 +272,7 @@ class InvoiceServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 invoiceService.recordReceipt("inv-1", request, orgId, userId)
             }
         assertThat(exception.message).contains("exceeds remaining balance")
@@ -290,7 +291,7 @@ class InvoiceServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 invoiceService.recordReceipt("inv-1", request, orgId, userId)
             }
         assertThat(exception.message).contains("approved or partially paid")

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.JournalEntryLineRequest
+import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.JournalEntry
@@ -99,7 +100,7 @@ class JournalEntryServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
         assertThat(exception.message).contains("at least 2 line items")
@@ -119,7 +120,7 @@ class JournalEntryServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
         assertThat(exception.message).contains("cannot have both debit and credit")
@@ -139,7 +140,7 @@ class JournalEntryServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
         assertThat(exception.message).contains("must have either a debit or credit amount")
@@ -159,7 +160,7 @@ class JournalEntryServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
         assertThat(exception.message).contains("must balance")
@@ -183,7 +184,7 @@ class JournalEntryServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
         assertThat(exception.message).contains("not found")
@@ -215,7 +216,7 @@ class JournalEntryServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
         assertThat(exception.message).contains("inactive")
@@ -241,7 +242,7 @@ class JournalEntryServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
         assertThat(exception.message).contains("not found")
@@ -342,7 +343,7 @@ class JournalEntryServiceTest {
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(postedEntry))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.postJournalEntry("entry-1", orgId)
             }
         assertThat(exception.message).contains("Only draft entries can be posted")
@@ -436,7 +437,7 @@ class JournalEntryServiceTest {
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(draftEntry))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.voidJournalEntry("entry-1", orgId, "Some reason")
             }
         assertThat(exception.message).contains("Only posted entries can be voided")
@@ -636,7 +637,7 @@ class JournalEntryServiceTest {
 
         `when`(accountRepository.findAllById(listOf("acc-1", "acc-2")))
             .thenReturn(listOf(cashAccount, revenueAccount))
-        doThrow(IllegalArgumentException("Fiscal period 'January 2026' is closed"))
+        doThrow(BusinessRuleException("Fiscal period 'January 2026' is closed"))
             .`when`(fiscalYearService)
             .validatePeriodOpen(orgId, LocalDate.of(2026, 1, 15))
 
@@ -660,7 +661,7 @@ class JournalEntryServiceTest {
             )
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.createJournalEntry(request, orgId, createdBy)
             }
         assertThat(exception.message).contains("closed")
@@ -740,12 +741,12 @@ class JournalEntryServiceTest {
             )
 
         `when`(journalEntryRepository.findById("entry-1")).thenReturn(Optional.of(entry))
-        doThrow(IllegalArgumentException("Fiscal period 'January 2026' is closed"))
+        doThrow(BusinessRuleException("Fiscal period 'January 2026' is closed"))
             .`when`(fiscalYearService)
             .validatePeriodOpen(orgId, LocalDate.of(2026, 1, 15))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 journalEntryService.postJournalEntry("entry-1", orgId)
             }
         assertThat(exception.message).contains("closed")

--- a/src/test/kotlin/com/froilan/synectix/service/VendorServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/VendorServiceTest.kt
@@ -2,6 +2,8 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.CreateVendorRequest
 import com.froilan.synectix.dto.UpdateVendorRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.Vendor
 import com.froilan.synectix.repository.VendorRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -64,7 +66,7 @@ class VendorServiceTest {
         `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<ResourceNotFoundException> {
                 vendorService.getVendor("v-1", orgId)
             }
         assertThat(exception.message).contains("Vendor not found")
@@ -98,7 +100,7 @@ class VendorServiceTest {
         `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 vendorService.updateVendor("v-1", UpdateVendorRequest(name = "New"), orgId)
             }
         assertThat(exception.message).contains("inactive")
@@ -124,7 +126,7 @@ class VendorServiceTest {
         `when`(vendorRepository.findById("v-1")).thenReturn(Optional.of(vendor))
 
         val exception =
-            assertThrows<IllegalArgumentException> {
+            assertThrows<BusinessRuleException> {
                 vendorService.deleteVendor("v-1", orgId)
             }
         assertThat(exception.message).contains("already inactive")


### PR DESCRIPTION
## Summary
Ships 3 PRs from staging to production:

### Accounts Receivable (#106, closes #27)
- Customer management with CRUD and soft delete
- Invoice lifecycle: DRAFT → APPROVED → PARTIALLY_PAID → PAID → VOID
- Auto-posted journal entries on approval (debit AR, credit revenue) and void via JournalEntryService
- Receipt recording with partial receipt support (debit Cash, credit AR)
- AR aging report with standard overdue buckets
- ar:create, ar:read, ar:approve, ar:receive, ar:void permissions
- 9 CustomerServiceTest + 13 InvoiceServiceTest cases

### Extract unauthorized() into AuthenticationContext (#107)
- Move duplicated `private fun unauthorized()` from all 10 controllers into `AuthenticationContext.unauthorized()`
- Add unit test for unauthorized() response body

### Centralize exception handling with @ControllerAdvice (#108, closes #101)
- Add typed exceptions: `ResourceNotFoundException` (404), `BusinessRuleException` (400), `AuthenticationException` (401)
- Add `GlobalExceptionHandler` @ControllerAdvice with null-safe fallback messages
- Strip try-catch from all 10 controllers (~50 endpoints), -276 lines
- Replace all `IllegalArgumentException` in services with domain exceptions
- Preserve original HTTP status codes: login/refresh → 401, validation → 400, not-found → 404

### Intentional status code improvements
- `DELETE /auth/api-keys/{id}` (missing key): 400 → 404
- `DELETE /auth/invitations/{id}` (missing invitation): 400 → 404

## Test plan
- [x] 273/274 tests pass (1 pre-existing MongoDB context load failure)
- [x] ktlintCheck passes
- [x] Multiple rounds of Copilot review findings addressed