### PR TITLE
Promote tax configuration & calculation engine to production

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/EnvironmentInitializer.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/EnvironmentInitializer.kt
@@ -46,7 +46,6 @@ class EnvironmentInitializer : ApplicationContextInitializer<ConfigurableApplica
             } catch (e: IllegalStateException) {
                 log.warn("Could not load .env file: {}", e.message)
             } catch (e: Exception) {
-                // Broad catch intentional: .env loading must never block startup
                 log.error("Unexpected error loading .env file: {}", e.message)
             }
         } else {

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -66,6 +66,9 @@ class RoleSeeder(
                             Permissions.AR_APPROVE,
                             Permissions.AR_RECEIVE,
                             Permissions.AR_VOID,
+                            Permissions.TAX_CREATE,
+                            Permissions.TAX_READ,
+                            Permissions.TAX_DELETE,
                         ),
                 ),
                 Role(
@@ -100,6 +103,9 @@ class RoleSeeder(
                             Permissions.AR_READ,
                             Permissions.AR_APPROVE,
                             Permissions.AR_RECEIVE,
+                            Permissions.TAX_CREATE,
+                            Permissions.TAX_READ,
+                            Permissions.TAX_DELETE,
                         ),
                 ),
                 Role(
@@ -121,6 +127,7 @@ class RoleSeeder(
                             Permissions.AP_READ,
                             Permissions.AR_CREATE,
                             Permissions.AR_READ,
+                            Permissions.TAX_READ,
                         ),
                 ),
                 Role(
@@ -136,6 +143,7 @@ class RoleSeeder(
                             Permissions.FISCAL_READ,
                             Permissions.AP_READ,
                             Permissions.AR_READ,
+                            Permissions.TAX_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/BillController.kt
@@ -152,6 +152,7 @@ class BillController(
             date = date.toString(),
             dueDate = dueDate.toString(),
             referenceNumber = referenceNumber,
+            taxGroupId = taxGroupId,
             organizationId = organizationId,
             status = status.name,
             lines =
@@ -165,6 +166,7 @@ class BillController(
                     )
                 },
             totalAmount = totalAmount,
+            taxAmount = taxAmount,
             amountPaid = amountPaid,
             journalEntryId = journalEntryId,
             createdBy = createdBy,
@@ -187,6 +189,7 @@ class BillController(
             dueDate = dueDate.toString(),
             status = status.name,
             totalAmount = totalAmount,
+            taxAmount = taxAmount,
             amountPaid = amountPaid,
         )
 

--- a/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/HealthController.kt
@@ -110,7 +110,6 @@ class HealthController(
                 "error" to (e.message ?: "Unknown database error"),
             )
         } catch (e: Exception) {
-            // Broad catch intentional: health endpoint must always return structured UP/DOWN
             log.error("Unexpected error during health check", e)
             mapOf(
                 "status" to "DOWN",

--- a/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InvoiceController.kt
@@ -152,6 +152,7 @@ class InvoiceController(
             date = date.toString(),
             dueDate = dueDate.toString(),
             referenceNumber = referenceNumber,
+            taxGroupId = taxGroupId,
             organizationId = organizationId,
             status = status.name,
             lines =
@@ -165,6 +166,7 @@ class InvoiceController(
                     )
                 },
             totalAmount = totalAmount,
+            taxAmount = taxAmount,
             amountReceived = amountReceived,
             journalEntryId = journalEntryId,
             createdBy = createdBy,
@@ -187,6 +189,7 @@ class InvoiceController(
             dueDate = dueDate.toString(),
             status = status.name,
             totalAmount = totalAmount,
+            taxAmount = taxAmount,
             amountReceived = amountReceived,
         )
 

--- a/src/main/kotlin/com/froilan/synectix/controller/TaxController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/TaxController.kt
@@ -110,7 +110,10 @@ class TaxController(
         val allRateIds = groups.flatMap { it.taxRateIds }.distinct()
         val allRates =
             if (allRateIds.isNotEmpty()) {
-                taxGroupService.loadRatesByIds(allRateIds).associateBy { it.id }
+                taxGroupService
+                    .loadRatesByIds(allRateIds)
+                    .filter { it.organizationId == orgId }
+                    .associateBy { it.id }
             } else {
                 emptyMap()
             }

--- a/src/main/kotlin/com/froilan/synectix/controller/TaxController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/TaxController.kt
@@ -1,0 +1,193 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateTaxGroupRequest
+import com.froilan.synectix.dto.CreateTaxRateRequest
+import com.froilan.synectix.dto.TaxGroupResponse
+import com.froilan.synectix.dto.TaxRateResponse
+import com.froilan.synectix.dto.UpdateTaxGroupRequest
+import com.froilan.synectix.dto.UpdateTaxRateRequest
+import com.froilan.synectix.model.TaxGroup
+import com.froilan.synectix.model.TaxRate
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.TaxGroupService
+import com.froilan.synectix.service.TaxRateService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/finance/tax")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class TaxController(
+    private val taxRateService: TaxRateService,
+    private val taxGroupService: TaxGroupService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping("/rates")
+    @PreAuthorize("hasAuthority('tax:create')")
+    fun createTaxRate(
+        @Valid @RequestBody request: CreateTaxRateRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val taxRate = taxRateService.createTaxRate(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(taxRate.toResponse())
+    }
+
+    @GetMapping("/rates")
+    @PreAuthorize("hasAuthority('tax:read')")
+    fun listTaxRates(
+        @RequestParam(required = false) active: Boolean?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val rates = taxRateService.listTaxRates(orgId, active ?: false)
+        return ResponseEntity.ok(rates.map { it.toResponse() })
+    }
+
+    @GetMapping("/rates/{id}")
+    @PreAuthorize("hasAuthority('tax:read')")
+    fun getTaxRate(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val taxRate = taxRateService.getTaxRate(id, orgId)
+        return ResponseEntity.ok(taxRate.toResponse())
+    }
+
+    @PutMapping("/rates/{id}")
+    @PreAuthorize("hasAuthority('tax:create')")
+    fun updateTaxRate(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateTaxRateRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val taxRate = taxRateService.updateTaxRate(id, request, orgId)
+        return ResponseEntity.ok(taxRate.toResponse())
+    }
+
+    @DeleteMapping("/rates/{id}")
+    @PreAuthorize("hasAuthority('tax:delete')")
+    fun deleteTaxRate(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        taxRateService.deleteTaxRate(id, orgId)
+        return ResponseEntity.ok(mapOf("message" to "Tax rate deactivated"))
+    }
+
+    @PostMapping("/groups")
+    @PreAuthorize("hasAuthority('tax:create')")
+    fun createTaxGroup(
+        @Valid @RequestBody request: CreateTaxGroupRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val (taxGroup, rates) =
+            taxGroupService.let {
+                val group = it.createTaxGroup(request, orgId)
+                it.getTaxGroupWithRates(group.id, orgId)
+            }
+        return ResponseEntity.status(HttpStatus.CREATED).body(taxGroup.toResponse(rates))
+    }
+
+    @GetMapping("/groups")
+    @PreAuthorize("hasAuthority('tax:read')")
+    fun listTaxGroups(
+        @RequestParam(required = false) active: Boolean?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val groups = taxGroupService.listTaxGroups(orgId, active ?: false)
+        val allRateIds = groups.flatMap { it.taxRateIds }.distinct()
+        val allRates =
+            if (allRateIds.isNotEmpty()) {
+                taxGroupService.loadRatesByIds(allRateIds).associateBy { it.id }
+            } else {
+                emptyMap()
+            }
+        return ResponseEntity.ok(
+            groups.map { group ->
+                val rates = group.taxRateIds.mapNotNull { allRates[it] }
+                group.toResponse(rates)
+            },
+        )
+    }
+
+    @GetMapping("/groups/{id}")
+    @PreAuthorize("hasAuthority('tax:read')")
+    fun getTaxGroup(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val (taxGroup, rates) = taxGroupService.getTaxGroupWithRates(id, orgId)
+        return ResponseEntity.ok(taxGroup.toResponse(rates))
+    }
+
+    @PutMapping("/groups/{id}")
+    @PreAuthorize("hasAuthority('tax:create')")
+    fun updateTaxGroup(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateTaxGroupRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val updated = taxGroupService.updateTaxGroup(id, request, orgId)
+        val (_, rates) = taxGroupService.getTaxGroupWithRates(updated.id, orgId)
+        return ResponseEntity.ok(updated.toResponse(rates))
+    }
+
+    @DeleteMapping("/groups/{id}")
+    @PreAuthorize("hasAuthority('tax:delete')")
+    fun deleteTaxGroup(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        taxGroupService.deleteTaxGroup(id, orgId)
+        return ResponseEntity.ok(mapOf("message" to "Tax group deactivated"))
+    }
+
+    @GetMapping("/summary")
+    @PreAuthorize("hasAuthority('tax:read')")
+    fun getTaxSummary(
+        @RequestParam startDate: java.time.LocalDate,
+        @RequestParam endDate: java.time.LocalDate,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val summary = taxGroupService.getTaxSummary(orgId, startDate, endDate)
+        return ResponseEntity.ok(summary)
+    }
+
+    private fun TaxRate.toResponse() =
+        TaxRateResponse(
+            id = id,
+            name = name,
+            code = code,
+            percentage = percentage,
+            authority = authority,
+            organizationId = organizationId,
+            isActive = isActive,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+
+    private fun TaxGroup.toResponse(rates: List<TaxRate>) =
+        TaxGroupResponse(
+            id = id,
+            name = name,
+            code = code,
+            taxRates = rates.map { it.toResponse() },
+            combinedRate = combinedRate,
+            organizationId = organizationId,
+            isActive = isActive,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/BillDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/BillDtos.kt
@@ -22,6 +22,7 @@ data class CreateBillRequest(
     val date: LocalDate,
     val dueDate: LocalDate,
     val referenceNumber: String? = null,
+    val taxGroupId: String? = null,
     @field:NotEmpty(message = "At least one line item is required")
     @field:Valid
     val lines: List<BillLineRequest>,
@@ -56,10 +57,12 @@ data class BillResponse(
     val date: String,
     val dueDate: String,
     val referenceNumber: String?,
+    val taxGroupId: String?,
     val organizationId: String,
     val status: String,
     val lines: List<BillLineResponse>,
     val totalAmount: BigDecimal,
+    val taxAmount: BigDecimal,
     val amountPaid: BigDecimal,
     val journalEntryId: String?,
     val createdBy: String,
@@ -81,6 +84,7 @@ data class BillSummaryResponse(
     val dueDate: String,
     val status: String,
     val totalAmount: BigDecimal,
+    val taxAmount: BigDecimal,
     val amountPaid: BigDecimal,
 )
 

--- a/src/main/kotlin/com/froilan/synectix/dto/InvoiceDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InvoiceDtos.kt
@@ -22,6 +22,7 @@ data class CreateInvoiceRequest(
     val date: LocalDate,
     val dueDate: LocalDate,
     val referenceNumber: String? = null,
+    val taxGroupId: String? = null,
     @field:NotEmpty(message = "At least one line item is required")
     @field:Valid
     val lines: List<InvoiceLineRequest>,
@@ -56,10 +57,12 @@ data class InvoiceResponse(
     val date: String,
     val dueDate: String,
     val referenceNumber: String?,
+    val taxGroupId: String?,
     val organizationId: String,
     val status: String,
     val lines: List<InvoiceLineResponse>,
     val totalAmount: BigDecimal,
+    val taxAmount: BigDecimal,
     val amountReceived: BigDecimal,
     val journalEntryId: String?,
     val createdBy: String,
@@ -81,6 +84,7 @@ data class InvoiceSummaryResponse(
     val dueDate: String,
     val status: String,
     val totalAmount: BigDecimal,
+    val taxAmount: BigDecimal,
     val amountReceived: BigDecimal,
 )
 

--- a/src/main/kotlin/com/froilan/synectix/dto/TaxDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/TaxDtos.kt
@@ -1,0 +1,75 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+
+data class CreateTaxRateRequest(
+    @field:NotBlank(message = "Tax rate name is required")
+    val name: String,
+    @field:NotBlank(message = "Tax rate code is required")
+    val code: String,
+    @field:Positive(message = "Percentage must be positive")
+    val percentage: BigDecimal,
+    @field:NotBlank(message = "Tax authority is required")
+    val authority: String,
+)
+
+data class UpdateTaxRateRequest(
+    @field:Size(min = 1, message = "Tax rate name cannot be blank")
+    val name: String? = null,
+    @field:Positive(message = "Percentage must be positive")
+    val percentage: BigDecimal? = null,
+    @field:Size(min = 1, message = "Tax authority cannot be blank")
+    val authority: String? = null,
+)
+
+data class CreateTaxGroupRequest(
+    @field:NotBlank(message = "Tax group name is required")
+    val name: String,
+    @field:NotBlank(message = "Tax group code is required")
+    val code: String,
+    @field:NotEmpty(message = "At least one tax rate is required")
+    val taxRateIds: List<String>,
+)
+
+data class UpdateTaxGroupRequest(
+    @field:Size(min = 1, message = "Tax group name cannot be blank")
+    val name: String? = null,
+    @field:Size(min = 1, message = "At least one tax rate is required")
+    val taxRateIds: List<String>? = null,
+)
+
+data class TaxRateResponse(
+    val id: String,
+    val name: String,
+    val code: String,
+    val percentage: BigDecimal,
+    val authority: String,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class TaxGroupResponse(
+    val id: String,
+    val name: String,
+    val code: String,
+    val taxRates: List<TaxRateResponse>,
+    val combinedRate: BigDecimal,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class TaxSummaryResponse(
+    val taxCollected: BigDecimal,
+    val taxPaid: BigDecimal,
+    val netTaxLiability: BigDecimal,
+    val startDate: String,
+    val endDate: String,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Bill.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Bill.kt
@@ -52,11 +52,13 @@ data class Bill(
     val date: LocalDate,
     val dueDate: LocalDate,
     val referenceNumber: String? = null,
+    val taxGroupId: String? = null,
     @Indexed
     val organizationId: String,
     val status: BillStatus = BillStatus.DRAFT,
     val lines: List<BillLine>,
     val totalAmount: BigDecimal,
+    val taxAmount: BigDecimal = BigDecimal.ZERO,
     val amountPaid: BigDecimal = BigDecimal.ZERO,
     val journalEntryId: String? = null,
     val createdBy: String,

--- a/src/main/kotlin/com/froilan/synectix/model/Invoice.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Invoice.kt
@@ -44,11 +44,13 @@ data class Invoice(
     val date: LocalDate,
     val dueDate: LocalDate,
     val referenceNumber: String? = null,
+    val taxGroupId: String? = null,
     @Indexed
     val organizationId: String,
     val status: InvoiceStatus = InvoiceStatus.DRAFT,
     val lines: List<InvoiceLine>,
     val totalAmount: BigDecimal,
+    val taxAmount: BigDecimal = BigDecimal.ZERO,
     val amountReceived: BigDecimal = BigDecimal.ZERO,
     val journalEntryId: String? = null,
     val createdBy: String,

--- a/src/main/kotlin/com/froilan/synectix/model/TaxGroup.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/TaxGroup.kt
@@ -1,0 +1,33 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "tax_groups")
+@CompoundIndex(
+    name = "unique_tax_group_code_per_org",
+    def = "{'organizationId': 1, 'code': 1}",
+    unique = true,
+)
+data class TaxGroup(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val code: String,
+    val taxRateIds: List<String>,
+    val combinedRate: BigDecimal,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/TaxRate.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/TaxRate.kt
@@ -1,0 +1,33 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "tax_rates")
+@CompoundIndex(
+    name = "unique_tax_rate_code_per_org",
+    def = "{'organizationId': 1, 'code': 1}",
+    unique = true,
+)
+data class TaxRate(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val code: String,
+    val percentage: BigDecimal,
+    val authority: String,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/TaxGroupRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/TaxGroupRepository.kt
@@ -1,0 +1,20 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.TaxGroup
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TaxGroupRepository : MongoRepository<TaxGroup, String> {
+    fun findByOrganizationId(organizationId: String): List<TaxGroup>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<TaxGroup>
+
+    fun findByOrganizationIdAndTaxRateIdsContaining(
+        organizationId: String,
+        taxRateId: String,
+    ): List<TaxGroup>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/TaxRateRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/TaxRateRepository.kt
@@ -1,0 +1,15 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.TaxRate
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TaxRateRepository : MongoRepository<TaxRate, String> {
+    fun findByOrganizationId(organizationId: String): List<TaxRate>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<TaxRate>
+}

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -45,6 +45,10 @@ object Permissions {
     const val AR_RECEIVE = "ar:receive"
     const val AR_VOID = "ar:void"
 
+    const val TAX_CREATE = "tax:create"
+    const val TAX_READ = "tax:read"
+    const val TAX_DELETE = "tax:delete"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -80,5 +84,8 @@ object Permissions {
             AR_APPROVE,
             AR_RECEIVE,
             AR_VOID,
+            TAX_CREATE,
+            TAX_READ,
+            TAX_DELETE,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/AccountService.kt
@@ -190,6 +190,20 @@ class AccountService(
                     isSystemAccount = true,
                 ),
                 Account(
+                    code = "2300",
+                    name = "Sales Tax Payable",
+                    type = AccountType.LIABILITY,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
+                    code = "2310",
+                    name = "Tax Input Credits",
+                    type = AccountType.ASSET,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+                Account(
                     code = "2500",
                     name = "Long-term Debt",
                     type = AccountType.LIABILITY,
@@ -275,10 +289,43 @@ class AccountService(
                 ),
             )
         if (accountRepository.existsByOrganizationIdAndCode(organizationId, "1000")) {
-            log.info("Default accounts already exist for org: {}. Skipping seed.", organizationId)
+            seedMissingTaxAccounts(organizationId)
             return
         }
         accountRepository.saveAll(defaults)
         log.info("Seeded {} default accounts for org: {}", defaults.size, organizationId)
+    }
+
+    private fun seedMissingTaxAccounts(organizationId: String) {
+        val missing = mutableListOf<Account>()
+
+        if (!accountRepository.existsByOrganizationIdAndCode(organizationId, "2300")) {
+            missing.add(
+                Account(
+                    code = "2300",
+                    name = "Sales Tax Payable",
+                    type = AccountType.LIABILITY,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+            )
+        }
+
+        if (!accountRepository.existsByOrganizationIdAndCode(organizationId, "2310")) {
+            missing.add(
+                Account(
+                    code = "2310",
+                    name = "Tax Input Credits",
+                    type = AccountType.ASSET,
+                    organizationId = organizationId,
+                    isSystemAccount = true,
+                ),
+            )
+        }
+
+        if (missing.isNotEmpty()) {
+            accountRepository.saveAll(missing)
+            log.info("Seeded missing tax accounts for existing org: {}", organizationId)
+        }
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/BillService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/BillService.kt
@@ -33,6 +33,7 @@ class BillService(
     private val accountRepository: AccountRepository,
     private val vendorService: VendorService,
     private val journalEntryService: JournalEntryService,
+    private val taxGroupService: TaxGroupService,
 ) {
     @Transactional
     fun createBill(
@@ -88,7 +89,9 @@ class BillService(
                 )
             }
 
-        val totalAmount = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.amount) }
+        val subtotalAmount = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.amount) }
+        val taxAmount = taxGroupService.calculateTaxAmount(request.taxGroupId, organizationId, subtotalAmount)
+        val totalAmount = subtotalAmount.add(taxAmount)
 
         return saveBillWithRetry(organizationId) { billNumber ->
             Bill(
@@ -98,9 +101,11 @@ class BillService(
                 date = request.date,
                 dueDate = request.dueDate,
                 referenceNumber = request.referenceNumber,
+                taxGroupId = request.taxGroupId,
                 organizationId = organizationId,
                 lines = lines,
                 totalAmount = totalAmount,
+                taxAmount = taxAmount,
                 createdBy = createdBy,
             )
         }
@@ -150,7 +155,7 @@ class BillService(
 
         val apAccount = getApAccount(organizationId)
 
-        val journalLines =
+        val expenseLines =
             bill.lines.map { line ->
                 JournalEntryLine(
                     accountId = line.accountId,
@@ -160,7 +165,28 @@ class BillService(
                     credit = BigDecimal.ZERO,
                     description = line.description,
                 )
-            } +
+            }
+
+        val taxLines =
+            if (bill.taxAmount.compareTo(BigDecimal.ZERO) > 0) {
+                val taxInputAccount = getTaxInputAccount(organizationId)
+                listOf(
+                    JournalEntryLine(
+                        accountId = taxInputAccount.id,
+                        accountCode = taxInputAccount.code,
+                        accountName = taxInputAccount.name,
+                        debit = bill.taxAmount,
+                        credit = BigDecimal.ZERO,
+                        description = "Tax Input - ${bill.vendorName} - ${bill.billNumber}",
+                    ),
+                )
+            } else {
+                emptyList()
+            }
+
+        val journalLines =
+            expenseLines +
+                taxLines +
                 JournalEntryLine(
                     accountId = apAccount.id,
                     accountCode = apAccount.code,
@@ -205,7 +231,6 @@ class BillService(
         }
         val now = LocalDateTime.now(ZoneOffset.UTC)
 
-        // Draft voids skip fiscal validation — no GL entries are posted
         if (bill.status == BillStatus.DRAFT) {
             return billRepository.save(
                 bill.copy(
@@ -448,6 +473,17 @@ class BillService(
             }
         if (!account.isActive) {
             throw BusinessRuleException("Cash account (1000) is inactive")
+        }
+        return account
+    }
+
+    private fun getTaxInputAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "2310").orElseThrow {
+                IllegalStateException("Tax Input Credits account (2310) not found")
+            }
+        if (!account.isActive) {
+            throw BusinessRuleException("Tax Input Credits account (2310) is inactive")
         }
         return account
     }

--- a/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InvoiceService.kt
@@ -33,6 +33,7 @@ class InvoiceService(
     private val accountRepository: AccountRepository,
     private val customerService: CustomerService,
     private val journalEntryService: JournalEntryService,
+    private val taxGroupService: TaxGroupService,
 ) {
     @Transactional
     fun createInvoice(
@@ -88,7 +89,9 @@ class InvoiceService(
                 )
             }
 
-        val totalAmount = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.amount) }
+        val subtotalAmount = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.amount) }
+        val taxAmount = taxGroupService.calculateTaxAmount(request.taxGroupId, organizationId, subtotalAmount)
+        val totalAmount = subtotalAmount.add(taxAmount)
 
         return saveInvoiceWithRetry(organizationId) { invoiceNumber ->
             Invoice(
@@ -98,9 +101,11 @@ class InvoiceService(
                 date = request.date,
                 dueDate = request.dueDate,
                 referenceNumber = request.referenceNumber,
+                taxGroupId = request.taxGroupId,
                 organizationId = organizationId,
                 lines = lines,
                 totalAmount = totalAmount,
+                taxAmount = taxAmount,
                 createdBy = createdBy,
             )
         }
@@ -150,7 +155,7 @@ class InvoiceService(
 
         val arAccount = getArAccount(organizationId)
 
-        val journalLines =
+        val revenueLines =
             invoice.lines.map { line ->
                 JournalEntryLine(
                     accountId = line.accountId,
@@ -160,7 +165,27 @@ class InvoiceService(
                     credit = line.amount,
                     description = line.description,
                 )
-            } +
+            }
+
+        val taxLines =
+            if (invoice.taxAmount.compareTo(BigDecimal.ZERO) > 0) {
+                val taxPayableAccount = getTaxPayableAccount(organizationId)
+                listOf(
+                    JournalEntryLine(
+                        accountId = taxPayableAccount.id,
+                        accountCode = taxPayableAccount.code,
+                        accountName = taxPayableAccount.name,
+                        debit = BigDecimal.ZERO,
+                        credit = invoice.taxAmount,
+                        description = "Tax Payable - ${invoice.customerName} - ${invoice.invoiceNumber}",
+                    ),
+                )
+            } else {
+                emptyList()
+            }
+
+        val journalLines =
+            listOf(
                 JournalEntryLine(
                     accountId = arAccount.id,
                     accountCode = arAccount.code,
@@ -168,7 +193,8 @@ class InvoiceService(
                     debit = invoice.totalAmount,
                     credit = BigDecimal.ZERO,
                     description = "AR - ${invoice.customerName} - ${invoice.invoiceNumber}",
-                )
+                ),
+            ) + revenueLines + taxLines
 
         val journalEntry =
             journalEntryService.createSystemEntry(
@@ -206,7 +232,6 @@ class InvoiceService(
 
         val now = LocalDateTime.now(ZoneOffset.UTC)
 
-        // Draft voids skip fiscal validation — no GL entries are posted
         if (invoice.status == InvoiceStatus.DRAFT) {
             return invoiceRepository.save(
                 invoice.copy(
@@ -431,6 +456,17 @@ class InvoiceService(
             }
         if (!account.isActive) {
             throw BusinessRuleException("Cash account (1000) is inactive")
+        }
+        return account
+    }
+
+    private fun getTaxPayableAccount(organizationId: String): Account {
+        val account =
+            accountRepository.findByOrganizationIdAndCode(organizationId, "2300").orElseThrow {
+                IllegalStateException("Sales Tax Payable account (2300) not found")
+            }
+        if (!account.isActive) {
+            throw BusinessRuleException("Sales Tax Payable account (2300) is inactive")
         }
         return account
     }

--- a/src/main/kotlin/com/froilan/synectix/service/TaxGroupService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/TaxGroupService.kt
@@ -1,0 +1,227 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateTaxGroupRequest
+import com.froilan.synectix.dto.TaxSummaryResponse
+import com.froilan.synectix.dto.UpdateTaxGroupRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.TaxGroup
+import com.froilan.synectix.model.TaxRate
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.TaxGroupRepository
+import com.froilan.synectix.repository.TaxRateRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+
+@Service
+class TaxGroupService(
+    private val taxGroupRepository: TaxGroupRepository,
+    private val taxRateRepository: TaxRateRepository,
+    private val accountRepository: AccountRepository,
+    private val journalEntryService: JournalEntryService,
+) {
+    @Transactional
+    fun createTaxGroup(
+        request: CreateTaxGroupRequest,
+        organizationId: String,
+    ): TaxGroup {
+        if (request.taxRateIds.isEmpty()) {
+            throw BusinessRuleException("At least one tax rate is required")
+        }
+        val uniqueRateIds = request.taxRateIds.distinct()
+        val rates = validateAndLoadRates(uniqueRateIds, organizationId)
+        val combinedRate = rates.fold(BigDecimal.ZERO) { sum, rate -> sum.add(rate.percentage) }
+
+        val taxGroup =
+            TaxGroup(
+                name = request.name,
+                code = request.code,
+                taxRateIds = uniqueRateIds,
+                combinedRate = combinedRate,
+                organizationId = organizationId,
+            )
+
+        return try {
+            taxGroupRepository.save(taxGroup)
+        } catch (e: DuplicateKeyException) {
+            throw BusinessRuleException(
+                "Tax group code '${request.code}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    fun getTaxGroup(
+        taxGroupId: String,
+        organizationId: String,
+    ): TaxGroup {
+        val taxGroup =
+            taxGroupRepository.findById(taxGroupId).orElseThrow {
+                ResourceNotFoundException("Tax group not found")
+            }
+        if (taxGroup.organizationId != organizationId) {
+            throw ResourceNotFoundException("Tax group not found")
+        }
+        return taxGroup
+    }
+
+    fun getTaxGroupWithRates(
+        taxGroupId: String,
+        organizationId: String,
+    ): Pair<TaxGroup, List<TaxRate>> {
+        val taxGroup = getTaxGroup(taxGroupId, organizationId)
+        val ratesById = taxRateRepository.findAllById(taxGroup.taxRateIds).associateBy { it.id }
+        val missing = taxGroup.taxRateIds.filter { it !in ratesById }
+        if (missing.isNotEmpty()) {
+            throw BusinessRuleException("Tax rates not found: ${missing.joinToString(", ")}")
+        }
+        val crossOrg = ratesById.values.filter { it.organizationId != organizationId }.map { it.id }
+        if (crossOrg.isNotEmpty()) {
+            throw BusinessRuleException("Tax rates not found: ${crossOrg.joinToString(", ")}")
+        }
+        val orderedRates = taxGroup.taxRateIds.map { ratesById.getValue(it) }
+        return taxGroup to orderedRates
+    }
+
+    fun listTaxGroups(
+        organizationId: String,
+        activeOnly: Boolean = false,
+    ): List<TaxGroup> =
+        if (activeOnly) {
+            taxGroupRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        } else {
+            taxGroupRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateTaxGroup(
+        taxGroupId: String,
+        request: UpdateTaxGroupRequest,
+        organizationId: String,
+    ): TaxGroup {
+        val taxGroup = getTaxGroup(taxGroupId, organizationId)
+
+        if (!taxGroup.isActive) {
+            throw BusinessRuleException("Cannot update inactive tax group")
+        }
+
+        if (request.name != null && request.name.isBlank()) {
+            throw BusinessRuleException("Tax group name cannot be blank")
+        }
+        if (request.taxRateIds != null && request.taxRateIds.isEmpty()) {
+            throw BusinessRuleException("At least one tax rate is required")
+        }
+        val newRateIds = request.taxRateIds?.distinct() ?: taxGroup.taxRateIds
+        val rates = validateAndLoadRates(newRateIds, organizationId)
+
+        val combinedRate = rates.fold(BigDecimal.ZERO) { sum, rate -> sum.add(rate.percentage) }
+
+        val updated =
+            taxGroup.copy(
+                name = request.name ?: taxGroup.name,
+                taxRateIds = newRateIds,
+                combinedRate = combinedRate,
+            )
+
+        return taxGroupRepository.save(updated)
+    }
+
+    @Transactional
+    fun deleteTaxGroup(
+        taxGroupId: String,
+        organizationId: String,
+    ): TaxGroup {
+        val taxGroup = getTaxGroup(taxGroupId, organizationId)
+
+        if (!taxGroup.isActive) {
+            throw BusinessRuleException("Tax group is already inactive")
+        }
+
+        return taxGroupRepository.save(taxGroup.copy(isActive = false))
+    }
+
+    fun calculateTaxAmount(
+        taxGroupId: String?,
+        organizationId: String,
+        baseAmount: BigDecimal,
+    ): BigDecimal {
+        if (taxGroupId == null) return BigDecimal.ZERO
+
+        val taxGroup = getTaxGroup(taxGroupId, organizationId)
+        if (!taxGroup.isActive) {
+            throw BusinessRuleException("Tax group '${taxGroup.code}' is inactive")
+        }
+
+        return baseAmount
+            .multiply(taxGroup.combinedRate)
+            .divide(BigDecimal("100"), 2, RoundingMode.HALF_UP)
+    }
+
+    fun loadRatesByIds(ids: List<String>): List<TaxRate> = taxRateRepository.findAllById(ids)
+
+    fun getTaxSummary(
+        organizationId: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): TaxSummaryResponse {
+        if (startDate.isAfter(endDate)) {
+            throw BusinessRuleException("Start date must be on or before end date")
+        }
+
+        val taxCollected =
+            accountRepository
+                .findByOrganizationIdAndCode(organizationId, "2300")
+                .map {
+                    val endBalance = journalEntryService.getAccountBalance(it.id, organizationId, endDate).balance
+                    val startBalance =
+                        journalEntryService.getAccountBalance(it.id, organizationId, startDate.minusDays(1)).balance
+                    endBalance.subtract(startBalance)
+                }.orElse(BigDecimal.ZERO)
+
+        val taxPaid =
+            accountRepository
+                .findByOrganizationIdAndCode(organizationId, "2310")
+                .map {
+                    val endBalance = journalEntryService.getAccountBalance(it.id, organizationId, endDate).balance
+                    val startBalance =
+                        journalEntryService.getAccountBalance(it.id, organizationId, startDate.minusDays(1)).balance
+                    endBalance.subtract(startBalance)
+                }.orElse(BigDecimal.ZERO)
+
+        return TaxSummaryResponse(
+            taxCollected = taxCollected,
+            taxPaid = taxPaid,
+            netTaxLiability = taxCollected.subtract(taxPaid),
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
+        )
+    }
+
+    private fun validateAndLoadRates(
+        taxRateIds: List<String>,
+        organizationId: String,
+    ): List<TaxRate> {
+        val rates = taxRateRepository.findAllById(taxRateIds)
+        val foundIds = rates.map { it.id }.toSet()
+
+        val missing = taxRateIds.filter { it !in foundIds }
+        if (missing.isNotEmpty()) {
+            throw BusinessRuleException("Tax rates not found: ${missing.joinToString(", ")}")
+        }
+
+        rates.forEach { rate ->
+            if (rate.organizationId != organizationId) {
+                throw BusinessRuleException("Tax rate '${rate.id}' not found")
+            }
+            if (!rate.isActive) {
+                throw BusinessRuleException("Tax rate '${rate.code}' is inactive")
+            }
+        }
+
+        return rates
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/TaxRateService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/TaxRateService.kt
@@ -135,10 +135,19 @@ class TaxRateService(
         val allRateIds = groups.flatMap { it.taxRateIds }.distinct()
         val ratesById = taxRateRepository.findAllById(allRateIds).associateBy { it.id }
 
+        val missing = allRateIds.filter { it !in ratesById }
+        if (missing.isNotEmpty()) {
+            throw BusinessRuleException("Tax rates not found: ${missing.joinToString(", ")}")
+        }
+        val crossOrg = ratesById.values.filter { it.organizationId != organizationId }.map { it.id }
+        if (crossOrg.isNotEmpty()) {
+            throw BusinessRuleException("Tax rates not found: ${crossOrg.joinToString(", ")}")
+        }
+
         groups.forEach { group ->
             val newCombinedRate =
                 group.taxRateIds.fold(BigDecimal.ZERO) { sum, id ->
-                    sum.add(ratesById[id]?.percentage ?: BigDecimal.ZERO)
+                    sum.add(ratesById.getValue(id).percentage)
                 }
             taxGroupRepository.save(group.copy(combinedRate = newCombinedRate))
         }

--- a/src/main/kotlin/com/froilan/synectix/service/TaxRateService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/TaxRateService.kt
@@ -1,0 +1,146 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateTaxRateRequest
+import com.froilan.synectix.dto.UpdateTaxRateRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.TaxRate
+import com.froilan.synectix.repository.TaxGroupRepository
+import com.froilan.synectix.repository.TaxRateRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+class TaxRateService(
+    private val taxRateRepository: TaxRateRepository,
+    private val taxGroupRepository: TaxGroupRepository,
+) {
+    @Transactional
+    fun createTaxRate(
+        request: CreateTaxRateRequest,
+        organizationId: String,
+    ): TaxRate {
+        val taxRate =
+            TaxRate(
+                name = request.name,
+                code = request.code,
+                percentage = request.percentage,
+                authority = request.authority,
+                organizationId = organizationId,
+            )
+
+        return try {
+            taxRateRepository.save(taxRate)
+        } catch (e: DuplicateKeyException) {
+            throw BusinessRuleException(
+                "Tax rate code '${request.code}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    fun getTaxRate(
+        taxRateId: String,
+        organizationId: String,
+    ): TaxRate {
+        val taxRate =
+            taxRateRepository.findById(taxRateId).orElseThrow {
+                ResourceNotFoundException("Tax rate not found")
+            }
+        if (taxRate.organizationId != organizationId) {
+            throw ResourceNotFoundException("Tax rate not found")
+        }
+        return taxRate
+    }
+
+    fun listTaxRates(
+        organizationId: String,
+        activeOnly: Boolean = false,
+    ): List<TaxRate> =
+        if (activeOnly) {
+            taxRateRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        } else {
+            taxRateRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateTaxRate(
+        taxRateId: String,
+        request: UpdateTaxRateRequest,
+        organizationId: String,
+    ): TaxRate {
+        val taxRate = getTaxRate(taxRateId, organizationId)
+
+        if (!taxRate.isActive) {
+            throw BusinessRuleException("Cannot update inactive tax rate")
+        }
+
+        if (request.name != null && request.name.isBlank()) {
+            throw BusinessRuleException("Tax rate name cannot be blank")
+        }
+        if (request.authority != null && request.authority.isBlank()) {
+            throw BusinessRuleException("Tax authority cannot be blank")
+        }
+        if (request.percentage != null && request.percentage <= BigDecimal.ZERO) {
+            throw BusinessRuleException("Percentage must be positive")
+        }
+
+        val updated =
+            taxRate.copy(
+                name = request.name ?: taxRate.name,
+                percentage = request.percentage ?: taxRate.percentage,
+                authority = request.authority ?: taxRate.authority,
+            )
+
+        val saved = taxRateRepository.save(updated)
+
+        if (request.percentage != null && request.percentage.compareTo(taxRate.percentage) != 0) {
+            cascadeCombinedRate(taxRateId, organizationId)
+        }
+
+        return saved
+    }
+
+    @Transactional
+    fun deleteTaxRate(
+        taxRateId: String,
+        organizationId: String,
+    ): TaxRate {
+        val taxRate = getTaxRate(taxRateId, organizationId)
+
+        if (!taxRate.isActive) {
+            throw BusinessRuleException("Tax rate is already inactive")
+        }
+
+        val activeGroups =
+            taxGroupRepository
+                .findByOrganizationIdAndTaxRateIdsContaining(organizationId, taxRateId)
+                .filter { it.isActive }
+        if (activeGroups.isNotEmpty()) {
+            throw BusinessRuleException("Cannot deactivate tax rate used in active tax groups")
+        }
+
+        return taxRateRepository.save(taxRate.copy(isActive = false))
+    }
+
+    private fun cascadeCombinedRate(
+        taxRateId: String,
+        organizationId: String,
+    ) {
+        val groups = taxGroupRepository.findByOrganizationIdAndTaxRateIdsContaining(organizationId, taxRateId)
+        if (groups.isEmpty()) return
+
+        val allRateIds = groups.flatMap { it.taxRateIds }.distinct()
+        val ratesById = taxRateRepository.findAllById(allRateIds).associateBy { it.id }
+
+        groups.forEach { group ->
+            val newCombinedRate =
+                group.taxRateIds.fold(BigDecimal.ZERO) { sum, id ->
+                    sum.add(ratesById[id]?.percentage ?: BigDecimal.ZERO)
+                }
+            taxGroupRepository.save(group.copy(combinedRate = newCombinedRate))
+        }
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -86,6 +86,9 @@ class RoleSeederTest {
                         Permissions.AR_APPROVE,
                         Permissions.AR_RECEIVE,
                         Permissions.AR_VOID,
+                        Permissions.TAX_CREATE,
+                        Permissions.TAX_READ,
+                        Permissions.TAX_DELETE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -164,6 +167,9 @@ class RoleSeederTest {
                         Permissions.AR_APPROVE,
                         Permissions.AR_RECEIVE,
                         Permissions.AR_VOID,
+                        Permissions.TAX_CREATE,
+                        Permissions.TAX_READ,
+                        Permissions.TAX_DELETE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -269,6 +275,9 @@ class RoleSeederTest {
                         Permissions.AR_APPROVE,
                         Permissions.AR_RECEIVE,
                         Permissions.AR_VOID,
+                        Permissions.TAX_CREATE,
+                        Permissions.TAX_READ,
+                        Permissions.TAX_DELETE,
                     ),
             )
         val admin =
@@ -304,6 +313,9 @@ class RoleSeederTest {
                         Permissions.AR_READ,
                         Permissions.AR_APPROVE,
                         Permissions.AR_RECEIVE,
+                        Permissions.TAX_CREATE,
+                        Permissions.TAX_READ,
+                        Permissions.TAX_DELETE,
                     ),
             )
         val member =
@@ -326,6 +338,7 @@ class RoleSeederTest {
                         Permissions.AP_READ,
                         Permissions.AR_CREATE,
                         Permissions.AR_READ,
+                        Permissions.TAX_READ,
                     ),
             )
         val viewer =
@@ -342,6 +355,7 @@ class RoleSeederTest {
                         Permissions.FISCAL_READ,
                         Permissions.AP_READ,
                         Permissions.AR_READ,
+                        Permissions.TAX_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/froilan/synectix/service/AccountServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/AccountServiceTest.kt
@@ -337,7 +337,7 @@ class AccountServiceTest {
     }
 
     @Test
-    fun `seedDefaultAccounts should create 20 default accounts`() {
+    fun `seedDefaultAccounts should create 22 default accounts`() {
         `when`(accountRepository.saveAll(any<List<Account>>())).thenAnswer { it.arguments[0] }
 
         accountService.seedDefaultAccounts("org-123")
@@ -347,7 +347,7 @@ class AccountServiceTest {
         verify(accountRepository).saveAll(captor.capture())
 
         val savedAccounts = captor.firstValue
-        assertThat(savedAccounts).hasSize(20)
+        assertThat(savedAccounts).hasSize(22)
         assertThat(savedAccounts).allMatch { it.isSystemAccount }
         assertThat(savedAccounts).allMatch { it.organizationId == "org-123" }
         assertThat(savedAccounts).allMatch { it.isActive }

--- a/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/BillServiceTest.kt
@@ -11,6 +11,7 @@ import com.froilan.synectix.model.BillLine
 import com.froilan.synectix.model.BillPayment
 import com.froilan.synectix.model.BillStatus
 import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.model.PaymentMethod
 import com.froilan.synectix.model.Vendor
@@ -25,6 +26,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -37,6 +39,7 @@ class BillServiceTest {
     private lateinit var accountRepository: AccountRepository
     private lateinit var vendorService: VendorService
     private lateinit var journalEntryService: JournalEntryService
+    private lateinit var taxGroupService: TaxGroupService
 
     private val orgId = "org-123"
     private val userId = "user-1"
@@ -48,6 +51,9 @@ class BillServiceTest {
         accountRepository = mock(AccountRepository::class.java)
         vendorService = mock(VendorService::class.java)
         journalEntryService = mock(JournalEntryService::class.java)
+        taxGroupService = mock(TaxGroupService::class.java)
+        `when`(taxGroupService.calculateTaxAmount(anyOrNull(), any(), any()))
+            .thenReturn(java.math.BigDecimal.ZERO)
         billService =
             BillService(
                 billRepository = billRepository,
@@ -55,6 +61,7 @@ class BillServiceTest {
                 accountRepository = accountRepository,
                 vendorService = vendorService,
                 journalEntryService = journalEntryService,
+                taxGroupService = taxGroupService,
             )
     }
 
@@ -356,14 +363,87 @@ class BillServiceTest {
         val vendorAging = report.vendors[0]
         assertThat(vendorAging.vendorName).isEqualTo("Acme Corp")
 
-        // bill-1: due May 15, asOf May 1 -> not overdue -> current
         assertThat(vendorAging.aging.current).isEqualByComparingTo(BigDecimal("100.00"))
-        // bill-2: due Apr 15, asOf May 1 -> 16 days overdue -> 1-30 bucket
         assertThat(vendorAging.aging.days1to30).isEqualByComparingTo(BigDecimal("200.00"))
-        // bill-3: due Feb 1, asOf May 1 -> 89 days overdue -> 61-90 bucket, outstanding = 250
         assertThat(vendorAging.aging.days61to90).isEqualByComparingTo(BigDecimal("250.00"))
 
         assertThat(report.totals.total).isEqualByComparingTo(BigDecimal("550.00"))
+    }
+
+    @Test
+    fun `create with taxGroupId should compute and store tax`() {
+        val vendor = createVendor()
+        val expenseAccount = createAccount("acc-1", "5000", "Office Supplies", AccountType.EXPENSE)
+
+        `when`(vendorService.getVendor("v-1", orgId)).thenReturn(vendor)
+        `when`(accountRepository.findAllById(listOf("acc-1")))
+            .thenReturn(listOf(expenseAccount))
+        `when`(billRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+        `when`(taxGroupService.calculateTaxAmount(any(), any(), any()))
+            .thenReturn(BigDecimal("42.50"))
+
+        val request =
+            CreateBillRequest(
+                vendorId = "v-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                taxGroupId = "tg-1",
+                lines = listOf(BillLineRequest(accountId = "acc-1", amount = BigDecimal("500.00"))),
+            )
+
+        val result = billService.createBill(request, orgId, userId)
+
+        assertThat(result.taxGroupId).isEqualTo("tg-1")
+        assertThat(result.taxAmount).isEqualByComparingTo(BigDecimal("42.50"))
+        assertThat(result.totalAmount).isEqualByComparingTo(BigDecimal("542.50"))
+    }
+
+    @Test
+    fun `approve with tax should include tax input debit and correct AP credit`() {
+        val bill =
+            createBill(
+                status = BillStatus.DRAFT,
+                totalAmount = BigDecimal("542.50"),
+                taxAmount = BigDecimal("42.50"),
+            )
+        val apAccount = createAccount("acc-ap", "2000", "Accounts Payable", AccountType.LIABILITY)
+        val taxInputAccount = createAccount("acc-tax", "2310", "Tax Input Credits", AccountType.ASSET)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(billRepository.findById("bill-1")).thenReturn(Optional.of(bill))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2000"))
+            .thenReturn(Optional.of(apAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2310"))
+            .thenReturn(Optional.of(taxInputAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(billRepository.save(any<Bill>())).thenAnswer { it.arguments[0] }
+
+        billService.approveBill("bill-1", orgId, userId)
+
+        val linesCaptor = argumentCaptor<List<JournalEntryLine>>()
+        verify(journalEntryService).createSystemEntry(
+            any(),
+            any(),
+            any(),
+            linesCaptor.capture(),
+            any(),
+            any(),
+        )
+        val lines = linesCaptor.firstValue
+
+        val expenseDebit = lines.find { it.accountCode == "5000" }
+        assertThat(expenseDebit).isNotNull
+        assertThat(expenseDebit!!.debit).isEqualByComparingTo(BigDecimal("500.00"))
+
+        val taxDebit = lines.find { it.accountCode == "2310" }
+        assertThat(taxDebit).isNotNull
+        assertThat(taxDebit!!.debit).isEqualByComparingTo(BigDecimal("42.50"))
+
+        val apCredit = lines.find { it.accountCode == "2000" }
+        assertThat(apCredit).isNotNull
+        assertThat(apCredit!!.credit).isEqualByComparingTo(BigDecimal("542.50"))
     }
 
     private fun createVendor(
@@ -396,6 +476,7 @@ class BillServiceTest {
         vendorId: String = "v-1",
         status: BillStatus = BillStatus.DRAFT,
         totalAmount: BigDecimal = BigDecimal("500.00"),
+        taxAmount: BigDecimal = BigDecimal.ZERO,
         amountPaid: BigDecimal = BigDecimal.ZERO,
         dueDate: LocalDate = LocalDate.of(2026, 3, 31),
         journalEntryId: String? = null,
@@ -414,10 +495,11 @@ class BillServiceTest {
                     accountId = "acc-1",
                     accountCode = "5000",
                     accountName = "Office Supplies",
-                    amount = totalAmount,
+                    amount = totalAmount.subtract(taxAmount),
                 ),
             ),
         totalAmount = totalAmount,
+        taxAmount = taxAmount,
         amountPaid = amountPaid,
         journalEntryId = journalEntryId,
         createdBy = userId,

--- a/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FiscalYearServiceTest.kt
@@ -449,17 +449,14 @@ class FiscalYearServiceTest {
         assertThat(closingEntry.description).contains("Year-end closing entry")
         assertThat(closingEntry.status).isEqualTo(JournalEntryStatus.POSTED)
 
-        // Revenue (1000 credit balance) should be debited to zero it
         val revenueLine = closingEntry.lines.find { it.accountId == "acc-revenue" }
         assertThat(revenueLine).isNotNull
         assertThat(revenueLine!!.debit).isEqualByComparingTo(BigDecimal("1000.00"))
 
-        // Expense (300 debit balance) should be credited to zero it
         val expenseLine = closingEntry.lines.find { it.accountId == "acc-expense" }
         assertThat(expenseLine).isNotNull
         assertThat(expenseLine!!.credit).isEqualByComparingTo(BigDecimal("300.00"))
 
-        // Net income = 1000 - 300 = 700, credited to Retained Earnings
         val reLine = closingEntry.lines.find { it.accountId == "acc-re" }
         assertThat(reLine).isNotNull
         assertThat(reLine!!.credit).isEqualByComparingTo(BigDecimal("700.00"))
@@ -556,8 +553,6 @@ class FiscalYearServiceTest {
         verify(journalEntryRepository).save(entryCaptor.capture())
 
         val closingEntry = entryCaptor.firstValue
-        // Net loss: 0 revenue - 500 expense = -500
-        // Retained Earnings should be debited (reducing equity)
         val reLine = closingEntry.lines.find { it.accountId == "acc-re" }
         assertThat(reLine).isNotNull
         assertThat(reLine!!.debit).isEqualByComparingTo(BigDecimal("500.00"))

--- a/src/test/kotlin/com/froilan/synectix/service/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InvoiceServiceTest.kt
@@ -12,6 +12,7 @@ import com.froilan.synectix.model.InvoiceLine
 import com.froilan.synectix.model.InvoiceReceipt
 import com.froilan.synectix.model.InvoiceStatus
 import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.model.PaymentMethod
 import com.froilan.synectix.repository.AccountRepository
@@ -25,6 +26,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -37,6 +39,7 @@ class InvoiceServiceTest {
     private lateinit var accountRepository: AccountRepository
     private lateinit var customerService: CustomerService
     private lateinit var journalEntryService: JournalEntryService
+    private lateinit var taxGroupService: TaxGroupService
 
     private val orgId = "org-123"
     private val userId = "user-1"
@@ -48,6 +51,9 @@ class InvoiceServiceTest {
         accountRepository = mock(AccountRepository::class.java)
         customerService = mock(CustomerService::class.java)
         journalEntryService = mock(JournalEntryService::class.java)
+        taxGroupService = mock(TaxGroupService::class.java)
+        `when`(taxGroupService.calculateTaxAmount(anyOrNull(), any(), any()))
+            .thenReturn(java.math.BigDecimal.ZERO)
         invoiceService =
             InvoiceService(
                 invoiceRepository = invoiceRepository,
@@ -55,6 +61,7 @@ class InvoiceServiceTest {
                 accountRepository = accountRepository,
                 customerService = customerService,
                 journalEntryService = journalEntryService,
+                taxGroupService = taxGroupService,
             )
     }
 
@@ -336,11 +343,8 @@ class InvoiceServiceTest {
         val customerAging = report.customers[0]
         assertThat(customerAging.customerName).isEqualTo("BigCorp")
 
-        // inv-1: due May 15, asOf May 1 -> not overdue -> current
         assertThat(customerAging.aging.current).isEqualByComparingTo(BigDecimal("500.00"))
-        // inv-2: due Apr 15, asOf May 1 -> 16 days overdue -> 1-30 bucket
         assertThat(customerAging.aging.days1to30).isEqualByComparingTo(BigDecimal("800.00"))
-        // inv-3: due Feb 1, asOf May 1 -> 89 days overdue -> 61-90 bucket, outstanding = 800
         assertThat(customerAging.aging.days61to90).isEqualByComparingTo(BigDecimal("800.00"))
 
         assertThat(report.totals.total).isEqualByComparingTo(BigDecimal("2100.00"))
@@ -357,6 +361,82 @@ class InvoiceServiceTest {
         organizationId = orgId,
         isActive = isActive,
     )
+
+    @Test
+    fun `create with taxGroupId should compute and store tax`() {
+        val customer = createCustomer()
+        val revenueAccount = createAccount("acc-1", "4100", "Service Revenue", AccountType.REVENUE)
+
+        `when`(customerService.getCustomer("c-1", orgId)).thenReturn(customer)
+        `when`(accountRepository.findAllById(listOf("acc-1")))
+            .thenReturn(listOf(revenueAccount))
+        `when`(invoiceRepository.countByOrganizationId(orgId)).thenReturn(0L)
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+        `when`(taxGroupService.calculateTaxAmount(any(), any(), any()))
+            .thenReturn(BigDecimal("170.00"))
+
+        val request =
+            CreateInvoiceRequest(
+                customerId = "c-1",
+                date = LocalDate.of(2026, 3, 1),
+                dueDate = LocalDate.of(2026, 3, 31),
+                taxGroupId = "tg-1",
+                lines = listOf(InvoiceLineRequest(accountId = "acc-1", amount = BigDecimal("2000.00"))),
+            )
+
+        val result = invoiceService.createInvoice(request, orgId, userId)
+
+        assertThat(result.taxGroupId).isEqualTo("tg-1")
+        assertThat(result.taxAmount).isEqualByComparingTo(BigDecimal("170.00"))
+        assertThat(result.totalAmount).isEqualByComparingTo(BigDecimal("2170.00"))
+    }
+
+    @Test
+    fun `approve with tax should include tax payable credit and correct AR debit`() {
+        val invoice =
+            createInvoice(
+                status = InvoiceStatus.DRAFT,
+                totalAmount = BigDecimal("2170.00"),
+                taxAmount = BigDecimal("170.00"),
+            )
+        val arAccount = createAccount("acc-ar", "1100", "Accounts Receivable", AccountType.ASSET)
+        val taxPayableAccount = createAccount("acc-tax", "2300", "Sales Tax Payable", AccountType.LIABILITY)
+        val mockEntry = createMockJournalEntry()
+
+        `when`(invoiceRepository.findById("inv-1")).thenReturn(Optional.of(invoice))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "1100"))
+            .thenReturn(Optional.of(arAccount))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2300"))
+            .thenReturn(Optional.of(taxPayableAccount))
+        `when`(journalEntryService.createSystemEntry(any(), any(), any(), any(), any(), any()))
+            .thenReturn(mockEntry)
+        `when`(invoiceRepository.save(any<Invoice>())).thenAnswer { it.arguments[0] }
+
+        invoiceService.approveInvoice("inv-1", orgId, userId)
+
+        val linesCaptor = argumentCaptor<List<JournalEntryLine>>()
+        verify(journalEntryService).createSystemEntry(
+            any(),
+            any(),
+            any(),
+            linesCaptor.capture(),
+            any(),
+            any(),
+        )
+        val lines = linesCaptor.firstValue
+
+        val arDebit = lines.find { it.accountCode == "1100" }
+        assertThat(arDebit).isNotNull
+        assertThat(arDebit!!.debit).isEqualByComparingTo(BigDecimal("2170.00"))
+
+        val revenueCredit = lines.find { it.accountCode == "4100" }
+        assertThat(revenueCredit).isNotNull
+        assertThat(revenueCredit!!.credit).isEqualByComparingTo(BigDecimal("2000.00"))
+
+        val taxCredit = lines.find { it.accountCode == "2300" }
+        assertThat(taxCredit).isNotNull
+        assertThat(taxCredit!!.credit).isEqualByComparingTo(BigDecimal("170.00"))
+    }
 
     private fun createAccount(
         id: String,
@@ -376,6 +456,7 @@ class InvoiceServiceTest {
         customerId: String = "c-1",
         status: InvoiceStatus = InvoiceStatus.DRAFT,
         totalAmount: BigDecimal = BigDecimal("2000.00"),
+        taxAmount: BigDecimal = BigDecimal.ZERO,
         amountReceived: BigDecimal = BigDecimal.ZERO,
         dueDate: LocalDate = LocalDate.of(2026, 3, 31),
         journalEntryId: String? = null,
@@ -394,10 +475,11 @@ class InvoiceServiceTest {
                     accountId = "acc-1",
                     accountCode = "4100",
                     accountName = "Service Revenue",
-                    amount = totalAmount,
+                    amount = totalAmount.subtract(taxAmount),
                 ),
             ),
         totalAmount = totalAmount,
+        taxAmount = taxAmount,
         amountReceived = amountReceived,
         journalEntryId = journalEntryId,
         createdBy = userId,

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -392,11 +392,9 @@ class JournalEntryServiceTest {
         val allSaved = captor.allValues
         assertThat(allSaved).hasSize(2)
 
-        // First save is the voided entry
         val voidedSave = allSaved[0]
         assertThat(voidedSave.status).isEqualTo(JournalEntryStatus.VOIDED)
 
-        // Second save is the reversing entry
         val reversingSave = allSaved[1]
         assertThat(reversingSave.status).isEqualTo(JournalEntryStatus.POSTED)
         assertThat(reversingSave.source).isEqualTo(JournalEntrySource.SYSTEM)
@@ -509,7 +507,6 @@ class JournalEntryServiceTest {
         assertThat(result.accountType).isEqualTo("ASSET")
         assertThat(result.totalDebits).isEqualByComparingTo(BigDecimal("500.00"))
         assertThat(result.totalCredits).isEqualByComparingTo(BigDecimal("150.00"))
-        // ASSET: balance = debits - credits
         assertThat(result.balance).isEqualByComparingTo(BigDecimal("350.00"))
     }
 
@@ -554,7 +551,6 @@ class JournalEntryServiceTest {
         assertThat(result.accounts).hasSize(2)
         assertThat(result.totalDebits).isEqualByComparingTo(BigDecimal("300.00"))
         assertThat(result.totalCredits).isEqualByComparingTo(BigDecimal("300.00"))
-        // Trial balance must balance: total debits == total credits
         assertThat(result.totalDebits).isEqualByComparingTo(result.totalCredits)
 
         val cashBalance = result.accounts.find { it.accountId == "acc-1" }
@@ -565,7 +561,6 @@ class JournalEntryServiceTest {
         val revenueBalance = result.accounts.find { it.accountId == "acc-2" }
         assertThat(revenueBalance).isNotNull
         assertThat(revenueBalance!!.totalCredits).isEqualByComparingTo(BigDecimal("300.00"))
-        // REVENUE: balance = credits - debits
         assertThat(revenueBalance.balance).isEqualByComparingTo(BigDecimal("300.00"))
     }
 

--- a/src/test/kotlin/com/froilan/synectix/service/TaxGroupServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/TaxGroupServiceTest.kt
@@ -1,0 +1,375 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.AccountBalanceResponse
+import com.froilan.synectix.dto.CreateTaxGroupRequest
+import com.froilan.synectix.dto.UpdateTaxGroupRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.model.Account
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.TaxGroup
+import com.froilan.synectix.model.TaxRate
+import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.TaxGroupRepository
+import com.froilan.synectix.repository.TaxRateRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class TaxGroupServiceTest {
+    private lateinit var taxGroupService: TaxGroupService
+    private lateinit var taxGroupRepository: TaxGroupRepository
+    private lateinit var taxRateRepository: TaxRateRepository
+    private lateinit var accountRepository: AccountRepository
+    private lateinit var journalEntryService: JournalEntryService
+
+    private val orgId = "org-123"
+
+    @BeforeEach
+    fun setup() {
+        taxGroupRepository = mock(TaxGroupRepository::class.java)
+        taxRateRepository = mock(TaxRateRepository::class.java)
+        accountRepository = mock(AccountRepository::class.java)
+        journalEntryService = mock(JournalEntryService::class.java)
+        taxGroupService = TaxGroupService(taxGroupRepository, taxRateRepository, accountRepository, journalEntryService)
+    }
+
+    @Test
+    fun `create should compute combinedRate from member rates`() {
+        val rate1 = createTaxRate("tr-1", BigDecimal("4.00"))
+        val rate2 = createTaxRate("tr-2", BigDecimal("4.50"))
+
+        `when`(taxRateRepository.findAllById(listOf("tr-1", "tr-2")))
+            .thenReturn(listOf(rate1, rate2))
+        `when`(taxGroupRepository.save(any<TaxGroup>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateTaxGroupRequest(
+                name = "NY Combined",
+                code = "NYC",
+                taxRateIds = listOf("tr-1", "tr-2"),
+            )
+
+        val result = taxGroupService.createTaxGroup(request, orgId)
+
+        assertThat(result.combinedRate).isEqualByComparingTo(BigDecimal("8.50"))
+        assertThat(result.taxRateIds).hasSize(2)
+    }
+
+    @Test
+    fun `create should throw when taxRateId not found`() {
+        `when`(taxRateRepository.findAllById(listOf("tr-missing")))
+            .thenReturn(emptyList())
+
+        val request =
+            CreateTaxGroupRequest(
+                name = "Bad Group",
+                code = "BAD",
+                taxRateIds = listOf("tr-missing"),
+            )
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                taxGroupService.createTaxGroup(request, orgId)
+            }
+        assertThat(exception.message).contains("not found")
+    }
+
+    @Test
+    fun `create should throw when taxRate belongs to different org`() {
+        val rate = createTaxRate("tr-1", BigDecimal("5.00"), orgId = "other-org")
+        `when`(taxRateRepository.findAllById(listOf("tr-1"))).thenReturn(listOf(rate))
+
+        val request =
+            CreateTaxGroupRequest(
+                name = "Wrong Org",
+                code = "WO",
+                taxRateIds = listOf("tr-1"),
+            )
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                taxGroupService.createTaxGroup(request, orgId)
+            }
+        assertThat(exception.message).contains("not found")
+    }
+
+    @Test
+    fun `update taxRateIds should recompute combinedRate`() {
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Old Group",
+                code = "OLD",
+                taxRateIds = listOf("tr-1"),
+                combinedRate = BigDecimal("4.00"),
+                organizationId = orgId,
+            )
+        val rate1 = createTaxRate("tr-1", BigDecimal("4.00"))
+        val rate2 = createTaxRate("tr-2", BigDecimal("6.00"))
+
+        `when`(taxGroupRepository.findById("tg-1")).thenReturn(Optional.of(group))
+        `when`(taxRateRepository.findAllById(listOf("tr-1", "tr-2")))
+            .thenReturn(listOf(rate1, rate2))
+        `when`(taxGroupRepository.save(any<TaxGroup>())).thenAnswer { it.arguments[0] }
+
+        val result =
+            taxGroupService.updateTaxGroup(
+                "tg-1",
+                UpdateTaxGroupRequest(taxRateIds = listOf("tr-1", "tr-2")),
+                orgId,
+            )
+
+        assertThat(result.combinedRate).isEqualByComparingTo(BigDecimal("10.00"))
+    }
+
+    @Test
+    fun `calculateTaxAmount should return zero for null taxGroupId`() {
+        val result = taxGroupService.calculateTaxAmount(null, orgId, BigDecimal("1000.00"))
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `calculateTaxAmount should compute correctly with rounding`() {
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Test",
+                code = "TST",
+                taxRateIds = listOf("tr-1"),
+                combinedRate = BigDecimal("8.50"),
+                organizationId = orgId,
+            )
+        `when`(taxGroupRepository.findById("tg-1")).thenReturn(Optional.of(group))
+
+        val result = taxGroupService.calculateTaxAmount("tg-1", orgId, BigDecimal("1000.00"))
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("85.00"))
+    }
+
+    @Test
+    fun `calculateTaxAmount should round to 2 decimal places`() {
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Test",
+                code = "TST",
+                taxRateIds = listOf("tr-1"),
+                combinedRate = BigDecimal("8.333"),
+                organizationId = orgId,
+            )
+        `when`(taxGroupRepository.findById("tg-1")).thenReturn(Optional.of(group))
+
+        val result = taxGroupService.calculateTaxAmount("tg-1", orgId, BigDecimal("100.00"))
+
+        assertThat(result).isEqualByComparingTo(BigDecimal("8.33"))
+    }
+
+    @Test
+    fun `getTaxGroupWithRates should preserve taxRateIds order`() {
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Ordered Group",
+                code = "ORD",
+                taxRateIds = listOf("tr-c", "tr-a", "tr-b"),
+                combinedRate = BigDecimal("10.00"),
+                organizationId = orgId,
+            )
+        val rateA = createTaxRate("tr-a", BigDecimal("3.00"))
+        val rateB = createTaxRate("tr-b", BigDecimal("3.00"))
+        val rateC = createTaxRate("tr-c", BigDecimal("4.00"))
+
+        `when`(taxGroupRepository.findById("tg-1")).thenReturn(Optional.of(group))
+        `when`(taxRateRepository.findAllById(listOf("tr-c", "tr-a", "tr-b")))
+            .thenReturn(listOf(rateA, rateB, rateC))
+
+        val (_, rates) = taxGroupService.getTaxGroupWithRates("tg-1", orgId)
+
+        assertThat(rates.map { it.id }).containsExactly("tr-c", "tr-a", "tr-b")
+    }
+
+    @Test
+    fun `getTaxGroupWithRates should reject cross-org rate ids`() {
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Group",
+                code = "GRP",
+                taxRateIds = listOf("tr-1", "tr-foreign"),
+                combinedRate = BigDecimal("10.00"),
+                organizationId = orgId,
+            )
+        val rate1 = createTaxRate("tr-1", BigDecimal("5.00"))
+        val foreignRate = createTaxRate("tr-foreign", BigDecimal("5.00"), orgId = "other-org")
+
+        `when`(taxGroupRepository.findById("tg-1")).thenReturn(Optional.of(group))
+        `when`(taxRateRepository.findAllById(listOf("tr-1", "tr-foreign")))
+            .thenReturn(listOf(rate1, foreignRate))
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                taxGroupService.getTaxGroupWithRates("tg-1", orgId)
+            }
+        assertThat(exception.message).contains("tr-foreign")
+    }
+
+    @Test
+    fun `update without taxRateIds should validate existing rates and reject cross-org`() {
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Existing",
+                code = "EXG",
+                taxRateIds = listOf("tr-1", "tr-foreign"),
+                combinedRate = BigDecimal("10.00"),
+                organizationId = orgId,
+            )
+        val rate1 = createTaxRate("tr-1", BigDecimal("5.00"))
+        val foreignRate = createTaxRate("tr-foreign", BigDecimal("5.00"), orgId = "other-org")
+
+        `when`(taxGroupRepository.findById("tg-1")).thenReturn(Optional.of(group))
+        `when`(taxRateRepository.findAllById(listOf("tr-1", "tr-foreign")))
+            .thenReturn(listOf(rate1, foreignRate))
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                taxGroupService.updateTaxGroup(
+                    "tg-1",
+                    UpdateTaxGroupRequest(name = "Renamed"),
+                    orgId,
+                )
+            }
+        assertThat(exception.message).contains("not found")
+    }
+
+    @Test
+    fun `getTaxGroupWithRates should throw when referenced rate is missing`() {
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Broken Group",
+                code = "BRK",
+                taxRateIds = listOf("tr-1", "tr-missing"),
+                combinedRate = BigDecimal("5.00"),
+                organizationId = orgId,
+            )
+        val rate1 = createTaxRate("tr-1", BigDecimal("5.00"))
+
+        `when`(taxGroupRepository.findById("tg-1")).thenReturn(Optional.of(group))
+        `when`(taxRateRepository.findAllById(listOf("tr-1", "tr-missing")))
+            .thenReturn(listOf(rate1))
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                taxGroupService.getTaxGroupWithRates("tg-1", orgId)
+            }
+        assertThat(exception.message).contains("tr-missing")
+    }
+
+    @Test
+    fun `getTaxSummary should reject when start date is after end date`() {
+        val exception =
+            assertThrows<BusinessRuleException> {
+                taxGroupService.getTaxSummary(
+                    orgId,
+                    startDate = LocalDate.of(2026, 4, 1),
+                    endDate = LocalDate.of(2026, 3, 1),
+                )
+            }
+        assertThat(exception.message).contains("on or before")
+    }
+
+    @Test
+    fun `getTaxSummary should return zero when tax accounts not configured`() {
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2300"))
+            .thenReturn(Optional.empty())
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2310"))
+            .thenReturn(Optional.empty())
+
+        val result =
+            taxGroupService.getTaxSummary(
+                orgId,
+                startDate = LocalDate.of(2026, 3, 1),
+                endDate = LocalDate.of(2026, 3, 31),
+            )
+
+        assertThat(result.taxCollected).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.taxPaid).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.netTaxLiability).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `getTaxSummary should compute net liability from balance deltas`() {
+        val payable = createAccount("acc-2300", "2300", AccountType.LIABILITY)
+        val input = createAccount("acc-2310", "2310", AccountType.ASSET)
+        val startDate = LocalDate.of(2026, 3, 1)
+        val endDate = LocalDate.of(2026, 3, 31)
+
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2300"))
+            .thenReturn(Optional.of(payable))
+        `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2310"))
+            .thenReturn(Optional.of(input))
+
+        `when`(journalEntryService.getAccountBalance("acc-2300", orgId, endDate))
+            .thenReturn(balanceOf(payable, BigDecimal("500.00")))
+        `when`(journalEntryService.getAccountBalance("acc-2300", orgId, startDate.minusDays(1)))
+            .thenReturn(balanceOf(payable, BigDecimal("100.00")))
+        `when`(journalEntryService.getAccountBalance("acc-2310", orgId, endDate))
+            .thenReturn(balanceOf(input, BigDecimal("150.00")))
+        `when`(journalEntryService.getAccountBalance("acc-2310", orgId, startDate.minusDays(1)))
+            .thenReturn(balanceOf(input, BigDecimal("50.00")))
+
+        val result = taxGroupService.getTaxSummary(orgId, startDate, endDate)
+
+        assertThat(result.taxCollected).isEqualByComparingTo(BigDecimal("400.00"))
+        assertThat(result.taxPaid).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(result.netTaxLiability).isEqualByComparingTo(BigDecimal("300.00"))
+        assertThat(result.startDate).isEqualTo(startDate.toString())
+        assertThat(result.endDate).isEqualTo(endDate.toString())
+    }
+
+    private fun createTaxRate(
+        id: String = "tr-1",
+        percentage: BigDecimal = BigDecimal("8.00"),
+        orgId: String = this.orgId,
+    ) = TaxRate(
+        id = id,
+        name = "Tax Rate $id",
+        code = "TR-$id",
+        percentage = percentage,
+        authority = "State",
+        organizationId = orgId,
+    )
+
+    private fun createAccount(
+        id: String,
+        code: String,
+        type: AccountType,
+    ) = Account(
+        id = id,
+        code = code,
+        name = "Account $code",
+        type = type,
+        organizationId = orgId,
+    )
+
+    private fun balanceOf(
+        account: Account,
+        balance: BigDecimal,
+    ) = AccountBalanceResponse(
+        accountId = account.id,
+        accountCode = account.code,
+        accountName = account.name,
+        accountType = account.type.name,
+        totalDebits = BigDecimal.ZERO,
+        totalCredits = BigDecimal.ZERO,
+        balance = balance,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/TaxRateServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/TaxRateServiceTest.kt
@@ -1,0 +1,141 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateTaxRateRequest
+import com.froilan.synectix.dto.UpdateTaxRateRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.TaxGroup
+import com.froilan.synectix.model.TaxRate
+import com.froilan.synectix.repository.TaxGroupRepository
+import com.froilan.synectix.repository.TaxRateRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import java.math.BigDecimal
+import java.util.Optional
+
+class TaxRateServiceTest {
+    private lateinit var taxRateService: TaxRateService
+    private lateinit var taxRateRepository: TaxRateRepository
+    private lateinit var taxGroupRepository: TaxGroupRepository
+
+    private val orgId = "org-123"
+
+    @BeforeEach
+    fun setup() {
+        taxRateRepository = mock(TaxRateRepository::class.java)
+        taxGroupRepository = mock(TaxGroupRepository::class.java)
+        taxRateService = TaxRateService(taxRateRepository, taxGroupRepository)
+    }
+
+    @Test
+    fun `create should save tax rate with correct fields`() {
+        `when`(taxRateRepository.save(any<TaxRate>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateTaxRateRequest(
+                name = "State Sales Tax",
+                code = "SST",
+                percentage = BigDecimal("8.00"),
+                authority = "State",
+            )
+
+        val result = taxRateService.createTaxRate(request, orgId)
+
+        assertThat(result.name).isEqualTo("State Sales Tax")
+        assertThat(result.code).isEqualTo("SST")
+        assertThat(result.percentage).isEqualByComparingTo(BigDecimal("8.00"))
+        assertThat(result.authority).isEqualTo("State")
+        assertThat(result.isActive).isTrue()
+    }
+
+    @Test
+    fun `get should throw ResourceNotFoundException for wrong org`() {
+        val rate = createTaxRate(orgId = "other-org")
+        `when`(taxRateRepository.findById("tr-1")).thenReturn(Optional.of(rate))
+
+        assertThrows<ResourceNotFoundException> {
+            taxRateService.getTaxRate("tr-1", orgId)
+        }
+    }
+
+    @Test
+    fun `update percentage should cascade to tax groups`() {
+        val rate = createTaxRate()
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Combined",
+                code = "COMB",
+                taxRateIds = listOf("tr-1"),
+                combinedRate = BigDecimal("8.00"),
+                organizationId = orgId,
+            )
+        val updatedRate = rate.copy(percentage = BigDecimal("10.00"))
+
+        `when`(taxRateRepository.findById("tr-1")).thenReturn(Optional.of(rate))
+        `when`(taxRateRepository.save(any<TaxRate>())).thenReturn(updatedRate)
+        `when`(taxGroupRepository.findByOrganizationIdAndTaxRateIdsContaining(orgId, "tr-1"))
+            .thenReturn(listOf(group))
+        `when`(taxRateRepository.findAllById(listOf("tr-1"))).thenReturn(listOf(updatedRate))
+        `when`(taxGroupRepository.save(any<TaxGroup>())).thenAnswer { it.arguments[0] }
+
+        taxRateService.updateTaxRate("tr-1", UpdateTaxRateRequest(percentage = BigDecimal("10.00")), orgId)
+
+        verify(taxGroupRepository).save(any<TaxGroup>())
+    }
+
+    @Test
+    fun `delete should throw when rate is in active group`() {
+        val rate = createTaxRate()
+        val activeGroup =
+            TaxGroup(
+                id = "tg-1",
+                name = "Combined",
+                code = "COMB",
+                taxRateIds = listOf("tr-1"),
+                combinedRate = BigDecimal("8.00"),
+                organizationId = orgId,
+            )
+
+        `when`(taxRateRepository.findById("tr-1")).thenReturn(Optional.of(rate))
+        `when`(taxGroupRepository.findByOrganizationIdAndTaxRateIdsContaining(orgId, "tr-1"))
+            .thenReturn(listOf(activeGroup))
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                taxRateService.deleteTaxRate("tr-1", orgId)
+            }
+        assertThat(exception.message).contains("active tax groups")
+    }
+
+    @Test
+    fun `delete should soft-delete when not in any group`() {
+        val rate = createTaxRate()
+
+        `when`(taxRateRepository.findById("tr-1")).thenReturn(Optional.of(rate))
+        `when`(taxGroupRepository.findByOrganizationIdAndTaxRateIdsContaining(orgId, "tr-1"))
+            .thenReturn(emptyList())
+        `when`(taxRateRepository.save(any<TaxRate>())).thenAnswer { it.arguments[0] }
+
+        val result = taxRateService.deleteTaxRate("tr-1", orgId)
+        assertThat(result.isActive).isFalse()
+    }
+
+    private fun createTaxRate(
+        id: String = "tr-1",
+        orgId: String = this.orgId,
+    ) = TaxRate(
+        id = id,
+        name = "State Sales Tax",
+        code = "SST",
+        percentage = BigDecimal("8.00"),
+        authority = "State",
+        organizationId = orgId,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/TaxRateServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/TaxRateServiceTest.kt
@@ -91,6 +91,38 @@ class TaxRateServiceTest {
     }
 
     @Test
+    fun `update percentage should fail-fast when cascade encounters missing rate`() {
+        val rate = createTaxRate()
+        val group =
+            TaxGroup(
+                id = "tg-1",
+                name = "Combined",
+                code = "COMB",
+                taxRateIds = listOf("tr-1", "tr-orphan"),
+                combinedRate = BigDecimal("12.00"),
+                organizationId = orgId,
+            )
+        val updatedRate = rate.copy(percentage = BigDecimal("10.00"))
+
+        `when`(taxRateRepository.findById("tr-1")).thenReturn(Optional.of(rate))
+        `when`(taxRateRepository.save(any<TaxRate>())).thenReturn(updatedRate)
+        `when`(taxGroupRepository.findByOrganizationIdAndTaxRateIdsContaining(orgId, "tr-1"))
+            .thenReturn(listOf(group))
+        `when`(taxRateRepository.findAllById(listOf("tr-1", "tr-orphan")))
+            .thenReturn(listOf(updatedRate))
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                taxRateService.updateTaxRate(
+                    "tr-1",
+                    UpdateTaxRateRequest(percentage = BigDecimal("10.00")),
+                    orgId,
+                )
+            }
+        assertThat(exception.message).contains("tr-orphan")
+    }
+
+    @Test
     fun `delete should throw when rate is in active group`() {
         val rate = createTaxRate()
         val activeGroup =


### PR DESCRIPTION
## Summary
- Promotes the merged tax module (#29 / PR #112) from staging to production.
- Single squashed commit on staging: `Tax configuration & calculation engine`.

## Scope
Ships:
- Tax rate and tax group CRUD (soft delete, per-org scoping)
- Combined-rate computation with cascading recompute on rate changes
- AP bill and AR invoice tax integration (creation locks taxAmount, approval posts to 2310 / 2300)
- Default seeding of 2300 Sales Tax Payable and 2310 Tax Input Credits
- Tax summary endpoint (period-delta over the tax accounts)
- TAX_CREATE / TAX_READ / TAX_DELETE permissions and role assignments
- Defense-in-depth validation on DTOs and service layer
- Cross-org rate guard on read and update paths

## Test plan
- [ ] CI passes on staging (already green from #112)
- [ ] Smoke test in production after deploy: create tax rate → group → bill with taxGroupId → approve → confirm GL entry includes 2310 debit line
- [ ] Same flow for invoice → confirm GL entry includes 2300 credit line
- [ ] GET /finance/tax/summary returns expected period delta