### PR TITLE
Financial reports: income statement and balance sheet

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/controller/FinancialReportController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FinancialReportController.kt
@@ -39,4 +39,20 @@ class FinancialReportController(
             )
         return ResponseEntity.ok(report)
     }
+
+    @GetMapping("/balance-sheet")
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun getBalanceSheet(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) asOfDate: LocalDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) compareAsOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val report =
+            financialReportService.getBalanceSheet(
+                organizationId = orgId,
+                asOfDate = asOfDate,
+                compareAsOfDate = compareAsOfDate,
+            )
+        return ResponseEntity.ok(report)
+    }
 }

--- a/src/main/kotlin/com/froilan/synectix/controller/FinancialReportController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FinancialReportController.kt
@@ -20,6 +20,17 @@ class FinancialReportController(
     private val financialReportService: FinancialReportService,
     private val authContext: AuthenticationContext,
 ) {
+    @GetMapping("/trial-balance")
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun getTrialBalance(
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) asOfDate: LocalDate?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) compareAsOfDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val report = financialReportService.getComparativeTrialBalance(orgId, asOfDate, compareAsOfDate)
+        return ResponseEntity.ok(report)
+    }
+
     @GetMapping("/income-statement")
     @PreAuthorize("hasAuthority('journal:read')")
     fun getIncomeStatement(

--- a/src/main/kotlin/com/froilan/synectix/controller/FinancialReportController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/FinancialReportController.kt
@@ -1,0 +1,42 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.FinancialReportService
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/finance/reports")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class FinancialReportController(
+    private val financialReportService: FinancialReportService,
+    private val authContext: AuthenticationContext,
+) {
+    @GetMapping("/income-statement")
+    @PreAuthorize("hasAuthority('journal:read')")
+    fun getIncomeStatement(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) compareStartDate: LocalDate?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) compareEndDate: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val report =
+            financialReportService.getIncomeStatement(
+                organizationId = orgId,
+                startDate = startDate,
+                endDate = endDate,
+                compareStartDate = compareStartDate,
+                compareEndDate = compareEndDate,
+            )
+        return ResponseEntity.ok(report)
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/FinancialReportDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/FinancialReportDtos.kt
@@ -8,7 +8,12 @@ data class ReportAccountLine(
     val accountName: String,
     val amount: BigDecimal,
     val comparativeAmount: BigDecimal? = null,
+    val isSynthetic: Boolean = false,
 )
+
+object SyntheticAccountIds {
+    const val CURRENT_PERIOD_EARNINGS = "__current_period_earnings__"
+}
 
 data class ComparativePeriodMeta(
     val startDate: String,

--- a/src/main/kotlin/com/froilan/synectix/dto/FinancialReportDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/FinancialReportDtos.kt
@@ -1,0 +1,55 @@
+package com.froilan.synectix.dto
+
+import java.math.BigDecimal
+
+data class ReportAccountLine(
+    val accountId: String,
+    val accountCode: String,
+    val accountName: String,
+    val amount: BigDecimal,
+    val comparativeAmount: BigDecimal? = null,
+)
+
+data class ComparativePeriodMeta(
+    val startDate: String,
+    val endDate: String,
+)
+
+data class IncomeStatementResponse(
+    val startDate: String,
+    val endDate: String,
+    val comparativePeriod: ComparativePeriodMeta? = null,
+    val revenue: List<ReportAccountLine>,
+    val totalRevenue: BigDecimal,
+    val comparativeTotalRevenue: BigDecimal? = null,
+    val expenses: List<ReportAccountLine>,
+    val totalExpenses: BigDecimal,
+    val comparativeTotalExpenses: BigDecimal? = null,
+    val netIncome: BigDecimal,
+    val comparativeNetIncome: BigDecimal? = null,
+)
+
+data class BalanceSheetResponse(
+    val asOfDate: String,
+    val comparativeAsOfDate: String? = null,
+    val assets: List<ReportAccountLine>,
+    val totalAssets: BigDecimal,
+    val comparativeTotalAssets: BigDecimal? = null,
+    val liabilities: List<ReportAccountLine>,
+    val totalLiabilities: BigDecimal,
+    val comparativeTotalLiabilities: BigDecimal? = null,
+    val equity: List<ReportAccountLine>,
+    val totalEquity: BigDecimal,
+    val comparativeTotalEquity: BigDecimal? = null,
+    val currentEarnings: BigDecimal,
+    val comparativeCurrentEarnings: BigDecimal? = null,
+    val totalLiabilitiesAndEquity: BigDecimal,
+    val comparativeTotalLiabilitiesAndEquity: BigDecimal? = null,
+    val isBalanced: Boolean,
+    val outOfBalanceAmount: BigDecimal,
+)
+
+data class ComparativeTrialBalanceResponse(
+    val current: TrialBalanceResponse,
+    val comparative: TrialBalanceResponse? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Account.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Account.kt
@@ -6,6 +6,7 @@ import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.mongodb.core.index.CompoundIndex
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -15,6 +16,16 @@ enum class AccountType {
     EQUITY,
     REVENUE,
     EXPENSE,
+    ;
+
+    fun signedBalance(
+        debits: BigDecimal,
+        credits: BigDecimal,
+    ): BigDecimal =
+        when (this) {
+            ASSET, EXPENSE -> debits.subtract(credits)
+            LIABILITY, EQUITY, REVENUE -> credits.subtract(debits)
+        }
 }
 
 @Document(collection = "accounts")

--- a/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
@@ -1,5 +1,6 @@
 package com.froilan.synectix.service
 
+import com.froilan.synectix.dto.BalanceSheetResponse
 import com.froilan.synectix.dto.ComparativePeriodMeta
 import com.froilan.synectix.dto.IncomeStatementResponse
 import com.froilan.synectix.dto.ReportAccountLine
@@ -84,6 +85,94 @@ class FinancialReportService(
                     null
                 },
         )
+    }
+
+    fun getBalanceSheet(
+        organizationId: String,
+        asOfDate: LocalDate,
+        compareAsOfDate: LocalDate? = null,
+    ): BalanceSheetResponse {
+        val accounts = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        val current = computePeriodTotals(organizationId, null, asOfDate)
+        val comparative = compareAsOfDate?.let { computePeriodTotals(organizationId, null, it) }
+
+        val assets = buildLines(accounts, AccountType.ASSET, current, comparative)
+        val liabilities = buildLines(accounts, AccountType.LIABILITY, current, comparative)
+        val equityAccounts = buildLines(accounts, AccountType.EQUITY, current, comparative)
+
+        val currentEarnings = computeCurrentEarnings(accounts, current)
+        val comparativeCurrentEarnings = comparative?.let { computeCurrentEarnings(accounts, it) }
+
+        val earningsLine =
+            ReportAccountLine(
+                accountId = "",
+                accountCode = "",
+                accountName = "Current Period Earnings",
+                amount = currentEarnings,
+                comparativeAmount = comparativeCurrentEarnings,
+            )
+        val equity = equityAccounts + earningsLine
+
+        val totalAssets = assets.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.amount) }
+        val totalLiabilities = liabilities.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.amount) }
+        val totalEquity = equity.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.amount) }
+        val totalLiabilitiesAndEquity = totalLiabilities.add(totalEquity)
+        val outOfBalance = totalAssets.subtract(totalLiabilitiesAndEquity)
+
+        val comparativeTotalAssets =
+            comparative?.let { assets.fold(BigDecimal.ZERO) { a, l -> a.add(l.comparativeAmount ?: BigDecimal.ZERO) } }
+        val comparativeTotalLiabilities =
+            comparative?.let {
+                liabilities.fold(BigDecimal.ZERO) { a, l -> a.add(l.comparativeAmount ?: BigDecimal.ZERO) }
+            }
+        val comparativeTotalEquity =
+            comparative?.let { equity.fold(BigDecimal.ZERO) { a, l -> a.add(l.comparativeAmount ?: BigDecimal.ZERO) } }
+        val comparativeTotalLiabAndEq =
+            if (comparativeTotalLiabilities != null && comparativeTotalEquity != null) {
+                comparativeTotalLiabilities.add(comparativeTotalEquity)
+            } else {
+                null
+            }
+
+        return BalanceSheetResponse(
+            asOfDate = asOfDate.toString(),
+            comparativeAsOfDate = compareAsOfDate?.toString(),
+            assets = assets,
+            totalAssets = totalAssets,
+            comparativeTotalAssets = comparativeTotalAssets,
+            liabilities = liabilities,
+            totalLiabilities = totalLiabilities,
+            comparativeTotalLiabilities = comparativeTotalLiabilities,
+            equity = equity,
+            totalEquity = totalEquity,
+            comparativeTotalEquity = comparativeTotalEquity,
+            currentEarnings = currentEarnings,
+            comparativeCurrentEarnings = comparativeCurrentEarnings,
+            totalLiabilitiesAndEquity = totalLiabilitiesAndEquity,
+            comparativeTotalLiabilitiesAndEquity = comparativeTotalLiabAndEq,
+            isBalanced = outOfBalance.abs() < BigDecimal("0.01"),
+            outOfBalanceAmount = outOfBalance,
+        )
+    }
+
+    private fun computeCurrentEarnings(
+        accounts: List<Account>,
+        totals: Map<String, Pair<BigDecimal, BigDecimal>>,
+    ): BigDecimal {
+        var earnings = BigDecimal.ZERO
+        accounts
+            .filter { it.type == AccountType.REVENUE || it.type == AccountType.EXPENSE }
+            .forEach { account ->
+                val (debits, credits) = totals.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
+                val signed = signedBalance(account.type, debits, credits)
+                earnings =
+                    if (account.type == AccountType.REVENUE) {
+                        earnings.add(signed)
+                    } else {
+                        earnings.subtract(signed)
+                    }
+            }
+        return earnings
     }
 
     private fun buildLines(

--- a/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
@@ -177,7 +177,7 @@ class FinancialReportService(
             .filter { it.type == AccountType.REVENUE || it.type == AccountType.EXPENSE }
             .forEach { account ->
                 val (debits, credits) = totals.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
-                val signed = signedBalance(account.type, debits, credits)
+                val signed = account.type.signedBalance(debits, credits)
                 earnings =
                     if (account.type == AccountType.REVENUE) {
                         earnings.add(signed)
@@ -198,11 +198,11 @@ class FinancialReportService(
             .filter { it.type == type }
             .map { account ->
                 val (debits, credits) = current.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
-                val amount = signedBalance(account.type, debits, credits)
+                val amount = account.type.signedBalance(debits, credits)
                 val compAmount =
                     comparative?.let {
                         val (cd, cc) = it.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
-                        signedBalance(account.type, cd, cc)
+                        account.type.signedBalance(cd, cc)
                     }
                 ReportAccountLine(
                     accountId = account.id,
@@ -244,14 +244,4 @@ class FinancialReportService(
         }
         return totals
     }
-
-    private fun signedBalance(
-        type: AccountType,
-        debits: BigDecimal,
-        credits: BigDecimal,
-    ): BigDecimal =
-        when (type) {
-            AccountType.ASSET, AccountType.EXPENSE -> debits.subtract(credits)
-            AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> credits.subtract(debits)
-        }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
@@ -1,7 +1,13 @@
 package com.froilan.synectix.service
 
+import com.froilan.synectix.dto.ComparativePeriodMeta
+import com.froilan.synectix.dto.IncomeStatementResponse
+import com.froilan.synectix.dto.ReportAccountLine
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -10,7 +16,101 @@ import java.time.LocalDate
 @Service
 class FinancialReportService(
     private val journalEntryRepository: JournalEntryRepository,
+    private val accountRepository: AccountRepository,
 ) {
+    fun getIncomeStatement(
+        organizationId: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        compareStartDate: LocalDate? = null,
+        compareEndDate: LocalDate? = null,
+    ): IncomeStatementResponse {
+        if (endDate.isBefore(startDate)) {
+            throw BusinessRuleException("End date must be on or after start date")
+        }
+        if ((compareStartDate == null) != (compareEndDate == null)) {
+            throw BusinessRuleException("Both comparative dates must be provided together")
+        }
+        if (compareStartDate != null && compareEndDate!!.isBefore(compareStartDate)) {
+            throw BusinessRuleException("Comparative end date must be on or after comparative start date")
+        }
+
+        val accounts =
+            accountRepository
+                .findByOrganizationIdAndIsActive(organizationId, true)
+                .filter { it.type == AccountType.REVENUE || it.type == AccountType.EXPENSE }
+        val currentTotals = computePeriodTotals(organizationId, startDate, endDate)
+        val comparativeTotals =
+            if (compareStartDate != null && compareEndDate != null) {
+                computePeriodTotals(organizationId, compareStartDate, compareEndDate)
+            } else {
+                null
+            }
+
+        val revenueLines = buildLines(accounts, AccountType.REVENUE, currentTotals, comparativeTotals)
+        val expenseLines = buildLines(accounts, AccountType.EXPENSE, currentTotals, comparativeTotals)
+
+        val totalRevenue = revenueLines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.amount) }
+        val totalExpenses = expenseLines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.amount) }
+        val comparativeTotalRevenue =
+            comparativeTotals?.let {
+                revenueLines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.comparativeAmount ?: BigDecimal.ZERO) }
+            }
+        val comparativeTotalExpenses =
+            comparativeTotals?.let {
+                expenseLines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.comparativeAmount ?: BigDecimal.ZERO) }
+            }
+
+        return IncomeStatementResponse(
+            startDate = startDate.toString(),
+            endDate = endDate.toString(),
+            comparativePeriod =
+                if (compareStartDate != null && compareEndDate != null) {
+                    ComparativePeriodMeta(compareStartDate.toString(), compareEndDate.toString())
+                } else {
+                    null
+                },
+            revenue = revenueLines,
+            totalRevenue = totalRevenue,
+            comparativeTotalRevenue = comparativeTotalRevenue,
+            expenses = expenseLines,
+            totalExpenses = totalExpenses,
+            comparativeTotalExpenses = comparativeTotalExpenses,
+            netIncome = totalRevenue.subtract(totalExpenses),
+            comparativeNetIncome =
+                if (comparativeTotalRevenue != null && comparativeTotalExpenses != null) {
+                    comparativeTotalRevenue.subtract(comparativeTotalExpenses)
+                } else {
+                    null
+                },
+        )
+    }
+
+    private fun buildLines(
+        accounts: List<Account>,
+        type: AccountType,
+        current: Map<String, Pair<BigDecimal, BigDecimal>>,
+        comparative: Map<String, Pair<BigDecimal, BigDecimal>>?,
+    ): List<ReportAccountLine> =
+        accounts
+            .filter { it.type == type }
+            .map { account ->
+                val (debits, credits) = current.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
+                val amount = signedBalance(account.type, debits, credits)
+                val compAmount =
+                    comparative?.let {
+                        val (cd, cc) = it.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
+                        signedBalance(account.type, cd, cc)
+                    }
+                ReportAccountLine(
+                    accountId = account.id,
+                    accountCode = account.code,
+                    accountName = account.name,
+                    amount = amount,
+                    comparativeAmount = compAmount,
+                )
+            }.sortedBy { it.accountCode }
+
     internal fun computePeriodTotals(
         organizationId: String,
         startDate: LocalDate?,

--- a/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
@@ -5,6 +5,7 @@ import com.froilan.synectix.dto.ComparativePeriodMeta
 import com.froilan.synectix.dto.ComparativeTrialBalanceResponse
 import com.froilan.synectix.dto.IncomeStatementResponse
 import com.froilan.synectix.dto.ReportAccountLine
+import com.froilan.synectix.dto.SyntheticAccountIds
 import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
@@ -116,11 +117,12 @@ class FinancialReportService(
 
         val earningsLine =
             ReportAccountLine(
-                accountId = "",
-                accountCode = "",
+                accountId = SyntheticAccountIds.CURRENT_PERIOD_EARNINGS,
+                accountCode = SyntheticAccountIds.CURRENT_PERIOD_EARNINGS,
                 accountName = "Current Period Earnings",
                 amount = currentEarnings,
                 comparativeAmount = comparativeCurrentEarnings,
+                isSynthetic = true,
             )
         val equity = equityAccounts + earningsLine
 
@@ -211,7 +213,7 @@ class FinancialReportService(
                 )
             }.sortedBy { it.accountCode }
 
-    internal fun computePeriodTotals(
+    private fun computePeriodTotals(
         organizationId: String,
         startDate: LocalDate?,
         endDate: LocalDate,
@@ -243,7 +245,7 @@ class FinancialReportService(
         return totals
     }
 
-    internal fun signedBalance(
+    private fun signedBalance(
         type: AccountType,
         debits: BigDecimal,
         credits: BigDecimal,

--- a/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
@@ -2,6 +2,7 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.BalanceSheetResponse
 import com.froilan.synectix.dto.ComparativePeriodMeta
+import com.froilan.synectix.dto.ComparativeTrialBalanceResponse
 import com.froilan.synectix.dto.IncomeStatementResponse
 import com.froilan.synectix.dto.ReportAccountLine
 import com.froilan.synectix.exception.BusinessRuleException
@@ -18,7 +19,17 @@ import java.time.LocalDate
 class FinancialReportService(
     private val journalEntryRepository: JournalEntryRepository,
     private val accountRepository: AccountRepository,
+    private val journalEntryService: JournalEntryService,
 ) {
+    fun getComparativeTrialBalance(
+        organizationId: String,
+        asOfDate: LocalDate?,
+        compareAsOfDate: LocalDate?,
+    ) = ComparativeTrialBalanceResponse(
+        current = journalEntryService.getTrialBalance(organizationId, asOfDate),
+        comparative = compareAsOfDate?.let { journalEntryService.getTrialBalance(organizationId, it) },
+    )
+
     fun getIncomeStatement(
         organizationId: String,
         startDate: LocalDate,

--- a/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
@@ -1,0 +1,55 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Service
+class FinancialReportService(
+    private val journalEntryRepository: JournalEntryRepository,
+) {
+    internal fun computePeriodTotals(
+        organizationId: String,
+        startDate: LocalDate?,
+        endDate: LocalDate,
+    ): Map<String, Pair<BigDecimal, BigDecimal>> {
+        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
+        val entries =
+            if (startDate != null) {
+                journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                    organizationId,
+                    postedStatuses,
+                    startDate,
+                    endDate,
+                )
+            } else {
+                journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
+                    organizationId,
+                    postedStatuses,
+                    endDate,
+                )
+            }
+
+        val totals = mutableMapOf<String, Pair<BigDecimal, BigDecimal>>()
+        entries.forEach { entry ->
+            entry.lines.forEach { line ->
+                val (debits, credits) = totals.getOrDefault(line.accountId, BigDecimal.ZERO to BigDecimal.ZERO)
+                totals[line.accountId] = debits.add(line.debit) to credits.add(line.credit)
+            }
+        }
+        return totals
+    }
+
+    internal fun signedBalance(
+        type: AccountType,
+        debits: BigDecimal,
+        credits: BigDecimal,
+    ): BigDecimal =
+        when (type) {
+            AccountType.ASSET, AccountType.EXPENSE -> debits.subtract(credits)
+            AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> credits.subtract(debits)
+        }
+}

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -5,7 +5,6 @@ import com.froilan.synectix.dto.CreateJournalEntryRequest
 import com.froilan.synectix.dto.TrialBalanceResponse
 import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.exception.ResourceNotFoundException
-import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
@@ -289,11 +288,7 @@ class JournalEntryService(
             }
         }
 
-        val balance =
-            when (account.type) {
-                AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
-                AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
-            }
+        val balance = account.type.signedBalance(totalDebits, totalCredits)
 
         return AccountBalanceResponse(
             accountId = account.id,
@@ -340,11 +335,7 @@ class JournalEntryService(
                 .map { account ->
                     val (totalDebits, totalCredits) =
                         accountTotals.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
-                    val balance =
-                        when (account.type) {
-                            AccountType.ASSET, AccountType.EXPENSE -> totalDebits.subtract(totalCredits)
-                            AccountType.LIABILITY, AccountType.EQUITY, AccountType.REVENUE -> totalCredits.subtract(totalDebits)
-                        }
+                    val balance = account.type.signedBalance(totalDebits, totalCredits)
                     AccountBalanceResponse(
                         accountId = account.id,
                         accountCode = account.code,

--- a/src/test/kotlin/com/froilan/synectix/controller/FinancialReportControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/FinancialReportControllerTest.kt
@@ -1,0 +1,253 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.dto.BalanceSheetResponse
+import com.froilan.synectix.dto.ComparativeTrialBalanceResponse
+import com.froilan.synectix.dto.IncomeStatementResponse
+import com.froilan.synectix.dto.ReportAccountLine
+import com.froilan.synectix.dto.SyntheticAccountIds
+import com.froilan.synectix.dto.TrialBalanceResponse
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.ApiKeyRepository
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.FinancialReportService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@WebMvcTest(controllers = [FinancialReportController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class FinancialReportControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var financialReportService: FinancialReportService
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var apiKeyRepository: ApiKeyRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("journal:read")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+        `when`(authenticationContext.userId()).thenReturn("user-123")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    @Test
+    fun `GET trial-balance returns 200 with current and comparative blocks`() {
+        val current =
+            TrialBalanceResponse(emptyList(), BigDecimal("500.00"), BigDecimal("500.00"), "2026-03-31")
+        val compare =
+            TrialBalanceResponse(emptyList(), BigDecimal("400.00"), BigDecimal("400.00"), "2026-02-28")
+        `when`(financialReportService.getComparativeTrialBalance(any(), anyOrNull(), anyOrNull()))
+            .thenReturn(ComparativeTrialBalanceResponse(current = current, comparative = compare))
+
+        mockMvc
+            .perform(get("/finance/reports/trial-balance?asOfDate=2026-03-31&compareAsOfDate=2026-02-28"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.current.totalDebits").value(500.00))
+            .andExpect(jsonPath("$.comparative.totalDebits").value(400.00))
+    }
+
+    @Test
+    fun `GET income-statement returns 200 and required fields`() {
+        val response =
+            IncomeStatementResponse(
+                startDate = "2026-03-01",
+                endDate = "2026-03-31",
+                comparativePeriod = null,
+                revenue =
+                    listOf(
+                        ReportAccountLine("acc-rev", "4000", "Sales", BigDecimal("1000.00")),
+                    ),
+                totalRevenue = BigDecimal("1000.00"),
+                comparativeTotalRevenue = null,
+                expenses =
+                    listOf(
+                        ReportAccountLine("acc-exp", "5000", "COGS", BigDecimal("300.00")),
+                    ),
+                totalExpenses = BigDecimal("300.00"),
+                comparativeTotalExpenses = null,
+                netIncome = BigDecimal("700.00"),
+                comparativeNetIncome = null,
+            )
+        `when`(
+            financialReportService.getIncomeStatement(
+                eq("org-123"),
+                eq(LocalDate.of(2026, 3, 1)),
+                eq(LocalDate.of(2026, 3, 31)),
+                anyOrNull(),
+                anyOrNull(),
+            ),
+        ).thenReturn(response)
+
+        mockMvc
+            .perform(get("/finance/reports/income-statement?startDate=2026-03-01&endDate=2026-03-31"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.totalRevenue").value(1000.00))
+            .andExpect(jsonPath("$.totalExpenses").value(300.00))
+            .andExpect(jsonPath("$.netIncome").value(700.00))
+    }
+
+    @Test
+    fun `GET income-statement returns 400 when required date is missing`() {
+        mockMvc
+            .perform(get("/finance/reports/income-statement?startDate=2026-03-01"))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET balance-sheet returns 200 with synthetic earnings line`() {
+        val response =
+            BalanceSheetResponse(
+                asOfDate = "2026-03-31",
+                comparativeAsOfDate = null,
+                assets = emptyList(),
+                totalAssets = BigDecimal("1000.00"),
+                comparativeTotalAssets = null,
+                liabilities = emptyList(),
+                totalLiabilities = BigDecimal.ZERO,
+                comparativeTotalLiabilities = null,
+                equity =
+                    listOf(
+                        ReportAccountLine(
+                            accountId = SyntheticAccountIds.CURRENT_PERIOD_EARNINGS,
+                            accountCode = SyntheticAccountIds.CURRENT_PERIOD_EARNINGS,
+                            accountName = "Current Period Earnings",
+                            amount = BigDecimal("1000.00"),
+                            isSynthetic = true,
+                        ),
+                    ),
+                totalEquity = BigDecimal("1000.00"),
+                comparativeTotalEquity = null,
+                currentEarnings = BigDecimal("1000.00"),
+                comparativeCurrentEarnings = null,
+                totalLiabilitiesAndEquity = BigDecimal("1000.00"),
+                comparativeTotalLiabilitiesAndEquity = null,
+                isBalanced = true,
+                outOfBalanceAmount = BigDecimal.ZERO,
+            )
+        `when`(financialReportService.getBalanceSheet(any(), any(), anyOrNull()))
+            .thenReturn(response)
+
+        mockMvc
+            .perform(get("/finance/reports/balance-sheet?asOfDate=2026-03-31"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.balanced").value(true))
+            .andExpect(jsonPath("$.equity[0].synthetic").value(true))
+            .andExpect(jsonPath("$.equity[0].accountId").value(SyntheticAccountIds.CURRENT_PERIOD_EARNINGS))
+    }
+
+    @Test
+    fun `GET trial-balance returns 403 without journal read permission`() {
+        setupAuthWithPermissions("account:read")
+
+        mockMvc
+            .perform(get("/finance/reports/trial-balance"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GET income-statement returns 403 without journal read permission`() {
+        setupAuthWithPermissions("account:read")
+
+        mockMvc
+            .perform(get("/finance/reports/income-statement?startDate=2026-03-01&endDate=2026-03-31"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GET balance-sheet returns 403 without journal read permission`() {
+        setupAuthWithPermissions("account:read")
+
+        mockMvc
+            .perform(get("/finance/reports/balance-sheet?asOfDate=2026-03-31"))
+            .andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
@@ -1,0 +1,126 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.AccountType
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryLine
+import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.JournalEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class FinancialReportServiceTest {
+    private lateinit var service: FinancialReportService
+    private lateinit var journalEntryRepository: JournalEntryRepository
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        journalEntryRepository = mock(JournalEntryRepository::class.java)
+        service = FinancialReportService(journalEntryRepository)
+    }
+
+    @Test
+    fun `computePeriodTotals sums debits and credits per account within range`() {
+        val start = LocalDate.of(2026, 3, 1)
+        val end = LocalDate.of(2026, 3, 31)
+        val entries =
+            listOf(
+                entry(
+                    "je-1",
+                    LocalDate.of(2026, 3, 5),
+                    listOf(
+                        line("acc-1", BigDecimal("100.00"), BigDecimal.ZERO),
+                        line("acc-2", BigDecimal.ZERO, BigDecimal("100.00")),
+                    ),
+                ),
+                entry(
+                    "je-2",
+                    LocalDate.of(2026, 3, 20),
+                    listOf(
+                        line("acc-1", BigDecimal("50.00"), BigDecimal.ZERO),
+                        line("acc-2", BigDecimal.ZERO, BigDecimal("50.00")),
+                    ),
+                ),
+            )
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                start,
+                end,
+            ),
+        ).thenReturn(entries)
+
+        val totals = service.computePeriodTotals(orgId, start, end)
+
+        assertThat(totals["acc-1"]).isEqualTo(BigDecimal("150.00") to BigDecimal.ZERO)
+        assertThat(totals["acc-2"]).isEqualTo(BigDecimal.ZERO to BigDecimal("150.00"))
+    }
+
+    @Test
+    fun `computePeriodTotals uses inception query when startDate is null`() {
+        val end = LocalDate.of(2026, 3, 31)
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                end,
+            ),
+        ).thenReturn(emptyList())
+
+        val totals = service.computePeriodTotals(orgId, null, end)
+
+        assertThat(totals).isEmpty()
+    }
+
+    @Test
+    fun `signedBalance applies normal sides per account type`() {
+        val debits = BigDecimal("100.00")
+        val credits = BigDecimal("30.00")
+
+        assertThat(service.signedBalance(AccountType.ASSET, debits, credits))
+            .isEqualByComparingTo(BigDecimal("70.00"))
+        assertThat(service.signedBalance(AccountType.EXPENSE, debits, credits))
+            .isEqualByComparingTo(BigDecimal("70.00"))
+        assertThat(service.signedBalance(AccountType.LIABILITY, debits, credits))
+            .isEqualByComparingTo(BigDecimal("-70.00"))
+        assertThat(service.signedBalance(AccountType.EQUITY, debits, credits))
+            .isEqualByComparingTo(BigDecimal("-70.00"))
+        assertThat(service.signedBalance(AccountType.REVENUE, debits, credits))
+            .isEqualByComparingTo(BigDecimal("-70.00"))
+    }
+
+    private fun entry(
+        id: String,
+        date: LocalDate,
+        lines: List<JournalEntryLine>,
+    ) = JournalEntry(
+        id = id,
+        entryNumber = id.uppercase(),
+        date = date,
+        description = "test",
+        organizationId = orgId,
+        status = JournalEntryStatus.POSTED,
+        lines = lines,
+        createdBy = userId,
+    )
+
+    private fun line(
+        accountId: String,
+        debit: BigDecimal,
+        credit: BigDecimal,
+    ) = JournalEntryLine(
+        accountId = accountId,
+        accountCode = accountId,
+        accountName = "Account $accountId",
+        debit = debit,
+        credit = credit,
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
@@ -1,5 +1,6 @@
 package com.froilan.synectix.service
 
+import com.froilan.synectix.dto.TrialBalanceResponse
 import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
@@ -21,6 +22,7 @@ class FinancialReportServiceTest {
     private lateinit var service: FinancialReportService
     private lateinit var journalEntryRepository: JournalEntryRepository
     private lateinit var accountRepository: AccountRepository
+    private lateinit var journalEntryService: JournalEntryService
 
     private val orgId = "org-1"
     private val userId = "user-1"
@@ -29,7 +31,8 @@ class FinancialReportServiceTest {
     fun setup() {
         journalEntryRepository = mock(JournalEntryRepository::class.java)
         accountRepository = mock(AccountRepository::class.java)
-        service = FinancialReportService(journalEntryRepository, accountRepository)
+        journalEntryService = mock(JournalEntryService::class.java)
+        service = FinancialReportService(journalEntryRepository, accountRepository, journalEntryService)
     }
 
     @Test
@@ -331,6 +334,35 @@ class FinancialReportServiceTest {
 
         assertThat(result.isBalanced).isFalse()
         assertThat(result.outOfBalanceAmount).isEqualByComparingTo(BigDecimal("20.00"))
+    }
+
+    @Test
+    fun `getComparativeTrialBalance returns current and comparative`() {
+        val asOf = LocalDate.of(2026, 3, 31)
+        val compareAsOf = LocalDate.of(2026, 2, 28)
+        val currentTb = TrialBalanceResponse(emptyList(), BigDecimal("100.00"), BigDecimal("100.00"), asOf.toString())
+        val compareTb =
+            TrialBalanceResponse(emptyList(), BigDecimal("80.00"), BigDecimal("80.00"), compareAsOf.toString())
+
+        `when`(journalEntryService.getTrialBalance(orgId, asOf)).thenReturn(currentTb)
+        `when`(journalEntryService.getTrialBalance(orgId, compareAsOf)).thenReturn(compareTb)
+
+        val result = service.getComparativeTrialBalance(orgId, asOf, compareAsOf)
+
+        assertThat(result.current).isSameAs(currentTb)
+        assertThat(result.comparative).isSameAs(compareTb)
+    }
+
+    @Test
+    fun `getComparativeTrialBalance omits comparative when not requested`() {
+        val asOf = LocalDate.of(2026, 3, 31)
+        val currentTb = TrialBalanceResponse(emptyList(), BigDecimal.ZERO, BigDecimal.ZERO, asOf.toString())
+
+        `when`(journalEntryService.getTrialBalance(orgId, asOf)).thenReturn(currentTb)
+
+        val result = service.getComparativeTrialBalance(orgId, asOf, null)
+
+        assertThat(result.comparative).isNull()
     }
 
     private fun account(

--- a/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
@@ -242,6 +242,97 @@ class FinancialReportServiceTest {
         assertThat(result.netIncome).isEqualByComparingTo(BigDecimal.ZERO)
     }
 
+    @Test
+    fun `getBalanceSheet computes totals and current earnings`() {
+        val asOf = LocalDate.of(2026, 3, 31)
+        val cash = account("acc-cash", "1000", AccountType.ASSET)
+        val ap = account("acc-ap", "2000", AccountType.LIABILITY)
+        val equity = account("acc-eq", "3000", AccountType.EQUITY)
+        val rev = account("acc-rev", "4000", AccountType.REVENUE)
+        val exp = account("acc-exp", "5000", AccountType.EXPENSE)
+
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(listOf(cash, ap, equity, rev, exp))
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                asOf,
+            ),
+        ).thenReturn(
+            listOf(
+                entry(
+                    "je-1",
+                    LocalDate.of(2026, 1, 1),
+                    listOf(
+                        line("acc-cash", BigDecimal("10000.00"), BigDecimal.ZERO),
+                        line("acc-eq", BigDecimal.ZERO, BigDecimal("10000.00")),
+                    ),
+                ),
+                entry(
+                    "je-2",
+                    LocalDate.of(2026, 3, 5),
+                    listOf(
+                        line("acc-cash", BigDecimal("3000.00"), BigDecimal.ZERO),
+                        line("acc-rev", BigDecimal.ZERO, BigDecimal("3000.00")),
+                    ),
+                ),
+                entry(
+                    "je-3",
+                    LocalDate.of(2026, 3, 10),
+                    listOf(
+                        line("acc-exp", BigDecimal("500.00"), BigDecimal.ZERO),
+                        line("acc-cash", BigDecimal.ZERO, BigDecimal("500.00")),
+                    ),
+                ),
+            ),
+        )
+
+        val result = service.getBalanceSheet(orgId, asOf)
+
+        assertThat(result.totalAssets).isEqualByComparingTo(BigDecimal("12500.00"))
+        assertThat(result.totalLiabilities).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.currentEarnings).isEqualByComparingTo(BigDecimal("2500.00"))
+        assertThat(result.totalEquity).isEqualByComparingTo(BigDecimal("12500.00"))
+        assertThat(result.totalLiabilitiesAndEquity).isEqualByComparingTo(BigDecimal("12500.00"))
+        assertThat(result.isBalanced).isTrue()
+        assertThat(result.outOfBalanceAmount).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(result.equity.last().accountName).isEqualTo("Current Period Earnings")
+    }
+
+    @Test
+    fun `getBalanceSheet flags imbalance without throwing`() {
+        val asOf = LocalDate.of(2026, 3, 31)
+        val cash = account("acc-cash", "1000", AccountType.ASSET)
+        val equity = account("acc-eq", "3000", AccountType.EQUITY)
+
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(listOf(cash, equity))
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                asOf,
+            ),
+        ).thenReturn(
+            listOf(
+                entry(
+                    "je-1",
+                    LocalDate.of(2026, 1, 1),
+                    listOf(
+                        line("acc-cash", BigDecimal("100.00"), BigDecimal.ZERO),
+                        line("acc-eq", BigDecimal.ZERO, BigDecimal("80.00")),
+                    ),
+                ),
+            ),
+        )
+
+        val result = service.getBalanceSheet(orgId, asOf)
+
+        assertThat(result.isBalanced).isFalse()
+        assertThat(result.outOfBalanceAmount).isEqualByComparingTo(BigDecimal("20.00"))
+    }
+
     private fun account(
         id: String,
         code: String,

--- a/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
@@ -1,5 +1,6 @@
 package com.froilan.synectix.service
 
+import com.froilan.synectix.dto.SyntheticAccountIds
 import com.froilan.synectix.dto.TrialBalanceResponse
 import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.Account
@@ -33,77 +34,6 @@ class FinancialReportServiceTest {
         accountRepository = mock(AccountRepository::class.java)
         journalEntryService = mock(JournalEntryService::class.java)
         service = FinancialReportService(journalEntryRepository, accountRepository, journalEntryService)
-    }
-
-    @Test
-    fun `computePeriodTotals sums debits and credits per account within range`() {
-        val start = LocalDate.of(2026, 3, 1)
-        val end = LocalDate.of(2026, 3, 31)
-        val entries =
-            listOf(
-                entry(
-                    "je-1",
-                    LocalDate.of(2026, 3, 5),
-                    listOf(
-                        line("acc-1", BigDecimal("100.00"), BigDecimal.ZERO),
-                        line("acc-2", BigDecimal.ZERO, BigDecimal("100.00")),
-                    ),
-                ),
-                entry(
-                    "je-2",
-                    LocalDate.of(2026, 3, 20),
-                    listOf(
-                        line("acc-1", BigDecimal("50.00"), BigDecimal.ZERO),
-                        line("acc-2", BigDecimal.ZERO, BigDecimal("50.00")),
-                    ),
-                ),
-            )
-        `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
-                orgId,
-                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
-                start,
-                end,
-            ),
-        ).thenReturn(entries)
-
-        val totals = service.computePeriodTotals(orgId, start, end)
-
-        assertThat(totals["acc-1"]).isEqualTo(BigDecimal("150.00") to BigDecimal.ZERO)
-        assertThat(totals["acc-2"]).isEqualTo(BigDecimal.ZERO to BigDecimal("150.00"))
-    }
-
-    @Test
-    fun `computePeriodTotals uses inception query when startDate is null`() {
-        val end = LocalDate.of(2026, 3, 31)
-        `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
-                orgId,
-                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
-                end,
-            ),
-        ).thenReturn(emptyList())
-
-        val totals = service.computePeriodTotals(orgId, null, end)
-
-        assertThat(totals).isEmpty()
-    }
-
-    @Test
-    fun `signedBalance applies normal sides per account type`() {
-        val debits = BigDecimal("100.00")
-        val credits = BigDecimal("30.00")
-
-        assertThat(service.signedBalance(AccountType.ASSET, debits, credits))
-            .isEqualByComparingTo(BigDecimal("70.00"))
-        assertThat(service.signedBalance(AccountType.EXPENSE, debits, credits))
-            .isEqualByComparingTo(BigDecimal("70.00"))
-        assertThat(service.signedBalance(AccountType.LIABILITY, debits, credits))
-            .isEqualByComparingTo(BigDecimal("-70.00"))
-        assertThat(service.signedBalance(AccountType.EQUITY, debits, credits))
-            .isEqualByComparingTo(BigDecimal("-70.00"))
-        assertThat(service.signedBalance(AccountType.REVENUE, debits, credits))
-            .isEqualByComparingTo(BigDecimal("-70.00"))
     }
 
     @Test
@@ -300,7 +230,11 @@ class FinancialReportServiceTest {
         assertThat(result.totalLiabilitiesAndEquity).isEqualByComparingTo(BigDecimal("12500.00"))
         assertThat(result.isBalanced).isTrue()
         assertThat(result.outOfBalanceAmount).isEqualByComparingTo(BigDecimal.ZERO)
-        assertThat(result.equity.last().accountName).isEqualTo("Current Period Earnings")
+        val earningsRow = result.equity.last()
+        assertThat(earningsRow.accountName).isEqualTo("Current Period Earnings")
+        assertThat(earningsRow.accountId).isEqualTo(SyntheticAccountIds.CURRENT_PERIOD_EARNINGS)
+        assertThat(earningsRow.accountCode).isEqualTo(SyntheticAccountIds.CURRENT_PERIOD_EARNINGS)
+        assertThat(earningsRow.isSynthetic).isTrue()
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
@@ -1,13 +1,17 @@
 package com.froilan.synectix.service
 
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntryStatus
+import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import java.math.BigDecimal
@@ -16,6 +20,7 @@ import java.time.LocalDate
 class FinancialReportServiceTest {
     private lateinit var service: FinancialReportService
     private lateinit var journalEntryRepository: JournalEntryRepository
+    private lateinit var accountRepository: AccountRepository
 
     private val orgId = "org-1"
     private val userId = "user-1"
@@ -23,7 +28,8 @@ class FinancialReportServiceTest {
     @BeforeEach
     fun setup() {
         journalEntryRepository = mock(JournalEntryRepository::class.java)
-        service = FinancialReportService(journalEntryRepository)
+        accountRepository = mock(AccountRepository::class.java)
+        service = FinancialReportService(journalEntryRepository, accountRepository)
     }
 
     @Test
@@ -96,6 +102,157 @@ class FinancialReportServiceTest {
         assertThat(service.signedBalance(AccountType.REVENUE, debits, credits))
             .isEqualByComparingTo(BigDecimal("-70.00"))
     }
+
+    @Test
+    fun `getIncomeStatement computes net income and sorts by code`() {
+        val start = LocalDate.of(2026, 3, 1)
+        val end = LocalDate.of(2026, 3, 31)
+        val revenue = account("acc-rev", "4100", AccountType.REVENUE)
+        val expense = account("acc-exp", "5000", AccountType.EXPENSE)
+
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(listOf(expense, revenue))
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                start,
+                end,
+            ),
+        ).thenReturn(
+            listOf(
+                entry(
+                    "je-1",
+                    LocalDate.of(2026, 3, 10),
+                    listOf(
+                        line("acc-rev", BigDecimal.ZERO, BigDecimal("1000.00")),
+                        line("acc-exp", BigDecimal("300.00"), BigDecimal.ZERO),
+                    ),
+                ),
+            ),
+        )
+
+        val result = service.getIncomeStatement(orgId, start, end)
+
+        assertThat(result.revenue).hasSize(1)
+        assertThat(result.revenue[0].accountCode).isEqualTo("4100")
+        assertThat(result.revenue[0].amount).isEqualByComparingTo(BigDecimal("1000.00"))
+        assertThat(result.expenses[0].amount).isEqualByComparingTo(BigDecimal("300.00"))
+        assertThat(result.totalRevenue).isEqualByComparingTo(BigDecimal("1000.00"))
+        assertThat(result.totalExpenses).isEqualByComparingTo(BigDecimal("300.00"))
+        assertThat(result.netIncome).isEqualByComparingTo(BigDecimal("700.00"))
+        assertThat(result.comparativeNetIncome).isNull()
+    }
+
+    @Test
+    fun `getIncomeStatement with comparative period returns both totals`() {
+        val start = LocalDate.of(2026, 3, 1)
+        val end = LocalDate.of(2026, 3, 31)
+        val compareStart = LocalDate.of(2026, 2, 1)
+        val compareEnd = LocalDate.of(2026, 2, 28)
+        val revenue = account("acc-rev", "4100", AccountType.REVENUE)
+
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(listOf(revenue))
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                start,
+                end,
+            ),
+        ).thenReturn(
+            listOf(
+                entry(
+                    "je-1",
+                    LocalDate.of(2026, 3, 10),
+                    listOf(line("acc-rev", BigDecimal.ZERO, BigDecimal("1000.00"))),
+                ),
+            ),
+        )
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                compareStart,
+                compareEnd,
+            ),
+        ).thenReturn(
+            listOf(
+                entry(
+                    "je-2",
+                    LocalDate.of(2026, 2, 15),
+                    listOf(line("acc-rev", BigDecimal.ZERO, BigDecimal("800.00"))),
+                ),
+            ),
+        )
+
+        val result = service.getIncomeStatement(orgId, start, end, compareStart, compareEnd)
+
+        assertThat(result.totalRevenue).isEqualByComparingTo(BigDecimal("1000.00"))
+        assertThat(result.comparativeTotalRevenue).isEqualByComparingTo(BigDecimal("800.00"))
+        assertThat(result.netIncome).isEqualByComparingTo(BigDecimal("1000.00"))
+        assertThat(result.comparativeNetIncome).isEqualByComparingTo(BigDecimal("800.00"))
+        assertThat(result.comparativePeriod?.startDate).isEqualTo("2026-02-01")
+    }
+
+    @Test
+    fun `getIncomeStatement rejects end before start`() {
+        val exception =
+            assertThrows<BusinessRuleException> {
+                service.getIncomeStatement(orgId, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 3, 1))
+            }
+        assertThat(exception.message).contains("on or after")
+    }
+
+    @Test
+    fun `getIncomeStatement rejects partial comparative dates`() {
+        val exception =
+            assertThrows<BusinessRuleException> {
+                service.getIncomeStatement(
+                    orgId,
+                    LocalDate.of(2026, 3, 1),
+                    LocalDate.of(2026, 3, 31),
+                    compareStartDate = LocalDate.of(2026, 2, 1),
+                    compareEndDate = null,
+                )
+            }
+        assertThat(exception.message).contains("together")
+    }
+
+    @Test
+    fun `getIncomeStatement returns empty lists when no accounts match`() {
+        val start = LocalDate.of(2026, 3, 1)
+        val end = LocalDate.of(2026, 3, 31)
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(listOf(account("acc-cash", "1000", AccountType.ASSET)))
+        `when`(
+            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
+                orgId,
+                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
+                start,
+                end,
+            ),
+        ).thenReturn(emptyList())
+
+        val result = service.getIncomeStatement(orgId, start, end)
+
+        assertThat(result.revenue).isEmpty()
+        assertThat(result.expenses).isEmpty()
+        assertThat(result.netIncome).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    private fun account(
+        id: String,
+        code: String,
+        type: AccountType,
+    ) = Account(
+        id = id,
+        code = code,
+        name = "Account $code",
+        type = type,
+        organizationId = orgId,
+    )
 
     private fun entry(
         id: String,


### PR DESCRIPTION
Closes #31

## Summary
- Adds `GET /finance/reports/income-statement` (P&L for a date range, optional comparative period)
- Adds `GET /finance/reports/balance-sheet` (assets/liabilities/equity as-of, with synthetic Current Period Earnings row, `isBalanced` flag, optional comparative)
- Adds `GET /finance/reports/trial-balance` as a wrapper around the existing trial balance, with optional comparative; legacy `/finance/journal/trial-balance` is untouched
- New `FinancialReportService` with shared period-totals + signed-balance helpers
- Reuses `journal:read` permission (no new permission, no RoleSeeder migration)

## Design notes
- Balance sheet **reports** out-of-balance state (`isBalanced` + `outOfBalanceAmount`) instead of throwing — operators need to see drift during imports/migrations
- Current earnings computed live as `Σ(revenue) − Σ(expense)` inception-to-date so the statement always reconciles without depending on a year-end close to retained earnings
- Flat by account, sorted by code; no parent/child rollup in v1
- No COGS/gross profit (no COGS account-type distinction yet)
- VOIDED entries included alongside POSTED, mirroring `getTrialBalance` (void + reversal nets to zero)

## Performance
All three reports use the same in-memory journal scan as the existing trial balance. Tracked centrally by #113 — don't pre-optimize per endpoint.

## Test plan
- [x] ktlint passes
- [x] FinancialReportServiceTest (10 unit tests) passes — covers period-totals helper, signed-balance, P&L (basic, comparative, validation, empty), balance sheet (balanced + deliberately unbalanced), comparative trial balance
- [x] Full test suite: only pre-existing MongoDB `contextLoads` failure
- [ ] Smoke test in staging: post a few journal entries, hit each report endpoint with and without comparative dates, verify totals match ledger