### PR TITLE
Replace in-memory journal scans with MongoDB aggregation

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/model/JournalEntry.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/JournalEntry.kt
@@ -37,6 +37,10 @@ data class JournalEntryLine(
     def = "{'organizationId': 1, 'entryNumber': 1}",
     unique = true,
 )
+@CompoundIndex(
+    name = "org_status_date",
+    def = "{'organizationId': 1, 'status': 1, 'date': 1}",
+)
 data class JournalEntry(
     @Id
     val id: String = UUID.randomUUID().toString(),

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryAggregations.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryAggregations.kt
@@ -1,0 +1,78 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.JournalEntry
+import com.froilan.synectix.model.JournalEntryStatus
+import org.bson.Document
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.aggregation.Aggregation
+import org.springframework.data.mongodb.core.query.Criteria
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class AccountTotals(
+    val totalDebits: BigDecimal,
+    val totalCredits: BigDecimal,
+)
+
+interface JournalEntryAggregations {
+    fun aggregateAccountTotals(
+        organizationId: String,
+        accountIds: Collection<String>?,
+        startDate: LocalDate?,
+        endDate: LocalDate?,
+    ): Map<String, AccountTotals>
+}
+
+class JournalEntryAggregationsImpl(
+    private val mongoTemplate: MongoTemplate,
+) : JournalEntryAggregations {
+    override fun aggregateAccountTotals(
+        organizationId: String,
+        accountIds: Collection<String>?,
+        startDate: LocalDate?,
+        endDate: LocalDate?,
+    ): Map<String, AccountTotals> {
+        val entryCriteria =
+            Criteria()
+                .and("organizationId")
+                .`is`(organizationId)
+                .and("status")
+                .`in`(JournalEntryStatus.POSTED.name, JournalEntryStatus.VOIDED.name)
+        if (startDate != null && endDate != null) {
+            entryCriteria.and("date").gte(startDate).lte(endDate)
+        } else if (startDate != null) {
+            entryCriteria.and("date").gte(startDate)
+        } else if (endDate != null) {
+            entryCriteria.and("date").lte(endDate)
+        }
+
+        val stages = mutableListOf<org.springframework.data.mongodb.core.aggregation.AggregationOperation>()
+        stages.add(Aggregation.match(entryCriteria))
+        stages.add(Aggregation.unwind("lines"))
+        if (!accountIds.isNullOrEmpty()) {
+            stages.add(Aggregation.match(Criteria.where("lines.accountId").`in`(accountIds)))
+        }
+        stages.add(
+            Aggregation
+                .group("lines.accountId")
+                .sum("lines.debit")
+                .`as`("totalDebits")
+                .sum("lines.credit")
+                .`as`("totalCredits"),
+        )
+
+        val results =
+            mongoTemplate.aggregate(
+                Aggregation.newAggregation(stages),
+                JournalEntry::class.java,
+                Document::class.java,
+            )
+
+        return results.mappedResults.associate { doc ->
+            val accountId = doc.getString("_id")
+            val debits = (doc.get("totalDebits") as? Number)?.let { BigDecimal(it.toString()) } ?: BigDecimal.ZERO
+            val credits = (doc.get("totalCredits") as? Number)?.let { BigDecimal(it.toString()) } ?: BigDecimal.ZERO
+            accountId to AccountTotals(debits, credits)
+        }
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryAggregations.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryAggregations.kt
@@ -32,6 +32,9 @@ open class JournalEntryAggregationsImpl(
         startDate: LocalDate?,
         endDate: LocalDate?,
     ): Map<String, AccountTotals> {
+        if (accountIds != null && accountIds.isEmpty()) {
+            return emptyMap()
+        }
         val entryCriteria =
             Criteria()
                 .and("organizationId")
@@ -49,7 +52,7 @@ open class JournalEntryAggregationsImpl(
         val stages = mutableListOf<org.springframework.data.mongodb.core.aggregation.AggregationOperation>()
         stages.add(Aggregation.match(entryCriteria))
         stages.add(Aggregation.unwind("lines"))
-        if (!accountIds.isNullOrEmpty()) {
+        if (accountIds != null) {
             stages.add(Aggregation.match(Criteria.where("lines.accountId").`in`(accountIds)))
         }
         stages.add(

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryAggregations.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryAggregations.kt
@@ -23,7 +23,7 @@ interface JournalEntryAggregations {
     ): Map<String, AccountTotals>
 }
 
-class JournalEntryAggregationsImpl(
+open class JournalEntryAggregationsImpl(
     private val mongoTemplate: MongoTemplate,
 ) : JournalEntryAggregations {
     override fun aggregateAccountTotals(

--- a/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/JournalEntryRepository.kt
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
 @Repository
-interface JournalEntryRepository : MongoRepository<JournalEntry, String> {
+interface JournalEntryRepository :
+    MongoRepository<JournalEntry, String>,
+    JournalEntryAggregations {
     fun findByOrganizationId(organizationId: String): List<JournalEntry>
 
     fun findByOrganizationIdAndStatus(

--- a/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/FinancialReportService.kt
@@ -9,7 +9,6 @@ import com.froilan.synectix.dto.SyntheticAccountIds
 import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.model.Account
 import com.froilan.synectix.model.AccountType
-import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.repository.AccountRepository
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.springframework.stereotype.Service
@@ -217,31 +216,8 @@ class FinancialReportService(
         organizationId: String,
         startDate: LocalDate?,
         endDate: LocalDate,
-    ): Map<String, Pair<BigDecimal, BigDecimal>> {
-        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
-        val entries =
-            if (startDate != null) {
-                journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
-                    organizationId,
-                    postedStatuses,
-                    startDate,
-                    endDate,
-                )
-            } else {
-                journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
-                    organizationId,
-                    postedStatuses,
-                    endDate,
-                )
-            }
-
-        val totals = mutableMapOf<String, Pair<BigDecimal, BigDecimal>>()
-        entries.forEach { entry ->
-            entry.lines.forEach { line ->
-                val (debits, credits) = totals.getOrDefault(line.accountId, BigDecimal.ZERO to BigDecimal.ZERO)
-                totals[line.accountId] = debits.add(line.debit) to credits.add(line.credit)
-            }
-        }
-        return totals
-    }
+    ): Map<String, Pair<BigDecimal, BigDecimal>> =
+        journalEntryRepository
+            .aggregateAccountTotals(organizationId, null, startDate, endDate)
+            .mapValues { (_, totals) -> totals.totalDebits to totals.totalCredits }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -286,6 +286,14 @@ class JournalEntryService(
         asOfDate: LocalDate? = null,
     ): TrialBalanceResponse {
         val allAccounts = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        if (allAccounts.isEmpty()) {
+            return TrialBalanceResponse(
+                accounts = emptyList(),
+                totalDebits = BigDecimal.ZERO,
+                totalCredits = BigDecimal.ZERO,
+                asOfDate = asOfDate?.toString(),
+            )
+        }
         val totals =
             journalEntryRepository.aggregateAccountTotals(
                 organizationId = organizationId,

--- a/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/JournalEntryService.kt
@@ -10,6 +10,7 @@ import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.AccountTotals
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -264,40 +265,19 @@ class JournalEntryService(
             throw ResourceNotFoundException("Account not found")
         }
 
-        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
-        val entries =
-            if (asOfDate != null) {
-                journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
-                    organizationId,
-                    postedStatuses,
-                    asOfDate,
-                )
-            } else {
-                journalEntryRepository.findByOrganizationIdAndStatusIn(
-                    organizationId,
-                    postedStatuses,
-                )
-            }
-
-        var totalDebits = BigDecimal.ZERO
-        var totalCredits = BigDecimal.ZERO
-        entries.forEach { entry ->
-            entry.lines.filter { it.accountId == accountId }.forEach { line ->
-                totalDebits = totalDebits.add(line.debit)
-                totalCredits = totalCredits.add(line.credit)
-            }
-        }
-
-        val balance = account.type.signedBalance(totalDebits, totalCredits)
+        val totals =
+            journalEntryRepository
+                .aggregateAccountTotals(organizationId, listOf(accountId), null, asOfDate)
+                .getOrDefault(accountId, AccountTotals(BigDecimal.ZERO, BigDecimal.ZERO))
 
         return AccountBalanceResponse(
             accountId = account.id,
             accountCode = account.code,
             accountName = account.name,
             accountType = account.type.name,
-            totalDebits = totalDebits,
-            totalCredits = totalCredits,
-            balance = balance,
+            totalDebits = totals.totalDebits,
+            totalCredits = totals.totalCredits,
+            balance = account.type.signedBalance(totals.totalDebits, totals.totalCredits),
         )
     }
 
@@ -305,45 +285,27 @@ class JournalEntryService(
         organizationId: String,
         asOfDate: LocalDate? = null,
     ): TrialBalanceResponse {
-        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
-        val entries =
-            if (asOfDate != null) {
-                journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
-                    organizationId,
-                    postedStatuses,
-                    asOfDate,
-                )
-            } else {
-                journalEntryRepository.findByOrganizationIdAndStatusIn(
-                    organizationId,
-                    postedStatuses,
-                )
-            }
-
-        val accountTotals = mutableMapOf<String, Pair<BigDecimal, BigDecimal>>()
-        entries.forEach { entry ->
-            entry.lines.forEach { line ->
-                val (debits, credits) = accountTotals.getOrDefault(line.accountId, BigDecimal.ZERO to BigDecimal.ZERO)
-                accountTotals[line.accountId] = debits.add(line.debit) to credits.add(line.credit)
-            }
-        }
-
         val allAccounts = accountRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        val totals =
+            journalEntryRepository.aggregateAccountTotals(
+                organizationId = organizationId,
+                accountIds = allAccounts.map { it.id },
+                startDate = null,
+                endDate = asOfDate,
+            )
 
         val accountBalances =
             allAccounts
                 .map { account ->
-                    val (totalDebits, totalCredits) =
-                        accountTotals.getOrDefault(account.id, BigDecimal.ZERO to BigDecimal.ZERO)
-                    val balance = account.type.signedBalance(totalDebits, totalCredits)
+                    val t = totals.getOrDefault(account.id, AccountTotals(BigDecimal.ZERO, BigDecimal.ZERO))
                     AccountBalanceResponse(
                         accountId = account.id,
                         accountCode = account.code,
                         accountName = account.name,
                         accountType = account.type.name,
-                        totalDebits = totalDebits,
-                        totalCredits = totalCredits,
-                        balance = balance,
+                        totalDebits = t.totalDebits,
+                        totalCredits = t.totalCredits,
+                        balance = account.type.signedBalance(t.totalDebits, t.totalCredits),
                     )
                 }.sortedBy { it.accountCode }
 

--- a/src/main/kotlin/com/froilan/synectix/service/TaxGroupService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/TaxGroupService.kt
@@ -8,6 +8,7 @@ import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.TaxGroup
 import com.froilan.synectix.model.TaxRate
 import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.JournalEntryRepository
 import com.froilan.synectix.repository.TaxGroupRepository
 import com.froilan.synectix.repository.TaxRateRepository
 import org.springframework.dao.DuplicateKeyException
@@ -22,7 +23,7 @@ class TaxGroupService(
     private val taxGroupRepository: TaxGroupRepository,
     private val taxRateRepository: TaxRateRepository,
     private val accountRepository: AccountRepository,
-    private val journalEntryService: JournalEntryService,
+    private val journalEntryRepository: JournalEntryRepository,
 ) {
     @Transactional
     fun createTaxGroup(
@@ -172,25 +173,25 @@ class TaxGroupService(
             throw BusinessRuleException("Start date must be on or before end date")
         }
 
-        val taxCollected =
-            accountRepository
-                .findByOrganizationIdAndCode(organizationId, "2300")
-                .map {
-                    val endBalance = journalEntryService.getAccountBalance(it.id, organizationId, endDate).balance
-                    val startBalance =
-                        journalEntryService.getAccountBalance(it.id, organizationId, startDate.minusDays(1)).balance
-                    endBalance.subtract(startBalance)
-                }.orElse(BigDecimal.ZERO)
+        val payable = accountRepository.findByOrganizationIdAndCode(organizationId, "2300").orElse(null)
+        val input = accountRepository.findByOrganizationIdAndCode(organizationId, "2310").orElse(null)
+        val accountIds = listOfNotNull(payable?.id, input?.id)
 
+        val totals =
+            if (accountIds.isEmpty()) {
+                emptyMap()
+            } else {
+                journalEntryRepository.aggregateAccountTotals(organizationId, accountIds, startDate, endDate)
+            }
+
+        val taxCollected =
+            payable?.let { totals[it.id] }?.let {
+                it.totalCredits.subtract(it.totalDebits)
+            } ?: BigDecimal.ZERO
         val taxPaid =
-            accountRepository
-                .findByOrganizationIdAndCode(organizationId, "2310")
-                .map {
-                    val endBalance = journalEntryService.getAccountBalance(it.id, organizationId, endDate).balance
-                    val startBalance =
-                        journalEntryService.getAccountBalance(it.id, organizationId, startDate.minusDays(1)).balance
-                    endBalance.subtract(startBalance)
-                }.orElse(BigDecimal.ZERO)
+            input?.let { totals[it.id] }?.let {
+                it.totalDebits.subtract(it.totalCredits)
+            } ?: BigDecimal.ZERO
 
         return TaxSummaryResponse(
             taxCollected = taxCollected,

--- a/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/FinancialReportServiceTest.kt
@@ -9,6 +9,7 @@ import com.froilan.synectix.model.JournalEntry
 import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.AccountTotals
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -45,25 +46,13 @@ class FinancialReportServiceTest {
 
         `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
             .thenReturn(listOf(expense, revenue))
-        `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
-                orgId,
-                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
-                start,
-                end,
-            ),
-        ).thenReturn(
-            listOf(
-                entry(
-                    "je-1",
-                    LocalDate.of(2026, 3, 10),
-                    listOf(
-                        line("acc-rev", BigDecimal.ZERO, BigDecimal("1000.00")),
-                        line("acc-exp", BigDecimal("300.00"), BigDecimal.ZERO),
-                    ),
+        `when`(journalEntryRepository.aggregateAccountTotals(orgId, null, start, end))
+            .thenReturn(
+                mapOf(
+                    "acc-rev" to AccountTotals(BigDecimal.ZERO, BigDecimal("1000.00")),
+                    "acc-exp" to AccountTotals(BigDecimal("300.00"), BigDecimal.ZERO),
                 ),
-            ),
-        )
+            )
 
         val result = service.getIncomeStatement(orgId, start, end)
 
@@ -87,38 +76,10 @@ class FinancialReportServiceTest {
 
         `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
             .thenReturn(listOf(revenue))
-        `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
-                orgId,
-                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
-                start,
-                end,
-            ),
-        ).thenReturn(
-            listOf(
-                entry(
-                    "je-1",
-                    LocalDate.of(2026, 3, 10),
-                    listOf(line("acc-rev", BigDecimal.ZERO, BigDecimal("1000.00"))),
-                ),
-            ),
-        )
-        `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
-                orgId,
-                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
-                compareStart,
-                compareEnd,
-            ),
-        ).thenReturn(
-            listOf(
-                entry(
-                    "je-2",
-                    LocalDate.of(2026, 2, 15),
-                    listOf(line("acc-rev", BigDecimal.ZERO, BigDecimal("800.00"))),
-                ),
-            ),
-        )
+        `when`(journalEntryRepository.aggregateAccountTotals(orgId, null, start, end))
+            .thenReturn(mapOf("acc-rev" to AccountTotals(BigDecimal.ZERO, BigDecimal("1000.00"))))
+        `when`(journalEntryRepository.aggregateAccountTotals(orgId, null, compareStart, compareEnd))
+            .thenReturn(mapOf("acc-rev" to AccountTotals(BigDecimal.ZERO, BigDecimal("800.00"))))
 
         val result = service.getIncomeStatement(orgId, start, end, compareStart, compareEnd)
 
@@ -159,14 +120,8 @@ class FinancialReportServiceTest {
         val end = LocalDate.of(2026, 3, 31)
         `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
             .thenReturn(listOf(account("acc-cash", "1000", AccountType.ASSET)))
-        `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusInAndDateBetween(
-                orgId,
-                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
-                start,
-                end,
-            ),
-        ).thenReturn(emptyList())
+        `when`(journalEntryRepository.aggregateAccountTotals(orgId, null, start, end))
+            .thenReturn(emptyMap())
 
         val result = service.getIncomeStatement(orgId, start, end)
 
@@ -186,40 +141,15 @@ class FinancialReportServiceTest {
 
         `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
             .thenReturn(listOf(cash, ap, equity, rev, exp))
-        `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
-                orgId,
-                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
-                asOf,
-            ),
-        ).thenReturn(
-            listOf(
-                entry(
-                    "je-1",
-                    LocalDate.of(2026, 1, 1),
-                    listOf(
-                        line("acc-cash", BigDecimal("10000.00"), BigDecimal.ZERO),
-                        line("acc-eq", BigDecimal.ZERO, BigDecimal("10000.00")),
-                    ),
+        `when`(journalEntryRepository.aggregateAccountTotals(orgId, null, null, asOf))
+            .thenReturn(
+                mapOf(
+                    "acc-cash" to AccountTotals(BigDecimal("13000.00"), BigDecimal("500.00")),
+                    "acc-eq" to AccountTotals(BigDecimal.ZERO, BigDecimal("10000.00")),
+                    "acc-rev" to AccountTotals(BigDecimal.ZERO, BigDecimal("3000.00")),
+                    "acc-exp" to AccountTotals(BigDecimal("500.00"), BigDecimal.ZERO),
                 ),
-                entry(
-                    "je-2",
-                    LocalDate.of(2026, 3, 5),
-                    listOf(
-                        line("acc-cash", BigDecimal("3000.00"), BigDecimal.ZERO),
-                        line("acc-rev", BigDecimal.ZERO, BigDecimal("3000.00")),
-                    ),
-                ),
-                entry(
-                    "je-3",
-                    LocalDate.of(2026, 3, 10),
-                    listOf(
-                        line("acc-exp", BigDecimal("500.00"), BigDecimal.ZERO),
-                        line("acc-cash", BigDecimal.ZERO, BigDecimal("500.00")),
-                    ),
-                ),
-            ),
-        )
+            )
 
         val result = service.getBalanceSheet(orgId, asOf)
 
@@ -245,24 +175,13 @@ class FinancialReportServiceTest {
 
         `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true))
             .thenReturn(listOf(cash, equity))
-        `when`(
-            journalEntryRepository.findByOrganizationIdAndStatusInAndDateLessThanEqual(
-                orgId,
-                listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED),
-                asOf,
-            ),
-        ).thenReturn(
-            listOf(
-                entry(
-                    "je-1",
-                    LocalDate.of(2026, 1, 1),
-                    listOf(
-                        line("acc-cash", BigDecimal("100.00"), BigDecimal.ZERO),
-                        line("acc-eq", BigDecimal.ZERO, BigDecimal("80.00")),
-                    ),
+        `when`(journalEntryRepository.aggregateAccountTotals(orgId, null, null, asOf))
+            .thenReturn(
+                mapOf(
+                    "acc-cash" to AccountTotals(BigDecimal("100.00"), BigDecimal.ZERO),
+                    "acc-eq" to AccountTotals(BigDecimal.ZERO, BigDecimal("80.00")),
                 ),
-            ),
-        )
+            )
 
         val result = service.getBalanceSheet(orgId, asOf)
 

--- a/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/JournalEntryServiceTest.kt
@@ -10,6 +10,7 @@ import com.froilan.synectix.model.JournalEntryLine
 import com.froilan.synectix.model.JournalEntrySource
 import com.froilan.synectix.model.JournalEntryStatus
 import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.AccountTotals
 import com.froilan.synectix.repository.JournalEntryRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -445,59 +446,8 @@ class JournalEntryServiceTest {
     fun `getAccountBalance should sum debits and credits from posted entries`() {
         val account = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
         `when`(accountRepository.findById("acc-1")).thenReturn(Optional.of(account))
-
-        val entries =
-            listOf(
-                createMockEntry(
-                    id = "entry-1",
-                    entryNumber = "JE-0001",
-                    status = JournalEntryStatus.POSTED,
-                    lines =
-                        listOf(
-                            JournalEntryLine(
-                                accountId = "acc-1",
-                                accountCode = "1000",
-                                accountName = "Cash",
-                                debit = BigDecimal("500.00"),
-                                credit = BigDecimal.ZERO,
-                            ),
-                            JournalEntryLine(
-                                accountId = "acc-2",
-                                accountCode = "4000",
-                                accountName = "Revenue",
-                                debit = BigDecimal.ZERO,
-                                credit = BigDecimal("500.00"),
-                            ),
-                        ),
-                    orgId = orgId,
-                ),
-                createMockEntry(
-                    id = "entry-2",
-                    entryNumber = "JE-0002",
-                    status = JournalEntryStatus.POSTED,
-                    lines =
-                        listOf(
-                            JournalEntryLine(
-                                accountId = "acc-3",
-                                accountCode = "5000",
-                                accountName = "Expense",
-                                debit = BigDecimal("150.00"),
-                                credit = BigDecimal.ZERO,
-                            ),
-                            JournalEntryLine(
-                                accountId = "acc-1",
-                                accountCode = "1000",
-                                accountName = "Cash",
-                                debit = BigDecimal.ZERO,
-                                credit = BigDecimal("150.00"),
-                            ),
-                        ),
-                    orgId = orgId,
-                ),
-            )
-
-        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
-        `when`(journalEntryRepository.findByOrganizationIdAndStatusIn(orgId, postedStatuses)).thenReturn(entries)
+        `when`(journalEntryRepository.aggregateAccountTotals(orgId, listOf("acc-1"), null, null))
+            .thenReturn(mapOf("acc-1" to AccountTotals(BigDecimal("500.00"), BigDecimal("150.00"))))
 
         val result = journalEntryService.getAccountBalance("acc-1", orgId)
 
@@ -515,36 +465,14 @@ class JournalEntryServiceTest {
         val cashAccount = createMockAccount(id = "acc-1", code = "1000", name = "Cash", type = AccountType.ASSET, orgId = orgId)
         val revenueAccount = createMockAccount(id = "acc-2", code = "4000", name = "Revenue", type = AccountType.REVENUE, orgId = orgId)
 
-        val entries =
-            listOf(
-                createMockEntry(
-                    id = "entry-1",
-                    entryNumber = "JE-0001",
-                    status = JournalEntryStatus.POSTED,
-                    lines =
-                        listOf(
-                            JournalEntryLine(
-                                accountId = "acc-1",
-                                accountCode = "1000",
-                                accountName = "Cash",
-                                debit = BigDecimal("300.00"),
-                                credit = BigDecimal.ZERO,
-                            ),
-                            JournalEntryLine(
-                                accountId = "acc-2",
-                                accountCode = "4000",
-                                accountName = "Revenue",
-                                debit = BigDecimal.ZERO,
-                                credit = BigDecimal("300.00"),
-                            ),
-                        ),
-                    orgId = orgId,
+        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(cashAccount, revenueAccount))
+        `when`(journalEntryRepository.aggregateAccountTotals(orgId, listOf("acc-1", "acc-2"), null, null))
+            .thenReturn(
+                mapOf(
+                    "acc-1" to AccountTotals(BigDecimal("300.00"), BigDecimal.ZERO),
+                    "acc-2" to AccountTotals(BigDecimal.ZERO, BigDecimal("300.00")),
                 ),
             )
-
-        val postedStatuses = listOf(JournalEntryStatus.POSTED, JournalEntryStatus.VOIDED)
-        `when`(journalEntryRepository.findByOrganizationIdAndStatusIn(orgId, postedStatuses)).thenReturn(entries)
-        `when`(accountRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(cashAccount, revenueAccount))
 
         val result = journalEntryService.getTrialBalance(orgId)
 

--- a/src/test/kotlin/com/froilan/synectix/service/TaxGroupServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/TaxGroupServiceTest.kt
@@ -1,6 +1,5 @@
 package com.froilan.synectix.service
 
-import com.froilan.synectix.dto.AccountBalanceResponse
 import com.froilan.synectix.dto.CreateTaxGroupRequest
 import com.froilan.synectix.dto.UpdateTaxGroupRequest
 import com.froilan.synectix.exception.BusinessRuleException
@@ -9,6 +8,8 @@ import com.froilan.synectix.model.AccountType
 import com.froilan.synectix.model.TaxGroup
 import com.froilan.synectix.model.TaxRate
 import com.froilan.synectix.repository.AccountRepository
+import com.froilan.synectix.repository.AccountTotals
+import com.froilan.synectix.repository.JournalEntryRepository
 import com.froilan.synectix.repository.TaxGroupRepository
 import com.froilan.synectix.repository.TaxRateRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -27,7 +28,7 @@ class TaxGroupServiceTest {
     private lateinit var taxGroupRepository: TaxGroupRepository
     private lateinit var taxRateRepository: TaxRateRepository
     private lateinit var accountRepository: AccountRepository
-    private lateinit var journalEntryService: JournalEntryService
+    private lateinit var journalEntryRepository: JournalEntryRepository
 
     private val orgId = "org-123"
 
@@ -36,8 +37,9 @@ class TaxGroupServiceTest {
         taxGroupRepository = mock(TaxGroupRepository::class.java)
         taxRateRepository = mock(TaxRateRepository::class.java)
         accountRepository = mock(AccountRepository::class.java)
-        journalEntryService = mock(JournalEntryService::class.java)
-        taxGroupService = TaxGroupService(taxGroupRepository, taxRateRepository, accountRepository, journalEntryService)
+        journalEntryRepository = mock(JournalEntryRepository::class.java)
+        taxGroupService =
+            TaxGroupService(taxGroupRepository, taxRateRepository, accountRepository, journalEntryRepository)
     }
 
     @Test
@@ -306,7 +308,7 @@ class TaxGroupServiceTest {
     }
 
     @Test
-    fun `getTaxSummary should compute net liability from balance deltas`() {
+    fun `getTaxSummary should compute net liability from period totals`() {
         val payable = createAccount("acc-2300", "2300", AccountType.LIABILITY)
         val input = createAccount("acc-2310", "2310", AccountType.ASSET)
         val startDate = LocalDate.of(2026, 3, 1)
@@ -317,14 +319,19 @@ class TaxGroupServiceTest {
         `when`(accountRepository.findByOrganizationIdAndCode(orgId, "2310"))
             .thenReturn(Optional.of(input))
 
-        `when`(journalEntryService.getAccountBalance("acc-2300", orgId, endDate))
-            .thenReturn(balanceOf(payable, BigDecimal("500.00")))
-        `when`(journalEntryService.getAccountBalance("acc-2300", orgId, startDate.minusDays(1)))
-            .thenReturn(balanceOf(payable, BigDecimal("100.00")))
-        `when`(journalEntryService.getAccountBalance("acc-2310", orgId, endDate))
-            .thenReturn(balanceOf(input, BigDecimal("150.00")))
-        `when`(journalEntryService.getAccountBalance("acc-2310", orgId, startDate.minusDays(1)))
-            .thenReturn(balanceOf(input, BigDecimal("50.00")))
+        `when`(
+            journalEntryRepository.aggregateAccountTotals(
+                orgId,
+                listOf("acc-2300", "acc-2310"),
+                startDate,
+                endDate,
+            ),
+        ).thenReturn(
+            mapOf(
+                "acc-2300" to AccountTotals(BigDecimal("0.00"), BigDecimal("400.00")),
+                "acc-2310" to AccountTotals(BigDecimal("100.00"), BigDecimal("0.00")),
+            ),
+        )
 
         val result = taxGroupService.getTaxSummary(orgId, startDate, endDate)
 
@@ -358,18 +365,5 @@ class TaxGroupServiceTest {
         name = "Account $code",
         type = type,
         organizationId = orgId,
-    )
-
-    private fun balanceOf(
-        account: Account,
-        balance: BigDecimal,
-    ) = AccountBalanceResponse(
-        accountId = account.id,
-        accountCode = account.code,
-        accountName = account.name,
-        accountType = account.type.name,
-        totalDebits = BigDecimal.ZERO,
-        totalCredits = BigDecimal.ZERO,
-        balance = balance,
     )
 }


### PR DESCRIPTION
Closes #113

## Summary
- New `JournalEntryAggregations` custom repository fragment with `aggregateAccountTotals(orgId, accountIds?, startDate?, endDate?)` running a single `\$match` → `\$unwind` → `\$match` → `\$group` pipeline via `MongoTemplate`
- Refactored every caller that previously scanned all posted+voided entries in app memory:
  - `JournalEntryService.getAccountBalance` and `getTrialBalance`
  - `FinancialReportService.computePeriodTotals` (powers P&L and balance sheet)
  - `TaxGroupService.getTaxSummary` (was 4 full scans → 1 aggregation)
- Added compound index `journal_entries (organizationId, status, date)` to back the `\$match` stage

## Tax summary simplification
`getTaxSummary` previously computed `endBalance - startMinus1Balance` via four `getAccountBalance` calls. Now it pulls per-account totals over the date range directly — period activity IS the delta, so the new path is one aggregation over both tax accounts within `[startDate, endDate]`.

## Performance
For an org with N journal entries:
- Before: O(N) entries loaded + iterated in app memory per call (4× for tax summary)
- After: filtered + aggregated server-side; result set sized by accounts touched, not entries scanned

Index supports the `\$match` on `(organizationId, status, date)`. The unwind on `lines` stays — unavoidable with the embedded-line schema.

## Test plan
- [x] ktlint passes
- [x] Service unit tests updated to mock `aggregateAccountTotals` directly (no longer seeding entry lists)
- [x] Full suite: 313/314 pass; only pre-existing MongoDB `contextLoads` failure
- [ ] Smoke test in staging: post journal entries, hit `/finance/journal/account-balance`, `/finance/journal/trial-balance`, `/finance/reports/income-statement`, `/finance/reports/balance-sheet`, and `/finance/tax/summary` — totals should match prior behaviour
- [ ] Verify the `org_status_date` compound index gets created on first startup