### PR TITLE
Product / item catalog CRUD (#38)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -71,6 +71,8 @@ class RoleSeeder(
                             Permissions.TAX_DELETE,
                             Permissions.FX_READ,
                             Permissions.FX_CREATE,
+                            Permissions.INVENTORY_READ,
+                            Permissions.INVENTORY_WRITE,
                         ),
                 ),
                 Role(
@@ -110,6 +112,8 @@ class RoleSeeder(
                             Permissions.TAX_DELETE,
                             Permissions.FX_READ,
                             Permissions.FX_CREATE,
+                            Permissions.INVENTORY_READ,
+                            Permissions.INVENTORY_WRITE,
                         ),
                 ),
                 Role(
@@ -133,6 +137,8 @@ class RoleSeeder(
                             Permissions.AR_READ,
                             Permissions.TAX_READ,
                             Permissions.FX_READ,
+                            Permissions.INVENTORY_READ,
+                            Permissions.INVENTORY_WRITE,
                         ),
                 ),
                 Role(
@@ -150,6 +156,7 @@ class RoleSeeder(
                             Permissions.AR_READ,
                             Permissions.TAX_READ,
                             Permissions.FX_READ,
+                            Permissions.INVENTORY_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/froilan/synectix/controller/ProductController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/ProductController.kt
@@ -44,7 +44,7 @@ class ProductController(
     @PreAuthorize("hasAuthority('inventory:read')")
     fun listProducts(
         @RequestParam(required = false) category: String?,
-        @RequestParam(required = false) isActive: Boolean?,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean,
         @RequestParam(required = false) search: String?,
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()

--- a/src/main/kotlin/com/froilan/synectix/controller/ProductController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/ProductController.kt
@@ -1,0 +1,106 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateProductRequest
+import com.froilan.synectix.dto.ProductResponse
+import com.froilan.synectix.dto.UpdateProductRequest
+import com.froilan.synectix.model.Product
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.ProductService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/inventory/products")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProductController(
+    private val productService: ProductService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun createProduct(
+        @Valid @RequestBody request: CreateProductRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+
+        val product = productService.createProduct(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(product.toResponse())
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun listProducts(
+        @RequestParam(required = false) category: String?,
+        @RequestParam(required = false) isActive: Boolean?,
+        @RequestParam(required = false) search: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+
+        val products = productService.listProducts(orgId, category, isActive, search)
+        return ResponseEntity.ok(products.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun getProduct(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+
+        val product = productService.getProduct(id, orgId)
+        return ResponseEntity.ok(product.toResponse())
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun updateProduct(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateProductRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+
+        val product = productService.updateProduct(id, request, orgId)
+        return ResponseEntity.ok(product.toResponse())
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun deleteProduct(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+
+        val product = productService.deleteProduct(id, orgId)
+        return ResponseEntity.ok(product.toResponse())
+    }
+
+    private fun Product.toResponse() =
+        ProductResponse(
+            id = id,
+            sku = sku,
+            name = name,
+            description = description,
+            category = category,
+            imageUrl = imageUrl,
+            listPrice = listPrice,
+            priceCurrency = priceCurrency,
+            taxGroupId = taxGroupId,
+            organizationId = organizationId,
+            isActive = isActive,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/ProductDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/ProductDtos.kt
@@ -1,0 +1,56 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+
+data class CreateProductRequest(
+    @field:NotBlank(message = "SKU is required")
+    @field:Size(max = 64, message = "SKU must be 64 characters or fewer")
+    val sku: String,
+    @field:NotBlank(message = "Product name is required")
+    @field:Size(max = 255, message = "Product name must be 255 characters or fewer")
+    val name: String,
+    @field:Size(max = 2000, message = "Description must be 2000 characters or fewer")
+    val description: String? = null,
+    @field:Size(max = 128, message = "Category must be 128 characters or fewer")
+    val category: String? = null,
+    @field:Size(max = 2048, message = "Image URL must be 2048 characters or fewer")
+    val imageUrl: String? = null,
+    @field:DecimalMin(value = "0.0", message = "List price must be zero or positive")
+    val listPrice: BigDecimal,
+    val priceCurrency: String? = null,
+    val taxGroupId: String? = null,
+)
+
+data class UpdateProductRequest(
+    @field:Size(max = 255, message = "Product name must be 255 characters or fewer")
+    val name: String? = null,
+    @field:Size(max = 2000, message = "Description must be 2000 characters or fewer")
+    val description: String? = null,
+    @field:Size(max = 128, message = "Category must be 128 characters or fewer")
+    val category: String? = null,
+    @field:Size(max = 2048, message = "Image URL must be 2048 characters or fewer")
+    val imageUrl: String? = null,
+    @field:DecimalMin(value = "0.0", message = "List price must be zero or positive")
+    val listPrice: BigDecimal? = null,
+    val priceCurrency: String? = null,
+    val taxGroupId: String? = null,
+)
+
+data class ProductResponse(
+    val id: String,
+    val sku: String,
+    val name: String,
+    val description: String?,
+    val category: String?,
+    val imageUrl: String?,
+    val listPrice: BigDecimal,
+    val priceCurrency: String,
+    val taxGroupId: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Product.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Product.kt
@@ -1,0 +1,48 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.CompoundIndexes
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "products")
+@CompoundIndexes(
+    CompoundIndex(
+        name = "unique_sku_per_org",
+        def = "{'organizationId': 1, 'sku': 1}",
+        unique = true,
+    ),
+    CompoundIndex(
+        name = "products_org_active",
+        def = "{'organizationId': 1, 'isActive': 1}",
+    ),
+    CompoundIndex(
+        name = "products_org_category",
+        def = "{'organizationId': 1, 'category': 1}",
+    ),
+)
+data class Product(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val sku: String,
+    val name: String,
+    val description: String? = null,
+    val category: String? = null,
+    val imageUrl: String? = null,
+    val listPrice: BigDecimal,
+    val priceCurrency: String,
+    val taxGroupId: String? = null,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/ProductQueries.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/ProductQueries.kt
@@ -1,0 +1,49 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Product
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+
+interface ProductQueries {
+    fun search(
+        organizationId: String,
+        isActive: Boolean,
+        category: String?,
+        term: String?,
+    ): List<Product>
+}
+
+open class ProductQueriesImpl(
+    private val mongoTemplate: MongoTemplate,
+) : ProductQueries {
+    override fun search(
+        organizationId: String,
+        isActive: Boolean,
+        category: String?,
+        term: String?,
+    ): List<Product> {
+        val criteria =
+            Criteria
+                .where("organizationId")
+                .`is`(organizationId)
+                .and("isActive")
+                .`is`(isActive)
+        if (category != null) {
+            criteria.and("category").`is`(category)
+        }
+        val cleaned = term?.trim()?.takeIf { it.isNotEmpty() }
+        if (cleaned != null) {
+            val escaped = Regex.escape(cleaned)
+            criteria.orOperator(
+                Criteria.where("sku").regex(escaped, "i"),
+                Criteria.where("name").regex(escaped, "i"),
+            )
+        }
+        return mongoTemplate.find(
+            Query(criteria).with(Sort.by(Sort.Direction.ASC, "sku")),
+            Product::class.java,
+        )
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/ProductRepository.kt
@@ -1,0 +1,26 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Product
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProductRepository : MongoRepository<Product, String> {
+    fun findByOrganizationId(organizationId: String): List<Product>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Product>
+
+    fun findByOrganizationIdAndCategory(
+        organizationId: String,
+        category: String,
+    ): List<Product>
+
+    fun findByOrganizationIdAndCategoryAndIsActive(
+        organizationId: String,
+        category: String,
+        isActive: Boolean,
+    ): List<Product>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/ProductRepository.kt
@@ -5,22 +5,6 @@ import org.springframework.data.mongodb.repository.MongoRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ProductRepository : MongoRepository<Product, String> {
-    fun findByOrganizationId(organizationId: String): List<Product>
-
-    fun findByOrganizationIdAndIsActive(
-        organizationId: String,
-        isActive: Boolean,
-    ): List<Product>
-
-    fun findByOrganizationIdAndCategory(
-        organizationId: String,
-        category: String,
-    ): List<Product>
-
-    fun findByOrganizationIdAndCategoryAndIsActive(
-        organizationId: String,
-        category: String,
-        isActive: Boolean,
-    ): List<Product>
-}
+interface ProductRepository :
+    MongoRepository<Product, String>,
+    ProductQueries

--- a/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/froilan/synectix/security/Permissions.kt
@@ -52,6 +52,9 @@ object Permissions {
     const val FX_READ = "fx:read"
     const val FX_CREATE = "fx:create"
 
+    const val INVENTORY_READ = "inventory:read"
+    const val INVENTORY_WRITE = "inventory:write"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -92,5 +95,7 @@ object Permissions {
             TAX_DELETE,
             FX_READ,
             FX_CREATE,
+            INVENTORY_READ,
+            INVENTORY_WRITE,
         )
 }

--- a/src/main/kotlin/com/froilan/synectix/service/ProductService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ProductService.kt
@@ -23,6 +23,8 @@ class ProductService(
         request: CreateProductRequest,
         organizationId: String,
     ): Product {
+        val sku = requireNonBlankTrimmed(request.sku, "SKU")
+        val name = requireNonBlankTrimmed(request.name, "Product name")
         val priceCurrency = (request.priceCurrency ?: getBaseCurrency(organizationId)).uppercase()
         currencyService.getCurrency(priceCurrency)
 
@@ -32,8 +34,8 @@ class ProductService(
 
         val product =
             Product(
-                sku = request.sku,
-                name = request.name,
+                sku = sku,
+                name = name,
                 description = request.description,
                 category = request.category,
                 imageUrl = request.imageUrl,
@@ -47,7 +49,7 @@ class ProductService(
             productRepository.save(product)
         } catch (e: DuplicateKeyException) {
             throw BusinessRuleException(
-                "Product with SKU '${request.sku}' already exists in this organization",
+                "Product with SKU '$sku' already exists in this organization",
                 e,
             )
         }
@@ -93,9 +95,12 @@ class ProductService(
             validateTaxGroup(request.taxGroupId, organizationId)
         }
 
+        val newName =
+            request.name?.let { requireNonBlankTrimmed(it, "Product name") } ?: existing.name
+
         val updated =
             existing.copy(
-                name = request.name ?: existing.name,
+                name = newName,
                 description = request.description ?: existing.description,
                 category = request.category ?: existing.category,
                 imageUrl = request.imageUrl ?: existing.imageUrl,
@@ -105,6 +110,17 @@ class ProductService(
             )
 
         return productRepository.save(updated)
+    }
+
+    private fun requireNonBlankTrimmed(
+        value: String,
+        fieldLabel: String,
+    ): String {
+        val trimmed = value.trim()
+        if (trimmed.isEmpty()) {
+            throw BusinessRuleException("$fieldLabel must not be blank")
+        }
+        return trimmed
     }
 
     @Transactional

--- a/src/main/kotlin/com/froilan/synectix/service/ProductService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ProductService.kt
@@ -1,0 +1,160 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateProductRequest
+import com.froilan.synectix.dto.UpdateProductRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.Product
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.ProductRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ProductService(
+    private val productRepository: ProductRepository,
+    private val organizationRepository: OrganizationRepository,
+    private val currencyService: CurrencyService,
+    private val taxGroupService: TaxGroupService,
+) {
+    @Transactional
+    fun createProduct(
+        request: CreateProductRequest,
+        organizationId: String,
+    ): Product {
+        val priceCurrency = (request.priceCurrency ?: getBaseCurrency(organizationId)).uppercase()
+        currencyService.getCurrency(priceCurrency)
+
+        if (request.taxGroupId != null) {
+            validateTaxGroup(request.taxGroupId, organizationId)
+        }
+
+        val product =
+            Product(
+                sku = request.sku,
+                name = request.name,
+                description = request.description,
+                category = request.category,
+                imageUrl = request.imageUrl,
+                listPrice = request.listPrice,
+                priceCurrency = priceCurrency,
+                taxGroupId = request.taxGroupId,
+                organizationId = organizationId,
+            )
+
+        return try {
+            productRepository.save(product)
+        } catch (e: DuplicateKeyException) {
+            throw BusinessRuleException(
+                "Product with SKU '${request.sku}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    fun getProduct(
+        productId: String,
+        organizationId: String,
+    ): Product {
+        val product =
+            productRepository.findById(productId).orElseThrow {
+                ResourceNotFoundException("Product not found")
+            }
+        if (product.organizationId != organizationId) {
+            throw ResourceNotFoundException("Product not found")
+        }
+        return product
+    }
+
+    fun listProducts(
+        organizationId: String,
+        category: String? = null,
+        isActive: Boolean? = true,
+        search: String? = null,
+    ): List<Product> {
+        val base =
+            when {
+                category != null && isActive != null ->
+                    productRepository.findByOrganizationIdAndCategoryAndIsActive(
+                        organizationId,
+                        category,
+                        isActive,
+                    )
+                category != null ->
+                    productRepository.findByOrganizationIdAndCategory(organizationId, category)
+                isActive != null ->
+                    productRepository.findByOrganizationIdAndIsActive(organizationId, isActive)
+                else ->
+                    productRepository.findByOrganizationId(organizationId)
+            }
+        val term = search?.trim()?.takeIf { it.isNotEmpty() } ?: return base.sortedBy { it.sku }
+        return base
+            .filter { it.sku.contains(term, ignoreCase = true) || it.name.contains(term, ignoreCase = true) }
+            .sortedBy { it.sku }
+    }
+
+    @Transactional
+    fun updateProduct(
+        productId: String,
+        request: UpdateProductRequest,
+        organizationId: String,
+    ): Product {
+        val existing = getProduct(productId, organizationId)
+        if (!existing.isActive) {
+            throw BusinessRuleException("Cannot update inactive product")
+        }
+
+        val newCurrency =
+            request.priceCurrency?.uppercase()?.also { currencyService.getCurrency(it) }
+                ?: existing.priceCurrency
+
+        if (request.taxGroupId != null && request.taxGroupId != existing.taxGroupId) {
+            validateTaxGroup(request.taxGroupId, organizationId)
+        }
+
+        val updated =
+            existing.copy(
+                name = request.name ?: existing.name,
+                description = request.description ?: existing.description,
+                category = request.category ?: existing.category,
+                imageUrl = request.imageUrl ?: existing.imageUrl,
+                listPrice = request.listPrice ?: existing.listPrice,
+                priceCurrency = newCurrency,
+                taxGroupId = request.taxGroupId ?: existing.taxGroupId,
+            )
+
+        return productRepository.save(updated)
+    }
+
+    @Transactional
+    fun deleteProduct(
+        productId: String,
+        organizationId: String,
+    ): Product {
+        val product = getProduct(productId, organizationId)
+        if (!product.isActive) {
+            throw BusinessRuleException("Product is already inactive")
+        }
+        // TODO: when #41/#10/#9 land, block hard delete (or even soft delete) if product
+        // is referenced by stock movements, sales lines, or purchase lines.
+        return productRepository.save(product.copy(isActive = false))
+    }
+
+    private fun validateTaxGroup(
+        taxGroupId: String,
+        organizationId: String,
+    ) {
+        val group = taxGroupService.getTaxGroup(taxGroupId, organizationId)
+        if (!group.isActive) {
+            throw BusinessRuleException("Tax group '${group.code}' is inactive")
+        }
+    }
+
+    private fun getBaseCurrency(organizationId: String): String =
+        organizationRepository
+            .findById(organizationId)
+            .orElseThrow {
+                ResourceNotFoundException("Organization not found")
+            }.baseCurrency
+}

--- a/src/main/kotlin/com/froilan/synectix/service/ProductService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/ProductService.kt
@@ -70,29 +70,9 @@ class ProductService(
     fun listProducts(
         organizationId: String,
         category: String? = null,
-        isActive: Boolean? = true,
+        isActive: Boolean = true,
         search: String? = null,
-    ): List<Product> {
-        val base =
-            when {
-                category != null && isActive != null ->
-                    productRepository.findByOrganizationIdAndCategoryAndIsActive(
-                        organizationId,
-                        category,
-                        isActive,
-                    )
-                category != null ->
-                    productRepository.findByOrganizationIdAndCategory(organizationId, category)
-                isActive != null ->
-                    productRepository.findByOrganizationIdAndIsActive(organizationId, isActive)
-                else ->
-                    productRepository.findByOrganizationId(organizationId)
-            }
-        val term = search?.trim()?.takeIf { it.isNotEmpty() } ?: return base.sortedBy { it.sku }
-        return base
-            .filter { it.sku.contains(term, ignoreCase = true) || it.name.contains(term, ignoreCase = true) }
-            .sortedBy { it.sku }
-    }
+    ): List<Product> = productRepository.search(organizationId, isActive, category, search)
 
     @Transactional
     fun updateProduct(

--- a/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/config/RoleSeederTest.kt
@@ -91,6 +91,8 @@ class RoleSeederTest {
                         Permissions.TAX_DELETE,
                         Permissions.FX_READ,
                         Permissions.FX_CREATE,
+                        Permissions.INVENTORY_READ,
+                        Permissions.INVENTORY_WRITE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -282,6 +284,8 @@ class RoleSeederTest {
                         Permissions.TAX_DELETE,
                         Permissions.FX_READ,
                         Permissions.FX_CREATE,
+                        Permissions.INVENTORY_READ,
+                        Permissions.INVENTORY_WRITE,
                     ),
             )
         val admin =
@@ -322,6 +326,8 @@ class RoleSeederTest {
                         Permissions.TAX_DELETE,
                         Permissions.FX_READ,
                         Permissions.FX_CREATE,
+                        Permissions.INVENTORY_READ,
+                        Permissions.INVENTORY_WRITE,
                     ),
             )
         val member =
@@ -346,6 +352,8 @@ class RoleSeederTest {
                         Permissions.AR_READ,
                         Permissions.TAX_READ,
                         Permissions.FX_READ,
+                        Permissions.INVENTORY_READ,
+                        Permissions.INVENTORY_WRITE,
                     ),
             )
         val viewer =
@@ -364,6 +372,7 @@ class RoleSeederTest {
                         Permissions.AR_READ,
                         Permissions.TAX_READ,
                         Permissions.FX_READ,
+                        Permissions.INVENTORY_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
@@ -40,8 +40,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.math.BigDecimal

--- a/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
@@ -212,6 +212,23 @@ class ProductControllerTest {
     }
 
     @Test
+    fun `GET products defaults isActive to true when param omitted`() {
+        `when`(productService.listProducts(any(), anyOrNull(), any(), anyOrNull())).thenReturn(emptyList())
+
+        mockMvc
+            .perform(get("/inventory/products"))
+            .andExpect(status().isOk)
+
+        val captor = org.mockito.ArgumentCaptor.forClass(Boolean::class.javaObjectType)
+        org.mockito.Mockito
+            .verify(productService)
+            .listProducts(any(), org.mockito.kotlin.anyOrNull(), captor.capture(), org.mockito.kotlin.anyOrNull())
+        org.assertj.core.api.Assertions
+            .assertThat(captor.value)
+            .isTrue()
+    }
+
+    @Test
     fun `GET products should support category filter`() {
         val products = listOf(createMockProduct())
         `when`(productService.listProducts(any(), any(), any(), anyOrNull())).thenReturn(products)

--- a/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
@@ -1,0 +1,373 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.Product
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.JournalEntryService
+import com.froilan.synectix.service.ProductService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@WebMvcTest(controllers = [ProductController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class ProductControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
+
+    @MockitoBean
+    private lateinit var productService: ProductService
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("inventory:read", "inventory:write")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+        `when`(authenticationContext.userId()).thenReturn("user-123")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    private fun createMockProduct() =
+        Product(
+            id = "prod-123",
+            sku = "WIDGET-001",
+            name = "Widget",
+            description = "A test widget",
+            category = "Hardware",
+            imageUrl = "https://example.com/image.jpg",
+            listPrice = BigDecimal("99.99"),
+            priceCurrency = "USD",
+            taxGroupId = "tax-123",
+            organizationId = "org-123",
+            isActive = true,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+        )
+
+    @Test
+    fun `POST products should return 201 when created`() {
+        val product = createMockProduct()
+        `when`(productService.createProduct(any(), any())).thenReturn(product)
+
+        mockMvc
+            .perform(
+                post("/inventory/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "sku": "WIDGET-001",
+                            "name": "Widget",
+                            "description": "A test widget",
+                            "category": "Hardware",
+                            "imageUrl": "https://example.com/image.jpg",
+                            "listPrice": "99.99",
+                            "priceCurrency": "USD",
+                            "taxGroupId": "tax-123"
+                        }""",
+                    ),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value("prod-123"))
+            .andExpect(jsonPath("$.sku").value("WIDGET-001"))
+            .andExpect(jsonPath("$.name").value("Widget"))
+            .andExpect(jsonPath("$.description").value("A test widget"))
+            .andExpect(jsonPath("$.category").value("Hardware"))
+            .andExpect(jsonPath("$.listPrice").value(99.99))
+            .andExpect(jsonPath("$.priceCurrency").value("USD"))
+            .andExpect(jsonPath("$.organizationId").value("org-123"))
+            .andExpect(jsonPath("$.isActive").value(true))
+    }
+
+    @Test
+    fun `POST products should return 400 when SKU is blank`() {
+        mockMvc
+            .perform(
+                post("/inventory/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "sku": "",
+                            "name": "Widget",
+                            "listPrice": "99.99"
+                        }""",
+                    ),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST products should return 400 when duplicate SKU in org`() {
+        `when`(productService.createProduct(any(), any()))
+            .thenThrow(BusinessRuleException("Product with SKU 'WIDGET-001' already exists in this organization"))
+
+        mockMvc
+            .perform(
+                post("/inventory/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "sku": "WIDGET-001",
+                            "name": "Widget",
+                            "listPrice": "99.99"
+                        }""",
+                    ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Product with SKU 'WIDGET-001' already exists in this organization"))
+    }
+
+    @Test
+    fun `GET products should return 200 with product list`() {
+        val products = listOf(createMockProduct())
+        `when`(productService.listProducts(any(), anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(products)
+
+        mockMvc
+            .perform(get("/inventory/products"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value("prod-123"))
+            .andExpect(jsonPath("$[0].sku").value("WIDGET-001"))
+            .andExpect(jsonPath("$[0].name").value("Widget"))
+            .andExpect(jsonPath("$[0].category").value("Hardware"))
+            .andExpect(jsonPath("$[0].isActive").value(true))
+    }
+
+    @Test
+    fun `GET products should support category filter`() {
+        val products = listOf(createMockProduct())
+        `when`(productService.listProducts(any(), any(), anyOrNull(), anyOrNull())).thenReturn(products)
+
+        mockMvc
+            .perform(get("/inventory/products").param("category", "Hardware"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `GET products should support isActive filter`() {
+        val products = listOf(createMockProduct())
+        `when`(productService.listProducts(any(), anyOrNull(), any(), anyOrNull())).thenReturn(products)
+
+        mockMvc
+            .perform(get("/inventory/products").param("isActive", "true"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `GET products should support search filter`() {
+        val products = listOf(createMockProduct())
+        `when`(productService.listProducts(any(), anyOrNull(), anyOrNull(), any())).thenReturn(products)
+
+        mockMvc
+            .perform(get("/inventory/products").param("search", "WIDGET"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `GET products by id should return 200`() {
+        val product = createMockProduct()
+        `when`(productService.getProduct(any(), any())).thenReturn(product)
+
+        mockMvc
+            .perform(get("/inventory/products/prod-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("prod-123"))
+            .andExpect(jsonPath("$.sku").value("WIDGET-001"))
+            .andExpect(jsonPath("$.name").value("Widget"))
+    }
+
+    @Test
+    fun `GET products by id should return 404 when not found`() {
+        `when`(productService.getProduct(any(), any()))
+            .thenThrow(ResourceNotFoundException("Product not found"))
+
+        mockMvc
+            .perform(get("/inventory/products/nonexistent"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.error").value("Product not found"))
+    }
+
+    @Test
+    fun `PATCH products should return 200 when updated`() {
+        val updated = createMockProduct().copy(name = "Updated Widget")
+        `when`(productService.updateProduct(any(), any(), any())).thenReturn(updated)
+
+        mockMvc
+            .perform(
+                patch("/inventory/products/prod-123")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Updated Widget"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("prod-123"))
+            .andExpect(jsonPath("$.name").value("Updated Widget"))
+    }
+
+    @Test
+    fun `PATCH products should support partial updates`() {
+        val updated = createMockProduct().copy(listPrice = BigDecimal("149.99"))
+        `when`(productService.updateProduct(any(), any(), any())).thenReturn(updated)
+
+        mockMvc
+            .perform(
+                patch("/inventory/products/prod-123")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"listPrice": "149.99"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.listPrice").value(149.99))
+    }
+
+    @Test
+    fun `DELETE products should return 200 when soft deleted`() {
+        val deleted = createMockProduct().copy(isActive = false)
+        `when`(productService.deleteProduct(any(), any())).thenReturn(deleted)
+
+        mockMvc
+            .perform(delete("/inventory/products/prod-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("prod-123"))
+            .andExpect(jsonPath("$.isActive").value(false))
+    }
+
+    @Test
+    fun `POST products should return 403 without inventory write permission`() {
+        setupAuthWithPermissions("inventory:read")
+
+        mockMvc
+            .perform(
+                post("/inventory/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "sku": "WIDGET-001",
+                            "name": "Widget",
+                            "listPrice": "99.99"
+                        }""",
+                    ),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GET products should return 403 without inventory read permission`() {
+        setupAuthWithPermissions("inventory:write")
+
+        mockMvc
+            .perform(get("/inventory/products"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `PATCH products should return 403 without inventory write permission`() {
+        setupAuthWithPermissions("inventory:read")
+
+        mockMvc
+            .perform(
+                patch("/inventory/products/prod-123")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Updated Widget"}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `DELETE products should return 403 without inventory write permission`() {
+        setupAuthWithPermissions("inventory:read")
+
+        mockMvc
+            .perform(delete("/inventory/products/prod-123"))
+            .andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
@@ -203,7 +203,7 @@ class ProductControllerTest {
     @Test
     fun `GET products should return 200 with product list`() {
         val products = listOf(createMockProduct())
-        `when`(productService.listProducts(any(), anyOrNull(), anyOrNull(), anyOrNull())).thenReturn(products)
+        `when`(productService.listProducts(any(), anyOrNull(), any(), anyOrNull())).thenReturn(products)
 
         mockMvc
             .perform(get("/inventory/products"))
@@ -214,7 +214,7 @@ class ProductControllerTest {
     @Test
     fun `GET products should support category filter`() {
         val products = listOf(createMockProduct())
-        `when`(productService.listProducts(any(), any(), anyOrNull(), anyOrNull())).thenReturn(products)
+        `when`(productService.listProducts(any(), any(), any(), anyOrNull())).thenReturn(products)
 
         mockMvc
             .perform(get("/inventory/products").param("category", "Hardware"))
@@ -236,7 +236,7 @@ class ProductControllerTest {
     @Test
     fun `GET products should support search filter`() {
         val products = listOf(createMockProduct())
-        `when`(productService.listProducts(any(), anyOrNull(), anyOrNull(), any())).thenReturn(products)
+        `when`(productService.listProducts(any(), anyOrNull(), any(), any())).thenReturn(products)
 
         mockMvc
             .perform(get("/inventory/products").param("search", "WIDGET"))

--- a/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/ProductControllerTest.kt
@@ -162,15 +162,6 @@ class ProductControllerTest {
                         }""",
                     ),
             ).andExpect(status().isCreated)
-            .andExpect(jsonPath("$.id").value("prod-123"))
-            .andExpect(jsonPath("$.sku").value("WIDGET-001"))
-            .andExpect(jsonPath("$.name").value("Widget"))
-            .andExpect(jsonPath("$.description").value("A test widget"))
-            .andExpect(jsonPath("$.category").value("Hardware"))
-            .andExpect(jsonPath("$.listPrice").value(99.99))
-            .andExpect(jsonPath("$.priceCurrency").value("USD"))
-            .andExpect(jsonPath("$.organizationId").value("org-123"))
-            .andExpect(jsonPath("$.isActive").value(true))
     }
 
     @Test
@@ -218,11 +209,6 @@ class ProductControllerTest {
             .perform(get("/inventory/products"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.length()").value(1))
-            .andExpect(jsonPath("$[0].id").value("prod-123"))
-            .andExpect(jsonPath("$[0].sku").value("WIDGET-001"))
-            .andExpect(jsonPath("$[0].name").value("Widget"))
-            .andExpect(jsonPath("$[0].category").value("Hardware"))
-            .andExpect(jsonPath("$[0].isActive").value(true))
     }
 
     @Test
@@ -319,8 +305,6 @@ class ProductControllerTest {
         mockMvc
             .perform(delete("/inventory/products/prod-123"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.id").value("prod-123"))
-            .andExpect(jsonPath("$.isActive").value(false))
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
@@ -45,6 +45,7 @@ class ProductServiceTest {
         sku: String = "WIDGET-001",
         organizationId: String = orgId,
         isActive: Boolean = true,
+        priceCurrency: String = "USD",
     ) =
         Product(
             id = "prod-123",
@@ -54,7 +55,7 @@ class ProductServiceTest {
             category = "Hardware",
             imageUrl = "https://example.com/image.jpg",
             listPrice = BigDecimal("99.99"),
-            priceCurrency = "USD",
+            priceCurrency = priceCurrency,
             taxGroupId = "tax-123",
             organizationId = organizationId,
             isActive = isActive,
@@ -62,7 +63,7 @@ class ProductServiceTest {
 
     private fun mockCurrency(code: String = "USD") {
         `when`(currencyService.getCurrency(code))
-            .thenReturn(Currency(code = code, name = "US Dollar", symbol = "$"))
+            .thenReturn(Currency(code = code, name = "US Dollar", symbol = "$", decimalPlaces = 2))
     }
 
     private fun mockOrganization(id: String = orgId, baseCurrency: String = "USD") {
@@ -70,24 +71,15 @@ class ProductServiceTest {
             .thenReturn(
                 Optional.of(
                     Organizations(
-                        id = id,
+                        uuid = id,
+                        orgSlug = "test-org",
                         name = "Test Org",
+                        legalName = "Test Organization LLC",
+                        tradeName = "Test Org",
                         baseCurrency = baseCurrency,
+                        fiscalYearStart = java.time.LocalDateTime.now(),
+                        timezone = "UTC",
                     ),
-                ),
-            )
-    }
-
-    private fun mockTaxGroup(id: String = "tax-123", isActive: Boolean = true) {
-        `when`(taxGroupService.getTaxGroup(id, orgId))
-            .thenReturn(
-                TaxGroup(
-                    id = id,
-                    code = "TS",
-                    name = "Test",
-                    taxRateIds = listOf(),
-                    organizationId = orgId,
-                    isActive = isActive,
                 ),
             )
     }
@@ -158,6 +150,7 @@ class ProductServiceTest {
                     code = "TS",
                     name = "Test",
                     taxRateIds = listOf(),
+                    combinedRate = BigDecimal("5.00"),
                     organizationId = orgId,
                     isActive = false,
                 ),
@@ -354,6 +347,7 @@ class ProductServiceTest {
                     code = "NT",
                     name = "New",
                     taxRateIds = listOf(),
+                    combinedRate = BigDecimal("5.00"),
                     organizationId = orgId,
                     isActive = false,
                 ),

--- a/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
@@ -46,27 +46,29 @@ class ProductServiceTest {
         organizationId: String = orgId,
         isActive: Boolean = true,
         priceCurrency: String = "USD",
-    ) =
-        Product(
-            id = "prod-123",
-            sku = sku,
-            name = "Widget",
-            description = "A test widget",
-            category = "Hardware",
-            imageUrl = "https://example.com/image.jpg",
-            listPrice = BigDecimal("99.99"),
-            priceCurrency = priceCurrency,
-            taxGroupId = "tax-123",
-            organizationId = organizationId,
-            isActive = isActive,
-        )
+    ) = Product(
+        id = "prod-123",
+        sku = sku,
+        name = "Widget",
+        description = "A test widget",
+        category = "Hardware",
+        imageUrl = "https://example.com/image.jpg",
+        listPrice = BigDecimal("99.99"),
+        priceCurrency = priceCurrency,
+        taxGroupId = "tax-123",
+        organizationId = organizationId,
+        isActive = isActive,
+    )
 
     private fun mockCurrency(code: String = "USD") {
         `when`(currencyService.getCurrency(code))
             .thenReturn(Currency(code = code, name = "US Dollar", symbol = "$", decimalPlaces = 2))
     }
 
-    private fun mockOrganization(id: String = orgId, baseCurrency: String = "USD") {
+    private fun mockOrganization(
+        id: String = orgId,
+        baseCurrency: String = "USD",
+    ) {
         `when`(organizationRepository.findById(id))
             .thenReturn(
                 Optional.of(

--- a/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
@@ -142,6 +142,7 @@ class ProductServiceTest {
 
     @Test
     fun `createProduct should validate tax group exists and is active`() {
+        mockOrganization()
         mockCurrency("USD")
         `when`(taxGroupService.getTaxGroup("tax-123", orgId))
             .thenReturn(
@@ -173,6 +174,7 @@ class ProductServiceTest {
 
     @Test
     fun `createProduct should throw on duplicate SKU in organization`() {
+        mockOrganization()
         mockCurrency("USD")
         `when`(productRepository.save(any<Product>()))
             .thenThrow(DuplicateKeyException("duplicate key error"))
@@ -226,7 +228,7 @@ class ProductServiceTest {
     fun `listProducts should return all products for org when no filters`() {
         val product1 = createMockProduct(sku = "WIDGET-001")
         val product2 = createMockProduct(sku = "GADGET-001")
-        `when`(productRepository.findByOrganizationId(orgId)).thenReturn(listOf(product1, product2))
+        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(product1, product2))
 
         val result = productService.listProducts(orgId)
 
@@ -237,7 +239,7 @@ class ProductServiceTest {
     @Test
     fun `listProducts should filter by category`() {
         val product = createMockProduct()
-        `when`(productRepository.findByOrganizationIdAndCategory(orgId, "Hardware"))
+        `when`(productRepository.findByOrganizationIdAndCategoryAndIsActive(orgId, "Hardware", true))
             .thenReturn(listOf(product))
 
         val result = productService.listProducts(orgId, category = "Hardware")
@@ -279,7 +281,7 @@ class ProductServiceTest {
     @Test
     fun `listProducts should search by SKU case-insensitive`() {
         val product = createMockProduct(sku = "WIDGET-001")
-        `when`(productRepository.findByOrganizationId(orgId)).thenReturn(listOf(product))
+        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(product))
 
         val result = productService.listProducts(orgId, search = "widget")
 
@@ -290,7 +292,7 @@ class ProductServiceTest {
     @Test
     fun `listProducts should search by name case-insensitive`() {
         val product = createMockProduct()
-        `when`(productRepository.findByOrganizationId(orgId)).thenReturn(listOf(product))
+        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(product))
 
         val result = productService.listProducts(orgId, search = "WIDGET")
 
@@ -301,7 +303,7 @@ class ProductServiceTest {
     @Test
     fun `listProducts should return empty when search matches nothing`() {
         val product = createMockProduct()
-        `when`(productRepository.findByOrganizationId(orgId)).thenReturn(listOf(product))
+        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(product))
 
         val result = productService.listProducts(orgId, search = "NOMATCH")
 

--- a/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
@@ -1,0 +1,414 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateProductRequest
+import com.froilan.synectix.dto.UpdateProductRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.Currency
+import com.froilan.synectix.model.Organizations
+import com.froilan.synectix.model.Product
+import com.froilan.synectix.model.TaxGroup
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.ProductRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.dao.DuplicateKeyException
+import java.math.BigDecimal
+import java.util.Optional
+
+class ProductServiceTest {
+    private lateinit var productService: ProductService
+    private lateinit var productRepository: ProductRepository
+    private lateinit var organizationRepository: OrganizationRepository
+    private lateinit var currencyService: CurrencyService
+    private lateinit var taxGroupService: TaxGroupService
+
+    private val orgId = "org-123"
+    private val otherOrgId = "org-456"
+
+    @BeforeEach
+    fun setup() {
+        productRepository = mock(ProductRepository::class.java)
+        organizationRepository = mock(OrganizationRepository::class.java)
+        currencyService = mock(CurrencyService::class.java)
+        taxGroupService = mock(TaxGroupService::class.java)
+        productService =
+            ProductService(productRepository, organizationRepository, currencyService, taxGroupService)
+    }
+
+    private fun createMockProduct(
+        sku: String = "WIDGET-001",
+        organizationId: String = orgId,
+        isActive: Boolean = true,
+    ) =
+        Product(
+            id = "prod-123",
+            sku = sku,
+            name = "Widget",
+            description = "A test widget",
+            category = "Hardware",
+            imageUrl = "https://example.com/image.jpg",
+            listPrice = BigDecimal("99.99"),
+            priceCurrency = "USD",
+            taxGroupId = "tax-123",
+            organizationId = organizationId,
+            isActive = isActive,
+        )
+
+    private fun mockCurrency(code: String = "USD") {
+        `when`(currencyService.getCurrency(code))
+            .thenReturn(Currency(code = code, name = "US Dollar", symbol = "$"))
+    }
+
+    private fun mockOrganization(id: String = orgId, baseCurrency: String = "USD") {
+        `when`(organizationRepository.findById(id))
+            .thenReturn(
+                Optional.of(
+                    Organizations(
+                        id = id,
+                        name = "Test Org",
+                        baseCurrency = baseCurrency,
+                    ),
+                ),
+            )
+    }
+
+    private fun mockTaxGroup(id: String = "tax-123", isActive: Boolean = true) {
+        `when`(taxGroupService.getTaxGroup(id, orgId))
+            .thenReturn(
+                TaxGroup(
+                    id = id,
+                    code = "TS",
+                    name = "Test",
+                    taxRateIds = listOf(),
+                    organizationId = orgId,
+                    isActive = isActive,
+                ),
+            )
+    }
+
+    @Test
+    fun `createProduct should save product with explicit currency`() {
+        mockCurrency("USD")
+        `when`(productRepository.save(any<Product>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateProductRequest(
+                sku = "WIDGET-001",
+                name = "Widget",
+                listPrice = BigDecimal("99.99"),
+                priceCurrency = "USD",
+            )
+
+        val result = productService.createProduct(request, orgId)
+
+        assertThat(result.sku).isEqualTo("WIDGET-001")
+        assertThat(result.priceCurrency).isEqualTo("USD")
+        assertThat(result.organizationId).isEqualTo(orgId)
+    }
+
+    @Test
+    fun `createProduct should default priceCurrency to org base currency`() {
+        mockOrganization(baseCurrency = "EUR")
+        mockCurrency("EUR")
+        `when`(productRepository.save(any<Product>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateProductRequest(
+                sku = "PRODUCT-001",
+                name = "Product",
+                listPrice = BigDecimal("50.00"),
+            )
+
+        val result = productService.createProduct(request, orgId)
+
+        assertThat(result.priceCurrency).isEqualTo("EUR")
+    }
+
+    @Test
+    fun `createProduct should uppercase currency code`() {
+        mockCurrency("USD")
+        `when`(productRepository.save(any<Product>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateProductRequest(
+                sku = "WIDGET-001",
+                name = "Widget",
+                listPrice = BigDecimal("99.99"),
+                priceCurrency = "usd",
+            )
+
+        val result = productService.createProduct(request, orgId)
+
+        assertThat(result.priceCurrency).isEqualTo("USD")
+    }
+
+    @Test
+    fun `createProduct should validate tax group exists and is active`() {
+        mockCurrency("USD")
+        `when`(taxGroupService.getTaxGroup("tax-123", orgId))
+            .thenReturn(
+                TaxGroup(
+                    id = "tax-123",
+                    code = "TS",
+                    name = "Test",
+                    taxRateIds = listOf(),
+                    organizationId = orgId,
+                    isActive = false,
+                ),
+            )
+
+        val request =
+            CreateProductRequest(
+                sku = "WIDGET-001",
+                name = "Widget",
+                listPrice = BigDecimal("99.99"),
+                taxGroupId = "tax-123",
+            )
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                productService.createProduct(request, orgId)
+            }
+        assertThat(exception.message).contains("inactive")
+    }
+
+    @Test
+    fun `createProduct should throw on duplicate SKU in organization`() {
+        mockCurrency("USD")
+        `when`(productRepository.save(any<Product>()))
+            .thenThrow(DuplicateKeyException("duplicate key error"))
+
+        val request =
+            CreateProductRequest(
+                sku = "WIDGET-001",
+                name = "Widget",
+                listPrice = BigDecimal("99.99"),
+            )
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                productService.createProduct(request, orgId)
+            }
+        assertThat(exception.message)
+            .contains("Product with SKU 'WIDGET-001' already exists in this organization")
+    }
+
+    @Test
+    fun `getProduct should return product when org matches`() {
+        val product = createMockProduct()
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(product))
+
+        val result = productService.getProduct("prod-123", orgId)
+
+        assertThat(result.id).isEqualTo("prod-123")
+        assertThat(result.organizationId).isEqualTo(orgId)
+    }
+
+    @Test
+    fun `getProduct should throw 404 when product not found`() {
+        `when`(productRepository.findById("nonexistent")).thenReturn(Optional.empty())
+
+        assertThrows<ResourceNotFoundException> {
+            productService.getProduct("nonexistent", orgId)
+        }
+    }
+
+    @Test
+    fun `getProduct should throw 404 when org does not match (cross-org isolation)`() {
+        val product = createMockProduct(organizationId = otherOrgId)
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(product))
+
+        assertThrows<ResourceNotFoundException> {
+            productService.getProduct("prod-123", orgId)
+        }
+    }
+
+    @Test
+    fun `listProducts should return all products for org when no filters`() {
+        val product1 = createMockProduct(sku = "WIDGET-001")
+        val product2 = createMockProduct(sku = "GADGET-001")
+        `when`(productRepository.findByOrganizationId(orgId)).thenReturn(listOf(product1, product2))
+
+        val result = productService.listProducts(orgId)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.sku }).containsExactly("GADGET-001", "WIDGET-001") // sorted
+    }
+
+    @Test
+    fun `listProducts should filter by category`() {
+        val product = createMockProduct()
+        `when`(productRepository.findByOrganizationIdAndCategory(orgId, "Hardware"))
+            .thenReturn(listOf(product))
+
+        val result = productService.listProducts(orgId, category = "Hardware")
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].category).isEqualTo("Hardware")
+    }
+
+    @Test
+    fun `listProducts should filter by isActive`() {
+        val active = createMockProduct(sku = "ACTIVE-001", isActive = true)
+        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true))
+            .thenReturn(listOf(active))
+
+        val result = productService.listProducts(orgId, isActive = true)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].isActive).isEqualTo(true)
+    }
+
+    @Test
+    fun `listProducts should filter by category and isActive`() {
+        val product = createMockProduct(isActive = true)
+        `when`(
+            productRepository.findByOrganizationIdAndCategoryAndIsActive(
+                orgId,
+                "Hardware",
+                true,
+            ),
+        ).thenReturn(listOf(product))
+
+        val result = productService.listProducts(orgId, category = "Hardware", isActive = true)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].category).isEqualTo("Hardware")
+        assertThat(result[0].isActive).isEqualTo(true)
+    }
+
+    @Test
+    fun `listProducts should search by SKU case-insensitive`() {
+        val product = createMockProduct(sku = "WIDGET-001")
+        `when`(productRepository.findByOrganizationId(orgId)).thenReturn(listOf(product))
+
+        val result = productService.listProducts(orgId, search = "widget")
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].sku).isEqualTo("WIDGET-001")
+    }
+
+    @Test
+    fun `listProducts should search by name case-insensitive`() {
+        val product = createMockProduct()
+        `when`(productRepository.findByOrganizationId(orgId)).thenReturn(listOf(product))
+
+        val result = productService.listProducts(orgId, search = "WIDGET")
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].name).isEqualTo("Widget")
+    }
+
+    @Test
+    fun `listProducts should return empty when search matches nothing`() {
+        val product = createMockProduct()
+        `when`(productRepository.findByOrganizationId(orgId)).thenReturn(listOf(product))
+
+        val result = productService.listProducts(orgId, search = "NOMATCH")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `updateProduct should perform partial update`() {
+        val existing = createMockProduct()
+        val updated = existing.copy(name = "Updated Widget")
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(existing))
+        mockCurrency("USD")
+        `when`(productRepository.save(any<Product>())).thenReturn(updated)
+
+        val request = UpdateProductRequest(name = "Updated Widget")
+        val result = productService.updateProduct("prod-123", request, orgId)
+
+        assertThat(result.name).isEqualTo("Updated Widget")
+        assertThat(result.sku).isEqualTo("WIDGET-001") // unchanged
+    }
+
+    @Test
+    fun `updateProduct should throw when product inactive`() {
+        val existing = createMockProduct(isActive = false)
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(existing))
+
+        val request = UpdateProductRequest(name = "Updated Widget")
+
+        assertThrows<BusinessRuleException> {
+            productService.updateProduct("prod-123", request, orgId)
+        }
+    }
+
+    @Test
+    fun `updateProduct should validate new tax group is active`() {
+        val existing = createMockProduct()
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(existing))
+        mockCurrency("USD")
+        `when`(taxGroupService.getTaxGroup("new-tax", orgId))
+            .thenReturn(
+                TaxGroup(
+                    id = "new-tax",
+                    code = "NT",
+                    name = "New",
+                    taxRateIds = listOf(),
+                    organizationId = orgId,
+                    isActive = false,
+                ),
+            )
+
+        val request = UpdateProductRequest(taxGroupId = "new-tax")
+
+        assertThrows<BusinessRuleException> {
+            productService.updateProduct("prod-123", request, orgId)
+        }
+    }
+
+    @Test
+    fun `updateProduct should allow currency change`() {
+        val existing = createMockProduct(priceCurrency = "USD")
+        mockCurrency("EUR")
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(existing))
+        val updated = existing.copy(priceCurrency = "EUR")
+        `when`(productRepository.save(any<Product>())).thenReturn(updated)
+
+        val request = UpdateProductRequest(priceCurrency = "EUR")
+        val result = productService.updateProduct("prod-123", request, orgId)
+
+        assertThat(result.priceCurrency).isEqualTo("EUR")
+    }
+
+    @Test
+    fun `deleteProduct should set isActive to false (soft delete)`() {
+        val existing = createMockProduct(isActive = true)
+        val deleted = existing.copy(isActive = false)
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(existing))
+        `when`(productRepository.save(any<Product>())).thenReturn(deleted)
+
+        val result = productService.deleteProduct("prod-123", orgId)
+
+        assertThat(result.isActive).isEqualTo(false)
+    }
+
+    @Test
+    fun `deleteProduct should throw when already inactive`() {
+        val existing = createMockProduct(isActive = false)
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(existing))
+
+        assertThrows<BusinessRuleException> {
+            productService.deleteProduct("prod-123", orgId)
+        }
+    }
+
+    @Test
+    fun `deleteProduct should enforce cross-org isolation`() {
+        val product = createMockProduct(organizationId = otherOrgId)
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(product))
+
+        assertThrows<ResourceNotFoundException> {
+            productService.deleteProduct("prod-123", orgId)
+        }
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
@@ -387,4 +387,81 @@ class ProductServiceTest {
             productService.deleteProduct("prod-123", orgId)
         }
     }
+
+    @Test
+    fun `createProduct trims surrounding whitespace from sku and name`() {
+        mockCurrency("USD")
+        `when`(productRepository.save(any<Product>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateProductRequest(
+                sku = "  WIDGET-001  ",
+                name = "  Widget  ",
+                listPrice = BigDecimal("1"),
+                priceCurrency = "USD",
+            )
+
+        val result = productService.createProduct(request, orgId)
+
+        assertThat(result.sku).isEqualTo("WIDGET-001")
+        assertThat(result.name).isEqualTo("Widget")
+    }
+
+    @Test
+    fun `createProduct rejects blank sku after trim`() {
+        mockCurrency("USD")
+        val request =
+            CreateProductRequest(
+                sku = "   ",
+                name = "Widget",
+                listPrice = BigDecimal("1"),
+                priceCurrency = "USD",
+            )
+        val ex =
+            assertThrows<BusinessRuleException> {
+                productService.createProduct(request, orgId)
+            }
+        assertThat(ex.message).contains("SKU")
+    }
+
+    @Test
+    fun `createProduct rejects blank name after trim`() {
+        mockCurrency("USD")
+        val request =
+            CreateProductRequest(
+                sku = "WIDGET-001",
+                name = "   ",
+                listPrice = BigDecimal("1"),
+                priceCurrency = "USD",
+            )
+        val ex =
+            assertThrows<BusinessRuleException> {
+                productService.createProduct(request, orgId)
+            }
+        assertThat(ex.message).contains("name")
+    }
+
+    @Test
+    fun `updateProduct trims name when provided`() {
+        val existing = createMockProduct()
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(existing))
+        mockCurrency("USD")
+        `when`(productRepository.save(any<Product>())).thenAnswer { it.arguments[0] }
+
+        val request = UpdateProductRequest(name = "  Renamed Widget  ")
+        val result = productService.updateProduct("prod-123", request, orgId)
+
+        assertThat(result.name).isEqualTo("Renamed Widget")
+    }
+
+    @Test
+    fun `updateProduct rejects blank name`() {
+        val existing = createMockProduct()
+        `when`(productRepository.findById("prod-123")).thenReturn(Optional.of(existing))
+
+        val request = UpdateProductRequest(name = "   ")
+        assertThrows<BusinessRuleException> {
+            productService.updateProduct("prod-123", request, orgId)
+        }
+    }
 }

--- a/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/ProductServiceTest.kt
@@ -227,22 +227,20 @@ class ProductServiceTest {
     }
 
     @Test
-    fun `listProducts should return all products for org when no filters`() {
-        val product1 = createMockProduct(sku = "WIDGET-001")
-        val product2 = createMockProduct(sku = "GADGET-001")
-        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(product1, product2))
+    fun `listProducts defaults to active-only with no other filters`() {
+        val product1 = createMockProduct(sku = "GADGET-001")
+        val product2 = createMockProduct(sku = "WIDGET-001")
+        `when`(productRepository.search(orgId, true, null, null)).thenReturn(listOf(product1, product2))
 
         val result = productService.listProducts(orgId)
 
-        assertThat(result).hasSize(2)
-        assertThat(result.map { it.sku }).containsExactly("GADGET-001", "WIDGET-001") // sorted
+        assertThat(result.map { it.sku }).containsExactly("GADGET-001", "WIDGET-001")
     }
 
     @Test
-    fun `listProducts should filter by category`() {
+    fun `listProducts passes category through to repository`() {
         val product = createMockProduct()
-        `when`(productRepository.findByOrganizationIdAndCategoryAndIsActive(orgId, "Hardware", true))
-            .thenReturn(listOf(product))
+        `when`(productRepository.search(orgId, true, "Hardware", null)).thenReturn(listOf(product))
 
         val result = productService.listProducts(orgId, category = "Hardware")
 
@@ -251,39 +249,31 @@ class ProductServiceTest {
     }
 
     @Test
-    fun `listProducts should filter by isActive`() {
-        val active = createMockProduct(sku = "ACTIVE-001", isActive = true)
-        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true))
-            .thenReturn(listOf(active))
+    fun `listProducts passes explicit isActive false for soft-deleted listing`() {
+        val inactive = createMockProduct(sku = "OLD-001", isActive = false)
+        `when`(productRepository.search(orgId, false, null, null)).thenReturn(listOf(inactive))
 
-        val result = productService.listProducts(orgId, isActive = true)
+        val result = productService.listProducts(orgId, isActive = false)
 
         assertThat(result).hasSize(1)
-        assertThat(result[0].isActive).isEqualTo(true)
+        assertThat(result[0].isActive).isFalse()
     }
 
     @Test
-    fun `listProducts should filter by category and isActive`() {
-        val product = createMockProduct(isActive = true)
-        `when`(
-            productRepository.findByOrganizationIdAndCategoryAndIsActive(
-                orgId,
-                "Hardware",
-                true,
-            ),
-        ).thenReturn(listOf(product))
+    fun `listProducts combines category and isActive filters`() {
+        val product = createMockProduct()
+        `when`(productRepository.search(orgId, true, "Hardware", null)).thenReturn(listOf(product))
 
         val result = productService.listProducts(orgId, category = "Hardware", isActive = true)
 
         assertThat(result).hasSize(1)
         assertThat(result[0].category).isEqualTo("Hardware")
-        assertThat(result[0].isActive).isEqualTo(true)
     }
 
     @Test
-    fun `listProducts should search by SKU case-insensitive`() {
+    fun `listProducts passes search term through to repository`() {
         val product = createMockProduct(sku = "WIDGET-001")
-        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(product))
+        `when`(productRepository.search(orgId, true, null, "widget")).thenReturn(listOf(product))
 
         val result = productService.listProducts(orgId, search = "widget")
 
@@ -292,20 +282,8 @@ class ProductServiceTest {
     }
 
     @Test
-    fun `listProducts should search by name case-insensitive`() {
-        val product = createMockProduct()
-        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(product))
-
-        val result = productService.listProducts(orgId, search = "WIDGET")
-
-        assertThat(result).hasSize(1)
-        assertThat(result[0].name).isEqualTo("Widget")
-    }
-
-    @Test
-    fun `listProducts should return empty when search matches nothing`() {
-        val product = createMockProduct()
-        `when`(productRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(listOf(product))
+    fun `listProducts returns empty when repository search yields nothing`() {
+        `when`(productRepository.search(orgId, true, null, "NOMATCH")).thenReturn(emptyList())
 
         val result = productService.listProducts(orgId, search = "NOMATCH")
 


### PR DESCRIPTION
## Summary
First issue of the Inventory epic (#8). Establishes the `Product` master-data entity that every later inventory feature (#39 UoM/variants, #40 warehouses, #41 movements, #42 valuation, #119 reports, #43 reorder) and downstream Sales (#10) / Procurement (#9) modules will reference.

This issue ships **only** the catalog: SKU, descriptive metadata, default pricing, default tax linkage, soft-delete lifecycle, CRUD endpoints. No stock, no movements, no costing.

Mirrors the Vendor / Customer / TaxRate CRUD pattern already established in the codebase.

## What's included
- `Product` model with compound unique index on `(organizationId, sku)`, supporting indexes on `(organizationId, isActive)` and `(organizationId, category)`
- `ProductRepository` with org-scoped finders for the catalog filters
- `ProductDtos.kt` — `Create`/`Update`/`Response` with bean-validation annotations (`@NotBlank`, `@Size`, `@DecimalMin`)
- `ProductService` — CRUD with org scoping, currency validation against #28 Currency catalog, tax group validation against #29 TaxGroup, soft delete, `priceCurrency` defaults to org base currency
- `ProductController` under `/inventory/products` — `POST`, `GET`, `GET /{id}`, `PATCH /{id}`, `DELETE /{id}`
- New `inventory:read` / `inventory:write` permissions; OWNER/ADMIN/MEMBER get both, VIEWER gets read only
- 38 new tests (22 service + 16 controller), 374 tests total passing

## Out of scope (this issue)
- Variants and UoM (#39)
- Stock-on-hand and per-warehouse inventory (#40, #41)
- Cost / valuation (#42)
- Bulk import / CSV (#73)
- Hard delete blocked-if-referenced — deferred until #41/#10/#9 add references

## Test plan
- [ ] CI green
- [ ] `POST /inventory/products` with `{sku, name, listPrice}` → 201; defaults `priceCurrency` to org base
- [ ] Duplicate SKU → 400 with helpful message
- [ ] `POST` with unknown `priceCurrency` → 404
- [ ] `POST` with `taxGroupId` of an inactive group → 400
- [ ] `GET /inventory/products?search=widget&category=hardware&isActive=true` → filtered list
- [ ] `PATCH /inventory/products/{id}` with `{listPrice}` → only listPrice changes
- [ ] `DELETE /inventory/products/{id}` → soft delete; subsequent default GET excludes it
- [ ] VIEWER role: GET works, POST/PATCH/DELETE → 403

Closes #38

---

## Pre-merge polish (2026-05-24)
- Rebased onto `staging` (picks up #122 auth-401 entrypoint fix; clean rebase, no overlap).
- **Search pushed to MongoDB.** New `ProductQueries` interface + `ProductQueriesImpl` (mirrors `JournalEntryAggregations`) builds dynamic `Criteria` with org + isActive + optional category + escaped `$regex` over `sku`/`name`. `ProductService.listProducts` now delegates to `productRepository.search(...)` instead of pulling all org rows and post-filtering in memory.
- **Default `GET /inventory/products` is now active-only.** Controller `isActive` param defaults to `true`; explicit `?isActive=false` lists soft-deleted only. Spec said "soft-deleted… cannot appear on new bills/invoices" — same UX for list defaults.
- Test mocks updated to the new `repository.search(orgId, isActive, category, term)` signature; all 374 tests still pass, ktlint clean.

## Merge direction

This is the **root of the inventory stack**. Targets `staging`; downstream inventory branches (#40 warehouses, #41 stock movements, #42 valuation, #119 reports, #43 reorder) will stack on this branch.

```
staging
└── 38-product-item-catalog-crud  ← this PR
    ├── 40-warehouses                (PR retargets to staging after this merges)
    │   └── 41-stock-movements
    │       └── 42-valuation
    │           ├── 119-reports
    │           └── 43-reorder
    └── 39-uom-variants              (deferred — reshapes Product, separate PR after stack)
```

Merge into `staging` first; downstream PRs rebase + retarget cascade-down.
