### PR TITLE
fix(security): return 401 for unauthenticated requests

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/SecurityConfig.kt
@@ -58,6 +58,11 @@ class SecurityConfig(
                 it.requestMatchers("/actuator/info").permitAll()
                 it.anyRequest().authenticated()
             }.exceptionHandling {
+                it.authenticationEntryPoint { _, resp, _ ->
+                    resp.status = 401
+                    resp.contentType = "application/json"
+                    resp.writer.write("""{"error":"Authentication required"}""")
+                }
                 it.accessDeniedHandler { _, resp, _ ->
                     resp.status = 403
                     resp.contentType = "application/json"


### PR DESCRIPTION
## Problem

Unauthenticated requests to protected endpoints (e.g. `GET /finance/ap/bills` with no/invalid session token) returned **403 Forbidden** instead of **401 Unauthorized**.

`SecurityConfig` configured an `accessDeniedHandler` but no `authenticationEntryPoint`, so Spring fell back to the default `Http403ForbiddenEntryPoint`. Clients could not distinguish "not authenticated" (should redirect to sign-in) from "authenticated but lacking permission" (forbidden).

Backend log confirming the misbehavior:

```
Securing GET /finance/ap/bills
Set SecurityContextHolder to anonymous SecurityContext
Http403ForbiddenEntryPoint - Pre-authenticated entry point called. Rejecting access
```

## Change

Add an `authenticationEntryPoint` that responds **401** with a JSON body for unauthenticated requests. The existing `accessDeniedHandler` continues to return **403** for authenticated-but-unauthorized requests, preserving correct semantics.

## Verification

- `./gradlew compileKotlin ktlintMainSourceSetCheck` — BUILD SUCCESSFUL
- Unauthenticated `GET /finance/ap/bills` now returns `401 {"error":"Authentication required"}`
