### PR TITLE
Warehouses & storage locations (#40)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/controller/WarehouseController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/WarehouseController.kt
@@ -1,0 +1,99 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateWarehouseRequest
+import com.froilan.synectix.dto.UpdateWarehouseRequest
+import com.froilan.synectix.dto.WarehouseResponse
+import com.froilan.synectix.model.Warehouse
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.WarehouseService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/inventory/warehouses")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class WarehouseController(
+    private val warehouseService: WarehouseService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun createWarehouse(
+        @Valid @RequestBody request: CreateWarehouseRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val warehouse = warehouseService.createWarehouse(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(warehouse.toResponse())
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun listWarehouses(
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean,
+        @RequestParam(required = false) search: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val warehouses = warehouseService.listWarehouses(orgId, isActive, search)
+        return ResponseEntity.ok(warehouses.map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun getWarehouse(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val warehouse = warehouseService.getWarehouse(id, orgId)
+        return ResponseEntity.ok(warehouse.toResponse())
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun updateWarehouse(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateWarehouseRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val warehouse = warehouseService.updateWarehouse(id, request, orgId)
+        return ResponseEntity.ok(warehouse.toResponse())
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun deleteWarehouse(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val warehouse = warehouseService.deleteWarehouse(id, orgId)
+        return ResponseEntity.ok(warehouse.toResponse())
+    }
+
+    private fun Warehouse.toResponse() =
+        WarehouseResponse(
+            id = id,
+            code = code,
+            name = name,
+            description = description,
+            addressLine = addressLine,
+            city = city,
+            country = country,
+            allowNegativeStock = allowNegativeStock,
+            organizationId = organizationId,
+            isActive = isActive,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/WarehouseDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/WarehouseDtos.kt
@@ -1,0 +1,51 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateWarehouseRequest(
+    @field:NotBlank(message = "Warehouse code is required")
+    @field:Size(max = 64, message = "Warehouse code must be 64 characters or fewer")
+    val code: String,
+    @field:NotBlank(message = "Warehouse name is required")
+    @field:Size(max = 255, message = "Warehouse name must be 255 characters or fewer")
+    val name: String,
+    @field:Size(max = 2000, message = "Description must be 2000 characters or fewer")
+    val description: String? = null,
+    @field:Size(max = 255, message = "Address line must be 255 characters or fewer")
+    val addressLine: String? = null,
+    @field:Size(max = 128, message = "City must be 128 characters or fewer")
+    val city: String? = null,
+    @field:Size(max = 64, message = "Country must be 64 characters or fewer")
+    val country: String? = null,
+    val allowNegativeStock: Boolean? = null,
+)
+
+data class UpdateWarehouseRequest(
+    @field:Size(max = 255, message = "Warehouse name must be 255 characters or fewer")
+    val name: String? = null,
+    @field:Size(max = 2000, message = "Description must be 2000 characters or fewer")
+    val description: String? = null,
+    @field:Size(max = 255, message = "Address line must be 255 characters or fewer")
+    val addressLine: String? = null,
+    @field:Size(max = 128, message = "City must be 128 characters or fewer")
+    val city: String? = null,
+    @field:Size(max = 64, message = "Country must be 64 characters or fewer")
+    val country: String? = null,
+    val allowNegativeStock: Boolean? = null,
+)
+
+data class WarehouseResponse(
+    val id: String,
+    val code: String,
+    val name: String,
+    val description: String?,
+    val addressLine: String?,
+    val city: String?,
+    val country: String?,
+    val allowNegativeStock: Boolean,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Warehouse.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Warehouse.kt
@@ -1,0 +1,42 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.CompoundIndexes
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "warehouses")
+@CompoundIndexes(
+    CompoundIndex(
+        name = "unique_code_per_org",
+        def = "{'organizationId': 1, 'code': 1}",
+        unique = true,
+    ),
+    CompoundIndex(
+        name = "warehouses_org_active",
+        def = "{'organizationId': 1, 'isActive': 1}",
+    ),
+)
+data class Warehouse(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val code: String,
+    val name: String,
+    val description: String? = null,
+    val addressLine: String? = null,
+    val city: String? = null,
+    val country: String? = null,
+    val allowNegativeStock: Boolean = false,
+    @Indexed
+    val organizationId: String,
+    val isActive: Boolean = true,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/WarehouseQueries.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/WarehouseQueries.kt
@@ -1,0 +1,44 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Warehouse
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+
+interface WarehouseQueries {
+    fun search(
+        organizationId: String,
+        isActive: Boolean,
+        term: String?,
+    ): List<Warehouse>
+}
+
+open class WarehouseQueriesImpl(
+    private val mongoTemplate: MongoTemplate,
+) : WarehouseQueries {
+    override fun search(
+        organizationId: String,
+        isActive: Boolean,
+        term: String?,
+    ): List<Warehouse> {
+        val criteria =
+            Criteria
+                .where("organizationId")
+                .`is`(organizationId)
+                .and("isActive")
+                .`is`(isActive)
+        val cleaned = term?.trim()?.takeIf { it.isNotEmpty() }
+        if (cleaned != null) {
+            val escaped = Regex.escape(cleaned)
+            criteria.orOperator(
+                Criteria.where("code").regex(escaped, "i"),
+                Criteria.where("name").regex(escaped, "i"),
+            )
+        }
+        return mongoTemplate.find(
+            Query(criteria).with(Sort.by(Sort.Direction.ASC, "code")),
+            Warehouse::class.java,
+        )
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/WarehouseRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/WarehouseRepository.kt
@@ -1,0 +1,10 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.Warehouse
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface WarehouseRepository :
+    MongoRepository<Warehouse, String>,
+    WarehouseQueries

--- a/src/main/kotlin/com/froilan/synectix/service/WarehouseService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/WarehouseService.kt
@@ -1,0 +1,97 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateWarehouseRequest
+import com.froilan.synectix.dto.UpdateWarehouseRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.Warehouse
+import com.froilan.synectix.repository.WarehouseRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class WarehouseService(
+    private val warehouseRepository: WarehouseRepository,
+) {
+    @Transactional
+    fun createWarehouse(
+        request: CreateWarehouseRequest,
+        organizationId: String,
+    ): Warehouse {
+        val warehouse =
+            Warehouse(
+                code = request.code,
+                name = request.name,
+                description = request.description,
+                addressLine = request.addressLine,
+                city = request.city,
+                country = request.country,
+                allowNegativeStock = request.allowNegativeStock ?: false,
+                organizationId = organizationId,
+            )
+        return try {
+            warehouseRepository.save(warehouse)
+        } catch (e: DuplicateKeyException) {
+            throw BusinessRuleException(
+                "Warehouse with code '${request.code}' already exists in this organization",
+                e,
+            )
+        }
+    }
+
+    fun getWarehouse(
+        warehouseId: String,
+        organizationId: String,
+    ): Warehouse {
+        val warehouse =
+            warehouseRepository.findById(warehouseId).orElseThrow {
+                ResourceNotFoundException("Warehouse not found")
+            }
+        if (warehouse.organizationId != organizationId) {
+            throw ResourceNotFoundException("Warehouse not found")
+        }
+        return warehouse
+    }
+
+    fun listWarehouses(
+        organizationId: String,
+        isActive: Boolean = true,
+        search: String? = null,
+    ): List<Warehouse> = warehouseRepository.search(organizationId, isActive, search)
+
+    @Transactional
+    fun updateWarehouse(
+        warehouseId: String,
+        request: UpdateWarehouseRequest,
+        organizationId: String,
+    ): Warehouse {
+        val existing = getWarehouse(warehouseId, organizationId)
+        if (!existing.isActive) {
+            throw BusinessRuleException("Cannot update inactive warehouse")
+        }
+        val updated =
+            existing.copy(
+                name = request.name ?: existing.name,
+                description = request.description ?: existing.description,
+                addressLine = request.addressLine ?: existing.addressLine,
+                city = request.city ?: existing.city,
+                country = request.country ?: existing.country,
+                allowNegativeStock = request.allowNegativeStock ?: existing.allowNegativeStock,
+            )
+        return warehouseRepository.save(updated)
+    }
+
+    @Transactional
+    fun deleteWarehouse(
+        warehouseId: String,
+        organizationId: String,
+    ): Warehouse {
+        val warehouse = getWarehouse(warehouseId, organizationId)
+        if (!warehouse.isActive) {
+            throw BusinessRuleException("Warehouse is already inactive")
+        }
+        // TODO: when #41 lands, block soft delete if warehouse has open stock or movements.
+        return warehouseRepository.save(warehouse.copy(isActive = false))
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/WarehouseControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/WarehouseControllerTest.kt
@@ -1,0 +1,298 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.model.Warehouse
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.JournalEntryService
+import com.froilan.synectix.service.WarehouseService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+@WebMvcTest(controllers = [WarehouseController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class WarehouseControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
+
+    @MockitoBean
+    private lateinit var warehouseService: WarehouseService
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("inventory:read", "inventory:write")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+        `when`(authenticationContext.userId()).thenReturn("user-123")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    private fun createMockWarehouse() =
+        Warehouse(
+            id = "wh-123",
+            code = "MAIN",
+            name = "Main Warehouse",
+            description = "Primary",
+            addressLine = "123 Main St",
+            city = "Springfield",
+            country = "US",
+            allowNegativeStock = false,
+            organizationId = "org-123",
+            isActive = true,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+        )
+
+    @Test
+    fun `POST warehouses should return 201 when created`() {
+        `when`(warehouseService.createWarehouse(any(), any())).thenReturn(createMockWarehouse())
+
+        mockMvc
+            .perform(
+                post("/inventory/warehouses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "code": "MAIN",
+                            "name": "Main Warehouse",
+                            "allowNegativeStock": false
+                        }""",
+                    ),
+            ).andExpect(status().isCreated)
+    }
+
+    @Test
+    fun `POST warehouses should return 400 when code is blank`() {
+        mockMvc
+            .perform(
+                post("/inventory/warehouses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "code": "",
+                            "name": "Main"
+                        }""",
+                    ),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST warehouses should return 400 when duplicate code in org`() {
+        `when`(warehouseService.createWarehouse(any(), any()))
+            .thenThrow(BusinessRuleException("Warehouse with code 'MAIN' already exists in this organization"))
+
+        mockMvc
+            .perform(
+                post("/inventory/warehouses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "code": "MAIN",
+                            "name": "Main"
+                        }""",
+                    ),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error").value("Warehouse with code 'MAIN' already exists in this organization"))
+    }
+
+    @Test
+    fun `GET warehouses should return 200 with list`() {
+        `when`(warehouseService.listWarehouses(any(), any(), anyOrNull())).thenReturn(listOf(createMockWarehouse()))
+
+        mockMvc
+            .perform(get("/inventory/warehouses"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `GET warehouses should support search filter`() {
+        `when`(warehouseService.listWarehouses(any(), any(), any())).thenReturn(listOf(createMockWarehouse()))
+
+        mockMvc
+            .perform(get("/inventory/warehouses").param("search", "MAIN"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `GET warehouse by id should return 200`() {
+        `when`(warehouseService.getWarehouse(any(), any())).thenReturn(createMockWarehouse())
+
+        mockMvc
+            .perform(get("/inventory/warehouses/wh-123"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value("wh-123"))
+            .andExpect(jsonPath("$.code").value("MAIN"))
+    }
+
+    @Test
+    fun `GET warehouse by id should return 404 when not found`() {
+        `when`(warehouseService.getWarehouse(any(), any()))
+            .thenThrow(ResourceNotFoundException("Warehouse not found"))
+
+        mockMvc
+            .perform(get("/inventory/warehouses/nonexistent"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PATCH warehouses should return 200 when updated`() {
+        val updated = createMockWarehouse().copy(name = "Renamed")
+        `when`(warehouseService.updateWarehouse(any(), any(), any())).thenReturn(updated)
+
+        mockMvc
+            .perform(
+                patch("/inventory/warehouses/wh-123")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Renamed"}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.name").value("Renamed"))
+    }
+
+    @Test
+    fun `DELETE warehouses should return 200 when soft deleted`() {
+        `when`(warehouseService.deleteWarehouse(any(), any())).thenReturn(createMockWarehouse().copy(isActive = false))
+
+        mockMvc
+            .perform(delete("/inventory/warehouses/wh-123"))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `POST warehouses should return 403 without inventory write`() {
+        setupAuthWithPermissions("inventory:read")
+
+        mockMvc
+            .perform(
+                post("/inventory/warehouses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"code": "MAIN", "name": "Main"}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GET warehouses should return 403 without inventory read`() {
+        setupAuthWithPermissions("inventory:write")
+
+        mockMvc
+            .perform(get("/inventory/warehouses"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `PATCH warehouses should return 403 without inventory write`() {
+        setupAuthWithPermissions("inventory:read")
+
+        mockMvc
+            .perform(
+                patch("/inventory/warehouses/wh-123")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Renamed"}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `DELETE warehouses should return 403 without inventory write`() {
+        setupAuthWithPermissions("inventory:read")
+
+        mockMvc
+            .perform(delete("/inventory/warehouses/wh-123"))
+            .andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/WarehouseServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/WarehouseServiceTest.kt
@@ -1,0 +1,229 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateWarehouseRequest
+import com.froilan.synectix.dto.UpdateWarehouseRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.Warehouse
+import com.froilan.synectix.repository.WarehouseRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.dao.DuplicateKeyException
+import java.util.Optional
+
+class WarehouseServiceTest {
+    private lateinit var warehouseService: WarehouseService
+    private lateinit var warehouseRepository: WarehouseRepository
+
+    private val orgId = "org-123"
+    private val otherOrgId = "org-456"
+
+    @BeforeEach
+    fun setup() {
+        warehouseRepository = mock(WarehouseRepository::class.java)
+        warehouseService = WarehouseService(warehouseRepository)
+    }
+
+    private fun createMockWarehouse(
+        code: String = "MAIN",
+        organizationId: String = orgId,
+        isActive: Boolean = true,
+        allowNegativeStock: Boolean = false,
+    ) = Warehouse(
+        id = "wh-123",
+        code = code,
+        name = "Main Warehouse",
+        description = "Primary warehouse",
+        addressLine = "123 Main St",
+        city = "Springfield",
+        country = "US",
+        allowNegativeStock = allowNegativeStock,
+        organizationId = organizationId,
+        isActive = isActive,
+    )
+
+    @Test
+    fun `createWarehouse should save warehouse with provided fields`() {
+        `when`(warehouseRepository.save(any<Warehouse>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateWarehouseRequest(
+                code = "MAIN",
+                name = "Main Warehouse",
+            )
+
+        val result = warehouseService.createWarehouse(request, orgId)
+
+        assertThat(result.code).isEqualTo("MAIN")
+        assertThat(result.organizationId).isEqualTo(orgId)
+        assertThat(result.allowNegativeStock).isFalse()
+        assertThat(result.isActive).isTrue()
+    }
+
+    @Test
+    fun `createWarehouse should honour allowNegativeStock when set`() {
+        `when`(warehouseRepository.save(any<Warehouse>())).thenAnswer { it.arguments[0] }
+
+        val request =
+            CreateWarehouseRequest(
+                code = "OVERFLOW",
+                name = "Overflow",
+                allowNegativeStock = true,
+            )
+
+        val result = warehouseService.createWarehouse(request, orgId)
+
+        assertThat(result.allowNegativeStock).isTrue()
+    }
+
+    @Test
+    fun `createWarehouse should throw on duplicate code in organization`() {
+        `when`(warehouseRepository.save(any<Warehouse>()))
+            .thenThrow(DuplicateKeyException("duplicate key error"))
+
+        val request = CreateWarehouseRequest(code = "MAIN", name = "Main Warehouse")
+
+        val exception =
+            assertThrows<BusinessRuleException> {
+                warehouseService.createWarehouse(request, orgId)
+            }
+        assertThat(exception.message).contains("Warehouse with code 'MAIN' already exists in this organization")
+    }
+
+    @Test
+    fun `getWarehouse should return warehouse when org matches`() {
+        val warehouse = createMockWarehouse()
+        `when`(warehouseRepository.findById("wh-123")).thenReturn(Optional.of(warehouse))
+
+        val result = warehouseService.getWarehouse("wh-123", orgId)
+
+        assertThat(result.id).isEqualTo("wh-123")
+        assertThat(result.organizationId).isEqualTo(orgId)
+    }
+
+    @Test
+    fun `getWarehouse should throw 404 when not found`() {
+        `when`(warehouseRepository.findById("nonexistent")).thenReturn(Optional.empty())
+
+        assertThrows<ResourceNotFoundException> {
+            warehouseService.getWarehouse("nonexistent", orgId)
+        }
+    }
+
+    @Test
+    fun `getWarehouse should enforce cross-org isolation`() {
+        val warehouse = createMockWarehouse(organizationId = otherOrgId)
+        `when`(warehouseRepository.findById("wh-123")).thenReturn(Optional.of(warehouse))
+
+        assertThrows<ResourceNotFoundException> {
+            warehouseService.getWarehouse("wh-123", orgId)
+        }
+    }
+
+    @Test
+    fun `listWarehouses defaults to active-only`() {
+        val a = createMockWarehouse(code = "MAIN")
+        val b = createMockWarehouse(code = "EAST")
+        `when`(warehouseRepository.search(orgId, true, null)).thenReturn(listOf(b, a))
+
+        val result = warehouseService.listWarehouses(orgId)
+
+        assertThat(result.map { it.code }).containsExactly("EAST", "MAIN")
+    }
+
+    @Test
+    fun `listWarehouses passes isActive false through to repository`() {
+        val inactive = createMockWarehouse(code = "OLD", isActive = false)
+        `when`(warehouseRepository.search(orgId, false, null)).thenReturn(listOf(inactive))
+
+        val result = warehouseService.listWarehouses(orgId, isActive = false)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].isActive).isFalse()
+    }
+
+    @Test
+    fun `listWarehouses passes search term through to repository`() {
+        val warehouse = createMockWarehouse(code = "MAIN")
+        `when`(warehouseRepository.search(orgId, true, "main")).thenReturn(listOf(warehouse))
+
+        val result = warehouseService.listWarehouses(orgId, search = "main")
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].code).isEqualTo("MAIN")
+    }
+
+    @Test
+    fun `updateWarehouse should perform partial update`() {
+        val existing = createMockWarehouse()
+        val updated = existing.copy(name = "Renamed Warehouse")
+        `when`(warehouseRepository.findById("wh-123")).thenReturn(Optional.of(existing))
+        `when`(warehouseRepository.save(any<Warehouse>())).thenReturn(updated)
+
+        val request = UpdateWarehouseRequest(name = "Renamed Warehouse")
+        val result = warehouseService.updateWarehouse("wh-123", request, orgId)
+
+        assertThat(result.name).isEqualTo("Renamed Warehouse")
+        assertThat(result.code).isEqualTo("MAIN")
+    }
+
+    @Test
+    fun `updateWarehouse should allow toggling allowNegativeStock`() {
+        val existing = createMockWarehouse(allowNegativeStock = false)
+        val updated = existing.copy(allowNegativeStock = true)
+        `when`(warehouseRepository.findById("wh-123")).thenReturn(Optional.of(existing))
+        `when`(warehouseRepository.save(any<Warehouse>())).thenReturn(updated)
+
+        val request = UpdateWarehouseRequest(allowNegativeStock = true)
+        val result = warehouseService.updateWarehouse("wh-123", request, orgId)
+
+        assertThat(result.allowNegativeStock).isTrue()
+    }
+
+    @Test
+    fun `updateWarehouse should throw when warehouse inactive`() {
+        val existing = createMockWarehouse(isActive = false)
+        `when`(warehouseRepository.findById("wh-123")).thenReturn(Optional.of(existing))
+
+        assertThrows<BusinessRuleException> {
+            warehouseService.updateWarehouse("wh-123", UpdateWarehouseRequest(name = "X"), orgId)
+        }
+    }
+
+    @Test
+    fun `deleteWarehouse should set isActive to false (soft delete)`() {
+        val existing = createMockWarehouse(isActive = true)
+        val deleted = existing.copy(isActive = false)
+        `when`(warehouseRepository.findById("wh-123")).thenReturn(Optional.of(existing))
+        `when`(warehouseRepository.save(any<Warehouse>())).thenReturn(deleted)
+
+        val result = warehouseService.deleteWarehouse("wh-123", orgId)
+
+        assertThat(result.isActive).isFalse()
+    }
+
+    @Test
+    fun `deleteWarehouse should throw when already inactive`() {
+        val existing = createMockWarehouse(isActive = false)
+        `when`(warehouseRepository.findById("wh-123")).thenReturn(Optional.of(existing))
+
+        assertThrows<BusinessRuleException> {
+            warehouseService.deleteWarehouse("wh-123", orgId)
+        }
+    }
+
+    @Test
+    fun `deleteWarehouse should enforce cross-org isolation`() {
+        val warehouse = createMockWarehouse(organizationId = otherOrgId)
+        `when`(warehouseRepository.findById("wh-123")).thenReturn(Optional.of(warehouse))
+
+        assertThrows<ResourceNotFoundException> {
+            warehouseService.deleteWarehouse("wh-123", orgId)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Second issue of the Inventory epic (#8). Adds the `Warehouse` master-data entity that #41 (stock movements), #42 (valuation per warehouse), #43 (reorder per warehouse), and #119 (reports) all depend on.

Mirrors the `Product` CRUD pattern from #121: org-scoped, compound-unique code, soft-delete via `isActive`, MongoTemplate-backed dynamic list/search.

## What's included
- `Warehouse` model with compound unique index on `(organizationId, code)`, supporting index on `(organizationId, isActive)`
- `WarehouseRepository` extending `MongoRepository` + custom `WarehouseQueries` (`WarehouseQueriesImpl` builds dynamic `Criteria` with org + isActive + optional escaped `$regex` search over `code`/`name`)
- `WarehouseDtos.kt` — `Create`/`Update`/`Response` with bean-validation
- `WarehouseService` — CRUD with org scoping, duplicate-code handling, soft delete, `allowNegativeStock` toggleable
- `WarehouseController` under `/inventory/warehouses` — `POST`, `GET`, `GET /{id}`, `PATCH /{id}`, `DELETE /{id}`
- Reuses existing `inventory:read` / `inventory:write` permissions (no new perm constants)
- 28 new tests (15 service + 13 controller)

## MVP additions from #40 (all included)
- `allowNegativeStock: Boolean` on Warehouse (default `false`) — to be enforced by movements in #41
- Org scoping verified on every endpoint
- Compound unique on `(organizationId, code)`

## Out of scope (this issue)
- Zones and bin locations — issue mentions these but acceptance criteria don't pin them; deferring to a follow-on if needed
- Soft-delete guard when warehouse has open stock or movements — TODO in `deleteWarehouse`, blocked until #41 lands

## Merge direction
Targets `38-product-item-catalog-crud` (PR #121). Part of the inventory stack:

```
staging
└── #121  38-product-item-catalog-crud
    └── this PR  40-warehouses          ← retargets to staging after #121 merges
        └── 41-stock-movements         (next)
            └── 42-valuation
                ├── 119-reports
                └── 43-reorder
```

After #121 merges to `staging`, rebase this branch onto `staging` and retarget the PR base. Same cascade for every downstream PR in the stack.

## Test plan
- [ ] CI green
- [ ] `POST /inventory/warehouses` with `{code, name}` → 201
- [ ] Duplicate code in same org → 400 with helpful message
- [ ] Cross-org isolation: GET a warehouse from another org → 404
- [ ] `GET /inventory/warehouses` defaults to active-only; `?isActive=false` returns soft-deleted only
- [ ] `GET /inventory/warehouses?search=main` filters by code or name (case-insensitive)
- [ ] `PATCH /inventory/warehouses/{id}` with `{allowNegativeStock: true}` toggles the flag
- [ ] `DELETE /inventory/warehouses/{id}` soft deletes; subsequent default GET excludes it
- [ ] VIEWER role: GET works, POST/PATCH/DELETE → 403

Part of #40

## CI note
The repo's `.github/workflows/ci.yml` triggers on PRs to `production`/`staging` only — so this PR (which targets `38-product-item-catalog-crud`) will not get a Build & Test run until it's retargeted to `staging` after #121 merges. Locally verified: `./gradlew ktlintCheck test --tests "*Warehouse*"` → all 28 new tests + ktlint pass against the rebased base.

We may want a tiny separate PR to broaden CI to all PRs (`pull_request:` without a `branches` filter) so every stacked branch in the inventory chain gets CI on each push.
