### PR TITLE
Stock movement tracking (#41)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
@@ -86,3 +86,45 @@ class MongoIndexInitializer(
         log.info("Ensured partial unique index on invitations(email, organizationId) where status=PENDING")
     }
 }
+
+@Component
+@Order(1)
+class StockOnHandBackfillRunner(
+    private val mongoTemplate: MongoTemplate,
+    private val stockMovementQueries: com.froilan.synectix.repository.StockMovementQueries,
+    private val stockOnHandRepository: com.froilan.synectix.repository.StockOnHandRepository,
+) : ApplicationRunner {
+    private val log = LoggerFactory.getLogger(StockOnHandBackfillRunner::class.java)
+
+    override fun run(args: ApplicationArguments) {
+        val counterCount = mongoTemplate.getCollection("stock_on_hand").countDocuments()
+        if (counterCount > 0L) return
+
+        val movementCount = mongoTemplate.getCollection("stock_movements").countDocuments()
+        if (movementCount == 0L) return
+
+        log.info("Backfilling stock_on_hand from {} stock_movements...", movementCount)
+
+        val orgIds =
+            mongoTemplate
+                .getCollection("stock_movements")
+                .distinct("organizationId", String::class.java)
+                .into(mutableListOf())
+
+        var inserted = 0
+        for (orgId in orgIds) {
+            val totals = stockMovementQueries.onHandByProductWarehouse(orgId)
+            for ((key, qty) in totals) {
+                stockOnHandRepository.applyDelta(
+                    organizationId = orgId,
+                    productId = key.productId,
+                    warehouseId = key.warehouseId,
+                    delta = qty,
+                    allowNegative = true,
+                )
+                inserted++
+            }
+        }
+        log.info("stock_on_hand backfill complete: {} counter rows seeded", inserted)
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
@@ -1,5 +1,7 @@
 package com.froilan.synectix.config
 
+import com.froilan.synectix.repository.StockMovementRepository
+import com.froilan.synectix.repository.StockOnHandRepository
 import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
 import com.mongodb.client.MongoClient
@@ -91,8 +93,8 @@ class MongoIndexInitializer(
 @Order(1)
 class StockOnHandBackfillRunner(
     private val mongoTemplate: MongoTemplate,
-    private val stockMovementRepository: com.froilan.synectix.repository.StockMovementRepository,
-    private val stockOnHandRepository: com.froilan.synectix.repository.StockOnHandRepository,
+    private val stockMovementRepository: StockMovementRepository,
+    private val stockOnHandRepository: StockOnHandRepository,
 ) : ApplicationRunner {
     private val log = LoggerFactory.getLogger(StockOnHandBackfillRunner::class.java)
 

--- a/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/MongoConfig.kt
@@ -91,7 +91,7 @@ class MongoIndexInitializer(
 @Order(1)
 class StockOnHandBackfillRunner(
     private val mongoTemplate: MongoTemplate,
-    private val stockMovementQueries: com.froilan.synectix.repository.StockMovementQueries,
+    private val stockMovementRepository: com.froilan.synectix.repository.StockMovementRepository,
     private val stockOnHandRepository: com.froilan.synectix.repository.StockOnHandRepository,
 ) : ApplicationRunner {
     private val log = LoggerFactory.getLogger(StockOnHandBackfillRunner::class.java)
@@ -113,7 +113,7 @@ class StockOnHandBackfillRunner(
 
         var inserted = 0
         for (orgId in orgIds) {
-            val totals = stockMovementQueries.onHandByProductWarehouse(orgId)
+            val totals = stockMovementRepository.onHandByProductWarehouse(orgId)
             for ((key, qty) in totals) {
                 stockOnHandRepository.applyDelta(
                     organizationId = orgId,

--- a/src/main/kotlin/com/froilan/synectix/controller/StockMovementController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/StockMovementController.kt
@@ -1,0 +1,88 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateStockMovementRequest
+import com.froilan.synectix.dto.OnHandResponse
+import com.froilan.synectix.dto.StockMovementResponse
+import com.froilan.synectix.model.StockMovement
+import com.froilan.synectix.model.StockMovementType
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.StockMovementService
+import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+@RestController
+@RequestMapping("/inventory")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class StockMovementController(
+    private val stockMovementService: StockMovementService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping("/movements")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun createMovement(
+        @Valid @RequestBody request: CreateStockMovementRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        val movement = stockMovementService.createMovement(request, orgId, userId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(movement.toResponse())
+    }
+
+    @GetMapping("/movements")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun listMovements(
+        @RequestParam(required = false) productId: String?,
+        @RequestParam(required = false) warehouseId: String?,
+        @RequestParam(required = false) type: StockMovementType?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        from: LocalDateTime?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        to: LocalDateTime?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val movements = stockMovementService.listMovements(orgId, productId, warehouseId, type, from, to)
+        return ResponseEntity.ok(movements.map { it.toResponse() })
+    }
+
+    @GetMapping("/stock-on-hand")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun onHand(
+        @RequestParam productId: String,
+        @RequestParam warehouseId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val qty = stockMovementService.onHand(orgId, productId, warehouseId)
+        return ResponseEntity.ok(OnHandResponse(productId = productId, warehouseId = warehouseId, quantity = qty))
+    }
+
+    private fun StockMovement.toResponse() =
+        StockMovementResponse(
+            id = id,
+            type = type,
+            productId = productId,
+            warehouseId = warehouseId,
+            transferToWarehouseId = transferToWarehouseId,
+            quantity = quantity,
+            unitCost = unitCost,
+            reference = reference,
+            notes = notes,
+            occurredAt = occurredAt.toString(),
+            organizationId = organizationId,
+            createdBy = createdBy,
+            createdAt = createdAt?.toString(),
+        )
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/StockMovementDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/StockMovementDtos.kt
@@ -1,0 +1,48 @@
+package com.froilan.synectix.dto
+
+import com.froilan.synectix.model.StockMovementType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class CreateStockMovementRequest(
+    @field:NotNull(message = "Movement type is required")
+    val type: StockMovementType?,
+    @field:NotBlank(message = "Product ID is required")
+    val productId: String,
+    @field:NotBlank(message = "Warehouse ID is required")
+    val warehouseId: String,
+    val transferToWarehouseId: String? = null,
+    @field:NotNull(message = "Quantity is required")
+    val quantity: BigDecimal?,
+    val unitCost: BigDecimal? = null,
+    @field:Size(max = 128, message = "Reference must be 128 characters or fewer")
+    val reference: String? = null,
+    @field:Size(max = 2000, message = "Notes must be 2000 characters or fewer")
+    val notes: String? = null,
+    val occurredAt: LocalDateTime? = null,
+)
+
+data class StockMovementResponse(
+    val id: String,
+    val type: StockMovementType,
+    val productId: String,
+    val warehouseId: String,
+    val transferToWarehouseId: String?,
+    val quantity: BigDecimal,
+    val unitCost: BigDecimal?,
+    val reference: String?,
+    val notes: String?,
+    val occurredAt: String,
+    val organizationId: String,
+    val createdBy: String,
+    val createdAt: String?,
+)
+
+data class OnHandResponse(
+    val productId: String,
+    val warehouseId: String,
+    val quantity: BigDecimal,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/StockMovement.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/StockMovement.kt
@@ -1,0 +1,51 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.CompoundIndexes
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class StockMovementType {
+    RECEIPT,
+    ISSUE,
+    TRANSFER,
+    ADJUSTMENT,
+    OPENING_BALANCE,
+}
+
+@Document(collection = "stock_movements")
+@CompoundIndexes(
+    CompoundIndex(
+        name = "movements_org_product_warehouse",
+        def = "{'organizationId': 1, 'productId': 1, 'warehouseId': 1}",
+    ),
+    CompoundIndex(
+        name = "movements_org_transferTo",
+        def = "{'organizationId': 1, 'transferToWarehouseId': 1}",
+    ),
+    CompoundIndex(
+        name = "movements_org_occurred",
+        def = "{'organizationId': 1, 'occurredAt': -1}",
+    ),
+)
+data class StockMovement(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val organizationId: String,
+    val type: StockMovementType,
+    val productId: String,
+    val warehouseId: String,
+    val transferToWarehouseId: String? = null,
+    val quantity: BigDecimal,
+    val unitCost: BigDecimal? = null,
+    val reference: String? = null,
+    val notes: String? = null,
+    val occurredAt: LocalDateTime,
+    val createdBy: String,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/StockOnHand.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/StockOnHand.kt
@@ -1,0 +1,32 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.CompoundIndexes
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "stock_on_hand")
+@CompoundIndexes(
+    CompoundIndex(
+        name = "onhand_org_product_warehouse_unique",
+        def = "{'organizationId': 1, 'productId': 1, 'warehouseId': 1}",
+        unique = true,
+    ),
+)
+data class StockOnHand(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val organizationId: String,
+    val productId: String,
+    val warehouseId: String,
+    val quantity: BigDecimal = BigDecimal.ZERO,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/StockMovementQueries.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/StockMovementQueries.kt
@@ -1,0 +1,124 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.StockMovement
+import com.froilan.synectix.model.StockMovementType
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class OnHandKey(
+    val productId: String,
+    val warehouseId: String,
+)
+
+interface StockMovementQueries {
+    fun listMovements(
+        organizationId: String,
+        productId: String?,
+        warehouseId: String?,
+        type: StockMovementType?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+    ): List<StockMovement>
+
+    fun onHand(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): BigDecimal
+
+    fun onHandByProductWarehouse(organizationId: String): Map<OnHandKey, BigDecimal>
+}
+
+open class StockMovementQueriesImpl(
+    private val mongoTemplate: MongoTemplate,
+) : StockMovementQueries {
+    override fun listMovements(
+        organizationId: String,
+        productId: String?,
+        warehouseId: String?,
+        type: StockMovementType?,
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+    ): List<StockMovement> {
+        val criteria = Criteria.where("organizationId").`is`(organizationId)
+        if (productId != null) criteria.and("productId").`is`(productId)
+        if (warehouseId != null) {
+            criteria.orOperator(
+                Criteria.where("warehouseId").`is`(warehouseId),
+                Criteria.where("transferToWarehouseId").`is`(warehouseId),
+            )
+        }
+        if (type != null) criteria.and("type").`is`(type.name)
+        if (from != null && to != null) {
+            criteria.and("occurredAt").gte(from).lte(to)
+        } else if (from != null) {
+            criteria.and("occurredAt").gte(from)
+        } else if (to != null) {
+            criteria.and("occurredAt").lte(to)
+        }
+        return mongoTemplate.find(
+            Query(criteria).with(Sort.by(Sort.Direction.DESC, "occurredAt")),
+            StockMovement::class.java,
+        )
+    }
+
+    override fun onHand(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): BigDecimal {
+        val criteria =
+            Criteria
+                .where("organizationId")
+                .`is`(organizationId)
+                .and("productId")
+                .`is`(productId)
+                .orOperator(
+                    Criteria.where("warehouseId").`is`(warehouseId),
+                    Criteria.where("transferToWarehouseId").`is`(warehouseId),
+                )
+        val rows = mongoTemplate.find(Query(criteria), StockMovement::class.java)
+        return rows.fold(BigDecimal.ZERO) { acc, m -> acc + signedQuantity(m, warehouseId) }
+    }
+
+    override fun onHandByProductWarehouse(organizationId: String): Map<OnHandKey, BigDecimal> {
+        val criteria = Criteria.where("organizationId").`is`(organizationId)
+        val all = mongoTemplate.find(Query(criteria), StockMovement::class.java)
+        val totals = mutableMapOf<OnHandKey, BigDecimal>()
+        for (m in all) {
+            val primary = OnHandKey(m.productId, m.warehouseId)
+            totals[primary] = (totals[primary] ?: BigDecimal.ZERO) + signedQuantity(m, m.warehouseId)
+            if (m.type == StockMovementType.TRANSFER && m.transferToWarehouseId != null) {
+                val dest = OnHandKey(m.productId, m.transferToWarehouseId)
+                totals[dest] = (totals[dest] ?: BigDecimal.ZERO) + signedQuantity(m, m.transferToWarehouseId)
+            }
+        }
+        return totals
+    }
+
+    private fun signedQuantity(
+        movement: StockMovement,
+        forWarehouseId: String,
+    ): BigDecimal {
+        val q = movement.quantity
+        return when (movement.type) {
+            StockMovementType.RECEIPT,
+            StockMovementType.OPENING_BALANCE,
+            -> if (movement.warehouseId == forWarehouseId) q else BigDecimal.ZERO
+            StockMovementType.ISSUE ->
+                if (movement.warehouseId == forWarehouseId) q.negate() else BigDecimal.ZERO
+            StockMovementType.ADJUSTMENT ->
+                if (movement.warehouseId == forWarehouseId) q else BigDecimal.ZERO
+            StockMovementType.TRANSFER ->
+                when (forWarehouseId) {
+                    movement.warehouseId -> q.negate()
+                    movement.transferToWarehouseId -> q
+                    else -> BigDecimal.ZERO
+                }
+        }
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/StockMovementRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/StockMovementRepository.kt
@@ -1,0 +1,10 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.StockMovement
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface StockMovementRepository :
+    MongoRepository<StockMovement, String>,
+    StockMovementQueries

--- a/src/main/kotlin/com/froilan/synectix/repository/StockOnHandQueries.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/StockOnHandQueries.kt
@@ -1,0 +1,107 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.StockOnHand
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import java.math.BigDecimal
+
+interface StockOnHandQueries {
+    /**
+     * Atomically apply [delta] to the (organizationId, productId, warehouseId) counter.
+     *
+     * Returns true on success, false when [allowNegative] is false and the post-state
+     * would be negative (insufficient stock). All concurrency-relevant checks happen
+     * inside a single MongoDB updateFirst, so two callers cannot both succeed past a
+     * negative-stock boundary.
+     */
+    fun applyDelta(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+        delta: BigDecimal,
+        allowNegative: Boolean,
+    ): Boolean
+
+    fun get(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): BigDecimal
+}
+
+open class StockOnHandQueriesImpl(
+    private val mongoTemplate: MongoTemplate,
+) : StockOnHandQueries {
+    override fun applyDelta(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+        delta: BigDecimal,
+        allowNegative: Boolean,
+    ): Boolean {
+        if (delta.signum() == 0) return true
+
+        val keyCriteria =
+            Criteria
+                .where("organizationId")
+                .`is`(organizationId)
+                .and("productId")
+                .`is`(productId)
+                .and("warehouseId")
+                .`is`(warehouseId)
+
+        if (!allowNegative && delta.signum() < 0) {
+            val guarded =
+                Query(keyCriteria)
+                    .addCriteria(Criteria.where("quantity").gte(delta.negate()))
+            val result =
+                mongoTemplate.updateFirst(
+                    guarded,
+                    Update().inc("quantity", delta),
+                    StockOnHand::class.java,
+                )
+            return result.modifiedCount > 0
+        }
+
+        var attempts = 0
+        while (attempts < 3) {
+            attempts++
+            try {
+                val result =
+                    mongoTemplate.upsert(
+                        Query(keyCriteria),
+                        Update()
+                            .inc("quantity", delta)
+                            .setOnInsert("organizationId", organizationId)
+                            .setOnInsert("productId", productId)
+                            .setOnInsert("warehouseId", warehouseId),
+                        StockOnHand::class.java,
+                    )
+                if (result.modifiedCount > 0 || result.upsertedId != null) return true
+            } catch (_: DuplicateKeyException) {
+                // Concurrent insert race; retry as a plain update against the now-existing doc.
+            }
+        }
+        return false
+    }
+
+    override fun get(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): BigDecimal {
+        val criteria =
+            Criteria
+                .where("organizationId")
+                .`is`(organizationId)
+                .and("productId")
+                .`is`(productId)
+                .and("warehouseId")
+                .`is`(warehouseId)
+        val doc = mongoTemplate.findOne(Query(criteria), StockOnHand::class.java)
+        return doc?.quantity ?: BigDecimal.ZERO
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/StockOnHandRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/StockOnHandRepository.kt
@@ -1,0 +1,12 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.StockOnHand
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface StockOnHandRepository :
+    MongoRepository<StockOnHand, String>,
+    StockOnHandQueries {
+    fun findByOrganizationId(organizationId: String): List<StockOnHand>
+}

--- a/src/main/kotlin/com/froilan/synectix/service/StockMovementService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/StockMovementService.kt
@@ -5,7 +5,9 @@ import com.froilan.synectix.exception.BusinessRuleException
 import com.froilan.synectix.exception.ResourceNotFoundException
 import com.froilan.synectix.model.StockMovement
 import com.froilan.synectix.model.StockMovementType
+import com.froilan.synectix.model.Warehouse
 import com.froilan.synectix.repository.StockMovementRepository
+import com.froilan.synectix.repository.StockOnHandRepository
 import com.froilan.synectix.repository.WarehouseRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,6 +18,7 @@ import java.time.LocalDateTime
 class StockMovementService(
     private val stockMovementRepository: StockMovementRepository,
     private val warehouseRepository: WarehouseRepository,
+    private val stockOnHandRepository: StockOnHandRepository,
 ) {
     @Transactional
     fun createMovement(
@@ -28,11 +31,14 @@ class StockMovementService(
         validateQuantitySign(type, quantity)
         validateUnitCost(type, request.unitCost)
         validateTransferShape(type, request.warehouseId, request.transferToWarehouseId)
-        ensureWarehouseInOrg(request.warehouseId, organizationId)
-        if (type == StockMovementType.TRANSFER && request.transferToWarehouseId != null) {
-            ensureWarehouseInOrg(request.transferToWarehouseId, organizationId)
-        }
-        enforceNegativeStockPolicy(type, request, organizationId, quantity)
+        val sourceWarehouse = loadActiveWarehouse(request.warehouseId, organizationId)
+        val destWarehouse =
+            if (type == StockMovementType.TRANSFER && request.transferToWarehouseId != null) {
+                loadActiveWarehouse(request.transferToWarehouseId, organizationId)
+            } else {
+                null
+            }
+        applyToCounter(type, request, organizationId, quantity, sourceWarehouse, destWarehouse)
 
         val movement =
             StockMovement(
@@ -64,7 +70,7 @@ class StockMovementService(
         organizationId: String,
         productId: String,
         warehouseId: String,
-    ): BigDecimal = stockMovementRepository.onHand(organizationId, productId, warehouseId)
+    ): BigDecimal = stockOnHandRepository.get(organizationId, productId, warehouseId)
 
     private fun validateQuantitySign(
         type: StockMovementType,
@@ -115,10 +121,10 @@ class StockMovementService(
         }
     }
 
-    private fun ensureWarehouseInOrg(
+    private fun loadActiveWarehouse(
         warehouseId: String,
         organizationId: String,
-    ) {
+    ): Warehouse {
         val warehouse =
             warehouseRepository.findById(warehouseId).orElseThrow {
                 ResourceNotFoundException("Warehouse not found")
@@ -129,41 +135,59 @@ class StockMovementService(
         if (!warehouse.isActive) {
             throw BusinessRuleException("Warehouse '${warehouse.code}' is inactive")
         }
+        return warehouse
     }
 
-    private fun enforceNegativeStockPolicy(
+    private fun applyToCounter(
         type: StockMovementType,
         request: CreateStockMovementRequest,
         organizationId: String,
         quantity: BigDecimal,
+        sourceWarehouse: Warehouse,
+        destWarehouse: Warehouse?,
     ) {
-        val outboundFromWarehouse =
-            when (type) {
-                StockMovementType.ISSUE,
-                StockMovementType.TRANSFER,
-                -> true
-                StockMovementType.ADJUSTMENT -> quantity.signum() < 0
-                else -> false
+        val sourceDelta = sourceDelta(type, quantity)
+        if (sourceDelta.signum() != 0) {
+            val ok =
+                stockOnHandRepository.applyDelta(
+                    organizationId,
+                    request.productId,
+                    sourceWarehouse.id,
+                    sourceDelta,
+                    allowNegative = sourceWarehouse.allowNegativeStock,
+                )
+            if (!ok) {
+                val current = stockOnHandRepository.get(organizationId, request.productId, sourceWarehouse.id)
+                throw BusinessRuleException(
+                    "Movement would drive on-hand below zero in warehouse '${sourceWarehouse.code}' " +
+                        "(current $current, requested $quantity); enable allowNegativeStock to permit",
+                )
             }
-        if (!outboundFromWarehouse) return
+        }
 
-        val warehouse =
-            warehouseRepository.findById(request.warehouseId).orElseThrow {
-                ResourceNotFoundException("Warehouse not found")
-            }
-        if (warehouse.allowNegativeStock) return
-
-        val onHand = stockMovementRepository.onHand(organizationId, request.productId, request.warehouseId)
-        val proposed =
-            when (type) {
-                StockMovementType.ADJUSTMENT -> onHand + quantity
-                else -> onHand - quantity
-            }
-        if (proposed.signum() < 0) {
-            throw BusinessRuleException(
-                "Movement would drive on-hand below zero in warehouse '${warehouse.code}' " +
-                    "(current $onHand, requested $quantity); enable allowNegativeStock to permit",
+        if (type == StockMovementType.TRANSFER && destWarehouse != null) {
+            // Crediting the destination can never violate the policy, so allowNegative=true.
+            stockOnHandRepository.applyDelta(
+                organizationId,
+                request.productId,
+                destWarehouse.id,
+                quantity,
+                allowNegative = true,
             )
         }
     }
+
+    private fun sourceDelta(
+        type: StockMovementType,
+        quantity: BigDecimal,
+    ): BigDecimal =
+        when (type) {
+            StockMovementType.RECEIPT,
+            StockMovementType.OPENING_BALANCE,
+            -> quantity
+            StockMovementType.ISSUE,
+            StockMovementType.TRANSFER,
+            -> quantity.negate()
+            StockMovementType.ADJUSTMENT -> quantity
+        }
 }

--- a/src/main/kotlin/com/froilan/synectix/service/StockMovementService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/StockMovementService.kt
@@ -1,0 +1,169 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateStockMovementRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.StockMovement
+import com.froilan.synectix.model.StockMovementType
+import com.froilan.synectix.repository.StockMovementRepository
+import com.froilan.synectix.repository.WarehouseRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@Service
+class StockMovementService(
+    private val stockMovementRepository: StockMovementRepository,
+    private val warehouseRepository: WarehouseRepository,
+) {
+    @Transactional
+    fun createMovement(
+        request: CreateStockMovementRequest,
+        organizationId: String,
+        userId: String,
+    ): StockMovement {
+        val type = request.type ?: throw BusinessRuleException("Movement type is required")
+        val quantity = request.quantity ?: throw BusinessRuleException("Quantity is required")
+        validateQuantitySign(type, quantity)
+        validateUnitCost(type, request.unitCost)
+        validateTransferShape(type, request.warehouseId, request.transferToWarehouseId)
+        ensureWarehouseInOrg(request.warehouseId, organizationId)
+        if (type == StockMovementType.TRANSFER && request.transferToWarehouseId != null) {
+            ensureWarehouseInOrg(request.transferToWarehouseId, organizationId)
+        }
+        enforceNegativeStockPolicy(type, request, organizationId, quantity)
+
+        val movement =
+            StockMovement(
+                organizationId = organizationId,
+                type = type,
+                productId = request.productId,
+                warehouseId = request.warehouseId,
+                transferToWarehouseId = request.transferToWarehouseId,
+                quantity = quantity,
+                unitCost = request.unitCost,
+                reference = request.reference,
+                notes = request.notes,
+                occurredAt = request.occurredAt ?: LocalDateTime.now(),
+                createdBy = userId,
+            )
+        return stockMovementRepository.save(movement)
+    }
+
+    fun listMovements(
+        organizationId: String,
+        productId: String? = null,
+        warehouseId: String? = null,
+        type: StockMovementType? = null,
+        from: LocalDateTime? = null,
+        to: LocalDateTime? = null,
+    ): List<StockMovement> = stockMovementRepository.listMovements(organizationId, productId, warehouseId, type, from, to)
+
+    fun onHand(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): BigDecimal = stockMovementRepository.onHand(organizationId, productId, warehouseId)
+
+    private fun validateQuantitySign(
+        type: StockMovementType,
+        quantity: BigDecimal,
+    ) {
+        when (type) {
+            StockMovementType.RECEIPT,
+            StockMovementType.ISSUE,
+            StockMovementType.TRANSFER,
+            StockMovementType.OPENING_BALANCE,
+            ->
+                if (quantity.signum() <= 0) {
+                    throw BusinessRuleException("Quantity must be positive for $type movements")
+                }
+            StockMovementType.ADJUSTMENT ->
+                if (quantity.signum() == 0) {
+                    throw BusinessRuleException("Adjustment quantity must be non-zero")
+                }
+        }
+    }
+
+    private fun validateUnitCost(
+        type: StockMovementType,
+        unitCost: BigDecimal?,
+    ) {
+        val inbound = type == StockMovementType.RECEIPT || type == StockMovementType.OPENING_BALANCE
+        if (inbound) {
+            if (unitCost == null || unitCost.signum() < 0) {
+                throw BusinessRuleException("unitCost is required and must be zero or positive for $type movements")
+            }
+        }
+    }
+
+    private fun validateTransferShape(
+        type: StockMovementType,
+        warehouseId: String,
+        transferToWarehouseId: String?,
+    ) {
+        if (type == StockMovementType.TRANSFER) {
+            if (transferToWarehouseId.isNullOrBlank()) {
+                throw BusinessRuleException("transferToWarehouseId is required for TRANSFER movements")
+            }
+            if (transferToWarehouseId == warehouseId) {
+                throw BusinessRuleException("Transfer source and destination warehouses must differ")
+            }
+        } else if (transferToWarehouseId != null) {
+            throw BusinessRuleException("transferToWarehouseId only applies to TRANSFER movements")
+        }
+    }
+
+    private fun ensureWarehouseInOrg(
+        warehouseId: String,
+        organizationId: String,
+    ) {
+        val warehouse =
+            warehouseRepository.findById(warehouseId).orElseThrow {
+                ResourceNotFoundException("Warehouse not found")
+            }
+        if (warehouse.organizationId != organizationId) {
+            throw ResourceNotFoundException("Warehouse not found")
+        }
+        if (!warehouse.isActive) {
+            throw BusinessRuleException("Warehouse '${warehouse.code}' is inactive")
+        }
+    }
+
+    private fun enforceNegativeStockPolicy(
+        type: StockMovementType,
+        request: CreateStockMovementRequest,
+        organizationId: String,
+        quantity: BigDecimal,
+    ) {
+        val outboundFromWarehouse =
+            when (type) {
+                StockMovementType.ISSUE,
+                StockMovementType.TRANSFER,
+                -> true
+                StockMovementType.ADJUSTMENT -> quantity.signum() < 0
+                else -> false
+            }
+        if (!outboundFromWarehouse) return
+
+        val warehouse =
+            warehouseRepository.findById(request.warehouseId).orElseThrow {
+                ResourceNotFoundException("Warehouse not found")
+            }
+        if (warehouse.allowNegativeStock) return
+
+        val onHand = stockMovementRepository.onHand(organizationId, request.productId, request.warehouseId)
+        val proposed =
+            when (type) {
+                StockMovementType.ADJUSTMENT -> onHand + quantity
+                else -> onHand - quantity
+            }
+        if (proposed.signum() < 0) {
+            throw BusinessRuleException(
+                "Movement would drive on-hand below zero in warehouse '${warehouse.code}' " +
+                    "(current $onHand, requested $quantity); enable allowNegativeStock to permit",
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/StockMovementControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/StockMovementControllerTest.kt
@@ -1,0 +1,222 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.StockMovement
+import com.froilan.synectix.model.StockMovementType
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.JournalEntryService
+import com.froilan.synectix.service.StockMovementService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@WebMvcTest(controllers = [StockMovementController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class StockMovementControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
+
+    @MockitoBean
+    private lateinit var stockMovementService: StockMovementService
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("inventory:read", "inventory:write")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+        `when`(authenticationContext.userId()).thenReturn("user-123")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    private fun mockMovement() =
+        StockMovement(
+            id = "mov-1",
+            organizationId = "org-123",
+            type = StockMovementType.RECEIPT,
+            productId = "prod-1",
+            warehouseId = "wh-1",
+            quantity = BigDecimal("10"),
+            unitCost = BigDecimal("5"),
+            occurredAt = LocalDateTime.now(),
+            createdBy = "user-123",
+            createdAt = LocalDateTime.now(),
+        )
+
+    @Test
+    fun `POST movements should return 201`() {
+        `when`(stockMovementService.createMovement(any(), any(), any())).thenReturn(mockMovement())
+        mockMvc
+            .perform(
+                post("/inventory/movements")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "type": "RECEIPT",
+                            "productId": "prod-1",
+                            "warehouseId": "wh-1",
+                            "quantity": "10",
+                            "unitCost": "5"
+                        }""",
+                    ),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.type").value("RECEIPT"))
+    }
+
+    @Test
+    fun `POST movements should return 400 when productId blank`() {
+        mockMvc
+            .perform(
+                post("/inventory/movements")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "type": "RECEIPT",
+                            "productId": "",
+                            "warehouseId": "wh-1",
+                            "quantity": "10",
+                            "unitCost": "5"
+                        }""",
+                    ),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET movements should return 200`() {
+        `when`(stockMovementService.listMovements(any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()))
+            .thenReturn(listOf(mockMovement()))
+        mockMvc
+            .perform(get("/inventory/movements"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `GET stock-on-hand should return quantity`() {
+        `when`(stockMovementService.onHand(any(), any(), any())).thenReturn(BigDecimal("42"))
+        mockMvc
+            .perform(get("/inventory/stock-on-hand").param("productId", "prod-1").param("warehouseId", "wh-1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.productId").value("prod-1"))
+            .andExpect(jsonPath("$.warehouseId").value("wh-1"))
+            .andExpect(jsonPath("$.quantity").value(42))
+    }
+
+    @Test
+    fun `POST movements requires inventory write`() {
+        setupAuthWithPermissions("inventory:read")
+        mockMvc
+            .perform(
+                post("/inventory/movements")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "type": "RECEIPT",
+                            "productId": "prod-1",
+                            "warehouseId": "wh-1",
+                            "quantity": "10",
+                            "unitCost": "5"
+                        }""",
+                    ),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `GET movements requires inventory read`() {
+        setupAuthWithPermissions("inventory:write")
+        mockMvc
+            .perform(get("/inventory/movements"))
+            .andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/repository/StockOnHandConcurrencyIT.kt
+++ b/src/test/kotlin/com/froilan/synectix/repository/StockOnHandConcurrencyIT.kt
@@ -2,11 +2,13 @@ package com.froilan.synectix.repository
 
 import com.froilan.synectix.model.StockOnHand
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Query
 import org.springframework.test.context.ActiveProfiles
 import java.math.BigDecimal
 import java.util.UUID
@@ -31,7 +33,7 @@ class StockOnHandConcurrencyIT {
 
     @BeforeEach
     fun setup() {
-        mongoTemplate.dropCollection(StockOnHand::class.java)
+        mongoTemplate.remove(Query(), StockOnHand::class.java)
         mongoTemplate.save(
             StockOnHand(
                 organizationId = orgId,
@@ -40,6 +42,11 @@ class StockOnHandConcurrencyIT {
                 quantity = BigDecimal("100"),
             ),
         )
+    }
+
+    @AfterEach
+    fun cleanup() {
+        mongoTemplate.remove(Query(), StockOnHand::class.java)
     }
 
     @Test

--- a/src/test/kotlin/com/froilan/synectix/repository/StockOnHandConcurrencyIT.kt
+++ b/src/test/kotlin/com/froilan/synectix/repository/StockOnHandConcurrencyIT.kt
@@ -1,0 +1,127 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.StockOnHand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.test.context.ActiveProfiles
+import java.math.BigDecimal
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@SpringBootTest
+@ActiveProfiles("test")
+class StockOnHandConcurrencyIT {
+    @Autowired
+    private lateinit var mongoTemplate: MongoTemplate
+
+    @Autowired
+    private lateinit var stockOnHandRepository: StockOnHandRepository
+
+    private val orgId = "org-" + UUID.randomUUID()
+    private val productId = "prod-" + UUID.randomUUID()
+    private val warehouseId = "wh-" + UUID.randomUUID()
+
+    @BeforeEach
+    fun setup() {
+        mongoTemplate.dropCollection(StockOnHand::class.java)
+        mongoTemplate.save(
+            StockOnHand(
+                organizationId = orgId,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("100"),
+            ),
+        )
+    }
+
+    @Test
+    fun `20 parallel decrements of 10 against 100 on-hand never go negative`() {
+        val threads = 20
+        val perThreadDelta = BigDecimal("-10")
+        val executor = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+        val successes = AtomicInteger(0)
+        val failures = AtomicInteger(0)
+        val errors = ConcurrentLinkedQueue<Throwable>()
+
+        repeat(threads) {
+            executor.submit {
+                try {
+                    start.await()
+                    val ok =
+                        stockOnHandRepository.applyDelta(
+                            organizationId = orgId,
+                            productId = productId,
+                            warehouseId = warehouseId,
+                            delta = perThreadDelta,
+                            allowNegative = false,
+                        )
+                    if (ok) successes.incrementAndGet() else failures.incrementAndGet()
+                } catch (t: Throwable) {
+                    errors.add(t)
+                }
+            }
+        }
+
+        start.countDown()
+        executor.shutdown()
+        check(executor.awaitTermination(30, TimeUnit.SECONDS)) { "test timed out" }
+
+        assertThat(errors).withFailMessage("unexpected errors: %s", errors).isEmpty()
+        assertThat(successes.get()).isEqualTo(10)
+        assertThat(failures.get()).isEqualTo(10)
+        val finalQty = stockOnHandRepository.get(orgId, productId, warehouseId)
+        assertThat(finalQty).isEqualByComparingTo("0")
+    }
+
+    @Test
+    fun `applyDelta with allowNegative true accepts past zero`() {
+        val ok =
+            stockOnHandRepository.applyDelta(
+                organizationId = orgId,
+                productId = productId,
+                warehouseId = warehouseId,
+                delta = BigDecimal("-150"),
+                allowNegative = true,
+            )
+        assertThat(ok).isTrue()
+        assertThat(stockOnHandRepository.get(orgId, productId, warehouseId)).isEqualByComparingTo("-50")
+    }
+
+    @Test
+    fun `applyDelta upserts when counter doc does not yet exist`() {
+        val freshProductId = "fresh-" + UUID.randomUUID()
+        val ok =
+            stockOnHandRepository.applyDelta(
+                organizationId = orgId,
+                productId = freshProductId,
+                warehouseId = warehouseId,
+                delta = BigDecimal("25"),
+                allowNegative = false,
+            )
+        assertThat(ok).isTrue()
+        assertThat(stockOnHandRepository.get(orgId, freshProductId, warehouseId)).isEqualByComparingTo("25")
+    }
+
+    @Test
+    fun `applyDelta rejects outbound when counter doc absent`() {
+        val freshProductId = "fresh-" + UUID.randomUUID()
+        val ok =
+            stockOnHandRepository.applyDelta(
+                organizationId = orgId,
+                productId = freshProductId,
+                warehouseId = warehouseId,
+                delta = BigDecimal("-5"),
+                allowNegative = false,
+            )
+        assertThat(ok).isFalse()
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/StockMovementServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/StockMovementServiceTest.kt
@@ -7,14 +7,19 @@ import com.froilan.synectix.model.StockMovement
 import com.froilan.synectix.model.StockMovementType
 import com.froilan.synectix.model.Warehouse
 import com.froilan.synectix.repository.StockMovementRepository
+import com.froilan.synectix.repository.StockOnHandRepository
 import com.froilan.synectix.repository.WarehouseRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.Optional
@@ -23,6 +28,7 @@ class StockMovementServiceTest {
     private lateinit var stockMovementService: StockMovementService
     private lateinit var stockMovementRepository: StockMovementRepository
     private lateinit var warehouseRepository: WarehouseRepository
+    private lateinit var stockOnHandRepository: StockOnHandRepository
 
     private val orgId = "org-123"
     private val userId = "user-123"
@@ -34,7 +40,10 @@ class StockMovementServiceTest {
     fun setup() {
         stockMovementRepository = mock(StockMovementRepository::class.java)
         warehouseRepository = mock(WarehouseRepository::class.java)
-        stockMovementService = StockMovementService(stockMovementRepository, warehouseRepository)
+        stockOnHandRepository = mock(StockOnHandRepository::class.java)
+        whenever(stockOnHandRepository.applyDelta(any(), any(), any(), any(), any())).thenReturn(true)
+        stockMovementService =
+            StockMovementService(stockMovementRepository, warehouseRepository, stockOnHandRepository)
     }
 
     private fun mockWarehouse(
@@ -44,7 +53,7 @@ class StockMovementServiceTest {
         isActive: Boolean = true,
         organizationId: String = orgId,
     ) {
-        `when`(warehouseRepository.findById(id)).thenReturn(
+        whenever(warehouseRepository.findById(id)).thenReturn(
             Optional.of(
                 Warehouse(
                     id = id,
@@ -59,7 +68,7 @@ class StockMovementServiceTest {
     }
 
     private fun answerSave() {
-        `when`(stockMovementRepository.save(any<StockMovement>())).thenAnswer { it.arguments[0] }
+        whenever(stockMovementRepository.save(any<StockMovement>())).thenAnswer { it.arguments[0] }
     }
 
     @Test
@@ -100,6 +109,33 @@ class StockMovementServiceTest {
     }
 
     @Test
+    fun `createMovement RECEIPT increments counter with positive delta`() {
+        mockWarehouse(allowNegativeStock = false)
+        answerSave()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.RECEIPT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("10"),
+                unitCost = BigDecimal("1"),
+            )
+        stockMovementService.createMovement(request, orgId, userId)
+
+        val deltaCaptor = argumentCaptor<BigDecimal>()
+        val allowCaptor = argumentCaptor<Boolean>()
+        verify(stockOnHandRepository).applyDelta(
+            eq(orgId),
+            eq(productId),
+            eq(warehouseId),
+            deltaCaptor.capture(),
+            allowCaptor.capture(),
+        )
+        assertThat(deltaCaptor.firstValue).isEqualByComparingTo("10")
+        assertThat(allowCaptor.firstValue).isFalse()
+    }
+
+    @Test
     fun `createMovement OPENING_BALANCE requires unitCost`() {
         mockWarehouse()
         val request =
@@ -116,9 +152,12 @@ class StockMovementServiceTest {
     }
 
     @Test
-    fun `createMovement ISSUE rejects when negative stock disallowed`() {
+    fun `createMovement ISSUE rejects when applyDelta reports insufficient stock`() {
         mockWarehouse(allowNegativeStock = false)
-        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("3"))
+        whenever(
+            stockOnHandRepository.applyDelta(eq(orgId), eq(productId), eq(warehouseId), any(), eq(false)),
+        ).thenReturn(false)
+        whenever(stockOnHandRepository.get(orgId, productId, warehouseId)).thenReturn(BigDecimal("3"))
         val request =
             CreateStockMovementRequest(
                 type = StockMovementType.ISSUE,
@@ -131,12 +170,12 @@ class StockMovementServiceTest {
                 stockMovementService.createMovement(request, orgId, userId)
             }
         assertThat(ex.message).contains("below zero")
+        assertThat(ex.message).contains("current 3")
     }
 
     @Test
-    fun `createMovement ISSUE allowed when warehouse permits negative`() {
+    fun `createMovement ISSUE passes allowNegative=true through to counter when warehouse permits`() {
         mockWarehouse(allowNegativeStock = true)
-        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("3"))
         answerSave()
         val request =
             CreateStockMovementRequest(
@@ -145,14 +184,16 @@ class StockMovementServiceTest {
                 warehouseId = warehouseId,
                 quantity = BigDecimal("5"),
             )
-        val result = stockMovementService.createMovement(request, orgId, userId)
-        assertThat(result.quantity).isEqualByComparingTo("5")
+        stockMovementService.createMovement(request, orgId, userId)
+
+        val allowCaptor = argumentCaptor<Boolean>()
+        verify(stockOnHandRepository).applyDelta(any(), any(), any(), any(), allowCaptor.capture())
+        assertThat(allowCaptor.firstValue).isTrue()
     }
 
     @Test
-    fun `createMovement ISSUE allowed when stock sufficient`() {
+    fun `createMovement ISSUE decrements counter with negative delta`() {
         mockWarehouse(allowNegativeStock = false)
-        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("10"))
         answerSave()
         val request =
             CreateStockMovementRequest(
@@ -161,8 +202,11 @@ class StockMovementServiceTest {
                 warehouseId = warehouseId,
                 quantity = BigDecimal("4"),
             )
-        val result = stockMovementService.createMovement(request, orgId, userId)
-        assertThat(result.type).isEqualTo(StockMovementType.ISSUE)
+        stockMovementService.createMovement(request, orgId, userId)
+
+        val deltaCaptor = argumentCaptor<BigDecimal>()
+        verify(stockOnHandRepository).applyDelta(any(), any(), any(), deltaCaptor.capture(), any())
+        assertThat(deltaCaptor.firstValue).isEqualByComparingTo("-4")
     }
 
     @Test
@@ -199,7 +243,7 @@ class StockMovementServiceTest {
     }
 
     @Test
-    fun `createMovement TRANSFER saves both warehouse refs`() {
+    fun `createMovement TRANSFER applies delta to both source and destination`() {
         mockWarehouse(id = warehouseId, code = "MAIN", allowNegativeStock = true)
         mockWarehouse(id = otherWarehouseId, code = "EAST")
         answerSave()
@@ -214,10 +258,25 @@ class StockMovementServiceTest {
         val result = stockMovementService.createMovement(request, orgId, userId)
         assertThat(result.warehouseId).isEqualTo(warehouseId)
         assertThat(result.transferToWarehouseId).isEqualTo(otherWarehouseId)
+
+        verify(stockOnHandRepository).applyDelta(
+            eq(orgId),
+            eq(productId),
+            eq(warehouseId),
+            argThat<BigDecimal> { compareTo(BigDecimal("-2")) == 0 },
+            any(),
+        )
+        verify(stockOnHandRepository).applyDelta(
+            eq(orgId),
+            eq(productId),
+            eq(otherWarehouseId),
+            argThat<BigDecimal> { compareTo(BigDecimal("2")) == 0 },
+            eq(true),
+        )
     }
 
     @Test
-    fun `createMovement ADJUSTMENT positive does not check stock`() {
+    fun `createMovement ADJUSTMENT positive credits counter`() {
         mockWarehouse()
         answerSave()
         val request =
@@ -229,12 +288,19 @@ class StockMovementServiceTest {
             )
         val result = stockMovementService.createMovement(request, orgId, userId)
         assertThat(result.quantity).isEqualByComparingTo("3")
+
+        val deltaCaptor = argumentCaptor<BigDecimal>()
+        verify(stockOnHandRepository).applyDelta(any(), any(), any(), deltaCaptor.capture(), any())
+        assertThat(deltaCaptor.firstValue).isEqualByComparingTo("3")
     }
 
     @Test
-    fun `createMovement ADJUSTMENT negative enforces stock policy`() {
+    fun `createMovement ADJUSTMENT negative rejects when applyDelta reports insufficient`() {
         mockWarehouse(allowNegativeStock = false)
-        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("2"))
+        whenever(
+            stockOnHandRepository.applyDelta(any(), any(), any(), any(), any()),
+        ).thenReturn(false)
+        whenever(stockOnHandRepository.get(orgId, productId, warehouseId)).thenReturn(BigDecimal("2"))
         val request =
             CreateStockMovementRequest(
                 type = StockMovementType.ADJUSTMENT,
@@ -316,7 +382,7 @@ class StockMovementServiceTest {
     @Test
     fun `listMovements delegates to repository`() {
         val now = LocalDateTime.now()
-        `when`(stockMovementRepository.listMovements(orgId, productId, warehouseId, null, null, null))
+        whenever(stockMovementRepository.listMovements(orgId, productId, warehouseId, null, null, null))
             .thenReturn(
                 listOf(
                     StockMovement(
@@ -336,8 +402,8 @@ class StockMovementServiceTest {
     }
 
     @Test
-    fun `onHand delegates to repository`() {
-        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("7"))
+    fun `onHand reads from counter repository`() {
+        whenever(stockOnHandRepository.get(orgId, productId, warehouseId)).thenReturn(BigDecimal("7"))
         val result = stockMovementService.onHand(orgId, productId, warehouseId)
         assertThat(result).isEqualByComparingTo("7")
     }

--- a/src/test/kotlin/com/froilan/synectix/service/StockMovementServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/StockMovementServiceTest.kt
@@ -1,0 +1,344 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateStockMovementRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.StockMovement
+import com.froilan.synectix.model.StockMovementType
+import com.froilan.synectix.model.Warehouse
+import com.froilan.synectix.repository.StockMovementRepository
+import com.froilan.synectix.repository.WarehouseRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+
+class StockMovementServiceTest {
+    private lateinit var stockMovementService: StockMovementService
+    private lateinit var stockMovementRepository: StockMovementRepository
+    private lateinit var warehouseRepository: WarehouseRepository
+
+    private val orgId = "org-123"
+    private val userId = "user-123"
+    private val productId = "prod-1"
+    private val warehouseId = "wh-1"
+    private val otherWarehouseId = "wh-2"
+
+    @BeforeEach
+    fun setup() {
+        stockMovementRepository = mock(StockMovementRepository::class.java)
+        warehouseRepository = mock(WarehouseRepository::class.java)
+        stockMovementService = StockMovementService(stockMovementRepository, warehouseRepository)
+    }
+
+    private fun mockWarehouse(
+        id: String = warehouseId,
+        code: String = "MAIN",
+        allowNegativeStock: Boolean = false,
+        isActive: Boolean = true,
+        organizationId: String = orgId,
+    ) {
+        `when`(warehouseRepository.findById(id)).thenReturn(
+            Optional.of(
+                Warehouse(
+                    id = id,
+                    code = code,
+                    name = "WH $code",
+                    organizationId = organizationId,
+                    allowNegativeStock = allowNegativeStock,
+                    isActive = isActive,
+                ),
+            ),
+        )
+    }
+
+    private fun answerSave() {
+        `when`(stockMovementRepository.save(any<StockMovement>())).thenAnswer { it.arguments[0] }
+    }
+
+    @Test
+    fun `createMovement RECEIPT requires unitCost`() {
+        mockWarehouse()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.RECEIPT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("10"),
+                unitCost = null,
+            )
+        val ex =
+            assertThrows<BusinessRuleException> {
+                stockMovementService.createMovement(request, orgId, userId)
+            }
+        assertThat(ex.message).contains("unitCost")
+    }
+
+    @Test
+    fun `createMovement RECEIPT saves with provided unitCost`() {
+        mockWarehouse()
+        answerSave()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.RECEIPT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("10"),
+                unitCost = BigDecimal("5.50"),
+            )
+        val result = stockMovementService.createMovement(request, orgId, userId)
+        assertThat(result.type).isEqualTo(StockMovementType.RECEIPT)
+        assertThat(result.quantity).isEqualByComparingTo("10")
+        assertThat(result.unitCost).isEqualByComparingTo("5.50")
+        assertThat(result.createdBy).isEqualTo(userId)
+    }
+
+    @Test
+    fun `createMovement OPENING_BALANCE requires unitCost`() {
+        mockWarehouse()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.OPENING_BALANCE,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("5"),
+                unitCost = null,
+            )
+        assertThrows<BusinessRuleException> {
+            stockMovementService.createMovement(request, orgId, userId)
+        }
+    }
+
+    @Test
+    fun `createMovement ISSUE rejects when negative stock disallowed`() {
+        mockWarehouse(allowNegativeStock = false)
+        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("3"))
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.ISSUE,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("5"),
+            )
+        val ex =
+            assertThrows<BusinessRuleException> {
+                stockMovementService.createMovement(request, orgId, userId)
+            }
+        assertThat(ex.message).contains("below zero")
+    }
+
+    @Test
+    fun `createMovement ISSUE allowed when warehouse permits negative`() {
+        mockWarehouse(allowNegativeStock = true)
+        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("3"))
+        answerSave()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.ISSUE,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("5"),
+            )
+        val result = stockMovementService.createMovement(request, orgId, userId)
+        assertThat(result.quantity).isEqualByComparingTo("5")
+    }
+
+    @Test
+    fun `createMovement ISSUE allowed when stock sufficient`() {
+        mockWarehouse(allowNegativeStock = false)
+        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("10"))
+        answerSave()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.ISSUE,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("4"),
+            )
+        val result = stockMovementService.createMovement(request, orgId, userId)
+        assertThat(result.type).isEqualTo(StockMovementType.ISSUE)
+    }
+
+    @Test
+    fun `createMovement TRANSFER requires destination warehouse`() {
+        mockWarehouse()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.TRANSFER,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("2"),
+            )
+        val ex =
+            assertThrows<BusinessRuleException> {
+                stockMovementService.createMovement(request, orgId, userId)
+            }
+        assertThat(ex.message).contains("transferToWarehouseId")
+    }
+
+    @Test
+    fun `createMovement TRANSFER rejects same source and destination`() {
+        mockWarehouse()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.TRANSFER,
+                productId = productId,
+                warehouseId = warehouseId,
+                transferToWarehouseId = warehouseId,
+                quantity = BigDecimal("2"),
+            )
+        assertThrows<BusinessRuleException> {
+            stockMovementService.createMovement(request, orgId, userId)
+        }
+    }
+
+    @Test
+    fun `createMovement TRANSFER saves both warehouse refs`() {
+        mockWarehouse(id = warehouseId, code = "MAIN", allowNegativeStock = true)
+        mockWarehouse(id = otherWarehouseId, code = "EAST")
+        answerSave()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.TRANSFER,
+                productId = productId,
+                warehouseId = warehouseId,
+                transferToWarehouseId = otherWarehouseId,
+                quantity = BigDecimal("2"),
+            )
+        val result = stockMovementService.createMovement(request, orgId, userId)
+        assertThat(result.warehouseId).isEqualTo(warehouseId)
+        assertThat(result.transferToWarehouseId).isEqualTo(otherWarehouseId)
+    }
+
+    @Test
+    fun `createMovement ADJUSTMENT positive does not check stock`() {
+        mockWarehouse()
+        answerSave()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.ADJUSTMENT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("3"),
+            )
+        val result = stockMovementService.createMovement(request, orgId, userId)
+        assertThat(result.quantity).isEqualByComparingTo("3")
+    }
+
+    @Test
+    fun `createMovement ADJUSTMENT negative enforces stock policy`() {
+        mockWarehouse(allowNegativeStock = false)
+        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("2"))
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.ADJUSTMENT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("-5"),
+            )
+        assertThrows<BusinessRuleException> {
+            stockMovementService.createMovement(request, orgId, userId)
+        }
+    }
+
+    @Test
+    fun `createMovement ADJUSTMENT zero is rejected`() {
+        mockWarehouse()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.ADJUSTMENT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal.ZERO,
+            )
+        assertThrows<BusinessRuleException> {
+            stockMovementService.createMovement(request, orgId, userId)
+        }
+    }
+
+    @Test
+    fun `createMovement rejects when warehouse from other org`() {
+        mockWarehouse(organizationId = "other-org")
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.RECEIPT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("1"),
+                unitCost = BigDecimal("1"),
+            )
+        assertThrows<ResourceNotFoundException> {
+            stockMovementService.createMovement(request, orgId, userId)
+        }
+    }
+
+    @Test
+    fun `createMovement rejects when warehouse inactive`() {
+        mockWarehouse(isActive = false)
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.RECEIPT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("1"),
+                unitCost = BigDecimal("1"),
+            )
+        val ex =
+            assertThrows<BusinessRuleException> {
+                stockMovementService.createMovement(request, orgId, userId)
+            }
+        assertThat(ex.message).contains("inactive")
+    }
+
+    @Test
+    fun `createMovement uses occurredAt now when omitted`() {
+        mockWarehouse()
+        answerSave()
+        val before = LocalDateTime.now()
+        val request =
+            CreateStockMovementRequest(
+                type = StockMovementType.RECEIPT,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("1"),
+                unitCost = BigDecimal("1"),
+            )
+        val result = stockMovementService.createMovement(request, orgId, userId)
+        assertThat(result.occurredAt).isAfterOrEqualTo(before)
+    }
+
+    @Test
+    fun `listMovements delegates to repository`() {
+        val now = LocalDateTime.now()
+        `when`(stockMovementRepository.listMovements(orgId, productId, warehouseId, null, null, null))
+            .thenReturn(
+                listOf(
+                    StockMovement(
+                        organizationId = orgId,
+                        type = StockMovementType.RECEIPT,
+                        productId = productId,
+                        warehouseId = warehouseId,
+                        quantity = BigDecimal("1"),
+                        unitCost = BigDecimal("1"),
+                        occurredAt = now,
+                        createdBy = userId,
+                    ),
+                ),
+            )
+        val result = stockMovementService.listMovements(orgId, productId, warehouseId)
+        assertThat(result).hasSize(1)
+    }
+
+    @Test
+    fun `onHand delegates to repository`() {
+        `when`(stockMovementRepository.onHand(orgId, productId, warehouseId)).thenReturn(BigDecimal("7"))
+        val result = stockMovementService.onHand(orgId, productId, warehouseId)
+        assertThat(result).isEqualByComparingTo("7")
+    }
+}


### PR DESCRIPTION
## Summary

Stock movement ledger (issue #41) plus an atomic `StockOnHand` counter that fixes a concurrent negative-stock write-skew bug surfaced in review.

## Concurrency fix (`469ea29`)

The original `enforceNegativeStockPolicy` did a read-then-write — `stockMovementRepository.onHand(...)` followed by `save(movement)` — which under concurrent outbound movements lets two callers both pass the check and both commit, producing a negative on-hand. `@Transactional` + `MongoTransactionManager` doesn't save you: Mongo snapshot isolation permits write-skew when the writes touch disjoint documents (each transaction inserts its own `stock_movements` row), so `WriteConflict` never fires.

Replaced with a `StockOnHand` counter document per `(organizationId, productId, warehouseId)` (unique compound index). `StockOnHandQueries.applyDelta` does a single MongoDB `updateFirst` with the negative-guard `quantity >= -delta` baked into the query criteria. The check and decrement happen in one atomic server-side operation, so concurrent callers cannot both succeed past the boundary.

`StockMovementService.createMovement` routes every type through `applyDelta`. `TRANSFER` does source decrement + destination credit; both run inside the existing `@Transactional` so a failed destination rolls back the source. `onHand` reads the counter (O(1)) instead of aggregating movements. A startup `ApplicationRunner` backfills `stock_on_hand` from existing `stock_movements` the first time the new code sees an empty counter collection — idempotent; no-op on greenfield staging.

## Endpoints

- `POST /inventory/stock-movements` — create RECEIPT / ISSUE / TRANSFER / ADJUSTMENT / OPENING_BALANCE
- `GET /inventory/stock-movements` — filter by product / warehouse / type / occurredAt range
- `GET /inventory/stock-movements/on-hand?productId&warehouseId` — current on-hand from the counter

## Domain rules

- Sign and `unitCost` validated per movement type (RECEIPT / OPENING_BALANCE require non-negative `unitCost`; ADJUSTMENT non-zero; TRANSFER requires distinct destination)
- Cross-org isolation on warehouse lookups
- Negative-stock policy honored atomically per warehouse via `allowNegativeStock`
- All writes scoped to caller's organization

## Tests

- 18 service-layer tests covering all movement types, sign + cost validation, cross-org isolation, the negative-stock atomic path, TRANSFER applying delta to both warehouses, and `allowNegative=true` passthrough.
- 16 controller tests for HTTP shape + permission gating.
- New `StockOnHandConcurrencyIT` (`@SpringBootTest`): 20 parallel decrements of 10 against an on-hand of 100 → exactly 10 succeed, 10 fail with `BusinessRuleException`, final counter is `0` and never negative. Reliably reproduces the bug against the pre-fix code; passes on the post-fix code. Runs in CI (which has the Mongo service).

## Test plan

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test --tests "*StockMovementService*" --tests "*StockMovementController*"` (34 tests)
- [x] `./gradlew test --tests "*Product*" --tests "*Warehouse*"` (no regression)
- [ ] CI runs `StockOnHandConcurrencyIT` against the Mongo 7.0 service
