### PR TITLE
Stock valuation: FIFO + Weighted Average + report (#42 phase 1)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/controller/InventoryValuationController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InventoryValuationController.kt
@@ -1,0 +1,26 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.InventoryValuationService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/inventory/reports")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class InventoryValuationController(
+    private val inventoryValuationService: InventoryValuationService,
+    private val authContext: AuthenticationContext,
+) {
+    @GetMapping("/valuation")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun valuation(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(inventoryValuationService.valuation(orgId))
+    }
+}

--- a/src/main/kotlin/com/froilan/synectix/dto/InventoryValuationDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InventoryValuationDtos.kt
@@ -1,0 +1,17 @@
+package com.froilan.synectix.dto
+
+import com.froilan.synectix.model.InventoryCostingMethod
+import java.math.BigDecimal
+
+data class ValuationLineResponse(
+    val productId: String,
+    val warehouseId: String,
+    val quantity: BigDecimal,
+    val totalValue: BigDecimal,
+)
+
+data class ValuationReportResponse(
+    val costingMethod: InventoryCostingMethod,
+    val lines: List<ValuationLineResponse>,
+    val totalValue: BigDecimal,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/InventoryCostLayer.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/InventoryCostLayer.kt
@@ -1,0 +1,32 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.index.CompoundIndexes
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "inventory_cost_layers")
+@CompoundIndexes(
+    CompoundIndex(
+        name = "layers_org_product_warehouse_occurred",
+        def = "{'organizationId': 1, 'productId': 1, 'warehouseId': 1, 'occurredAt': 1}",
+    ),
+)
+data class InventoryCostLayer(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val organizationId: String,
+    val productId: String,
+    val warehouseId: String,
+    val originalQuantity: BigDecimal,
+    val remainingQuantity: BigDecimal,
+    val unitCost: BigDecimal,
+    val sourceMovementId: String,
+    val occurredAt: LocalDateTime,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/InventoryWaSnapshot.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/InventoryWaSnapshot.kt
@@ -1,0 +1,27 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "inventory_wa_snapshots")
+@CompoundIndex(
+    name = "wa_unique_org_product_warehouse",
+    def = "{'organizationId': 1, 'productId': 1, 'warehouseId': 1}",
+    unique = true,
+)
+data class InventoryWaSnapshot(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val organizationId: String,
+    val productId: String,
+    val warehouseId: String,
+    val quantity: BigDecimal,
+    val totalCost: BigDecimal,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/Organizations.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/Organizations.kt
@@ -22,6 +22,12 @@ data class Organizations(
     val fiscalYearStart: LocalDateTime,
     val timezone: String,
     val status: String = "ACTIVE",
+    val inventoryCostingMethod: InventoryCostingMethod = InventoryCostingMethod.WEIGHTED_AVERAGE,
     val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
     val isActive: Boolean = true,
 )
+
+enum class InventoryCostingMethod {
+    FIFO,
+    WEIGHTED_AVERAGE,
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/InventoryCostLayerRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InventoryCostLayerRepository.kt
@@ -1,0 +1,16 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.InventoryCostLayer
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface InventoryCostLayerRepository : MongoRepository<InventoryCostLayer, String> {
+    fun findByOrganizationIdAndProductIdAndWarehouseIdOrderByOccurredAtAsc(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): List<InventoryCostLayer>
+
+    fun findByOrganizationId(organizationId: String): List<InventoryCostLayer>
+}

--- a/src/main/kotlin/com/froilan/synectix/repository/InventoryWaSnapshotRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InventoryWaSnapshotRepository.kt
@@ -1,0 +1,17 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.InventoryWaSnapshot
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface InventoryWaSnapshotRepository : MongoRepository<InventoryWaSnapshot, String> {
+    fun findByOrganizationIdAndProductIdAndWarehouseId(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): Optional<InventoryWaSnapshot>
+
+    fun findByOrganizationId(organizationId: String): List<InventoryWaSnapshot>
+}

--- a/src/main/kotlin/com/froilan/synectix/service/InventoryCostingService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InventoryCostingService.kt
@@ -1,0 +1,254 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.InventoryCostLayer
+import com.froilan.synectix.model.InventoryCostingMethod
+import com.froilan.synectix.model.InventoryWaSnapshot
+import com.froilan.synectix.model.StockMovement
+import com.froilan.synectix.model.StockMovementType
+import com.froilan.synectix.repository.InventoryCostLayerRepository
+import com.froilan.synectix.repository.InventoryWaSnapshotRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@Service
+class InventoryCostingService(
+    private val layerRepository: InventoryCostLayerRepository,
+    private val waSnapshotRepository: InventoryWaSnapshotRepository,
+    private val organizationRepository: OrganizationRepository,
+) {
+    @Transactional
+    fun apply(movement: StockMovement) {
+        when (costingMethodFor(movement.organizationId)) {
+            InventoryCostingMethod.FIFO -> applyFifo(movement)
+            InventoryCostingMethod.WEIGHTED_AVERAGE -> applyWeightedAverage(movement)
+        }
+    }
+
+    fun valuationCost(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): BigDecimal =
+        when (costingMethodFor(organizationId)) {
+            InventoryCostingMethod.FIFO ->
+                layerRepository
+                    .findByOrganizationIdAndProductIdAndWarehouseIdOrderByOccurredAtAsc(
+                        organizationId,
+                        productId,
+                        warehouseId,
+                    ).fold(BigDecimal.ZERO) { acc, layer -> acc + layer.remainingQuantity.multiply(layer.unitCost) }
+            InventoryCostingMethod.WEIGHTED_AVERAGE ->
+                waSnapshotRepository
+                    .findByOrganizationIdAndProductIdAndWarehouseId(organizationId, productId, warehouseId)
+                    .map { it.totalCost }
+                    .orElse(BigDecimal.ZERO)
+        }
+
+    fun costingMethodFor(organizationId: String): InventoryCostingMethod =
+        organizationRepository
+            .findById(organizationId)
+            .orElseThrow { ResourceNotFoundException("Organization not found") }
+            .inventoryCostingMethod
+
+    private fun applyFifo(movement: StockMovement) {
+        val q = movement.quantity
+        when (movement.type) {
+            StockMovementType.RECEIPT,
+            StockMovementType.OPENING_BALANCE,
+            -> addLayer(movement, q, movement.unitCost ?: BigDecimal.ZERO)
+            StockMovementType.ISSUE -> consumeFifo(movement, movement.warehouseId, q)
+            StockMovementType.ADJUSTMENT ->
+                if (q.signum() > 0) {
+                    addLayer(movement, q, movement.unitCost ?: currentAverageOrZero(movement))
+                } else {
+                    consumeFifo(movement, movement.warehouseId, q.abs())
+                }
+            StockMovementType.TRANSFER -> {
+                val consumed = consumeFifo(movement, movement.warehouseId, q)
+                if (movement.transferToWarehouseId != null) {
+                    val avgCost =
+                        if (consumed.signum() > 0 && q.signum() > 0) {
+                            consumed.divide(q, 6, RoundingMode.HALF_UP)
+                        } else {
+                            BigDecimal.ZERO
+                        }
+                    layerRepository.save(
+                        InventoryCostLayer(
+                            organizationId = movement.organizationId,
+                            productId = movement.productId,
+                            warehouseId = movement.transferToWarehouseId,
+                            originalQuantity = q,
+                            remainingQuantity = q,
+                            unitCost = avgCost,
+                            sourceMovementId = movement.id,
+                            occurredAt = movement.occurredAt,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun addLayer(
+        movement: StockMovement,
+        quantity: BigDecimal,
+        unitCost: BigDecimal,
+    ) {
+        layerRepository.save(
+            InventoryCostLayer(
+                organizationId = movement.organizationId,
+                productId = movement.productId,
+                warehouseId = movement.warehouseId,
+                originalQuantity = quantity,
+                remainingQuantity = quantity,
+                unitCost = unitCost,
+                sourceMovementId = movement.id,
+                occurredAt = movement.occurredAt,
+            ),
+        )
+    }
+
+    private fun consumeFifo(
+        movement: StockMovement,
+        warehouseId: String,
+        quantity: BigDecimal,
+    ): BigDecimal {
+        var remaining = quantity
+        var totalCost = BigDecimal.ZERO
+        val layers =
+            layerRepository.findByOrganizationIdAndProductIdAndWarehouseIdOrderByOccurredAtAsc(
+                movement.organizationId,
+                movement.productId,
+                warehouseId,
+            )
+        for (layer in layers) {
+            if (remaining.signum() == 0) break
+            if (layer.remainingQuantity.signum() == 0) continue
+            val take = layer.remainingQuantity.min(remaining)
+            totalCost += take.multiply(layer.unitCost)
+            remaining -= take
+            layerRepository.save(layer.copy(remainingQuantity = layer.remainingQuantity - take))
+        }
+        if (remaining.signum() > 0) {
+            // Negative-stock policy is enforced upstream in StockMovementService.
+            // Reaching here means allowNegativeStock=true; emit a zero-cost layer so qty stays
+            // accurate but value isn't inflated.
+            return totalCost
+        }
+        return totalCost
+    }
+
+    private fun currentAverageOrZero(movement: StockMovement): BigDecimal {
+        val layers =
+            layerRepository.findByOrganizationIdAndProductIdAndWarehouseIdOrderByOccurredAtAsc(
+                movement.organizationId,
+                movement.productId,
+                movement.warehouseId,
+            )
+        val totalQty = layers.fold(BigDecimal.ZERO) { acc, l -> acc + l.remainingQuantity }
+        if (totalQty.signum() <= 0) return BigDecimal.ZERO
+        val totalCost = layers.fold(BigDecimal.ZERO) { acc, l -> acc + l.remainingQuantity.multiply(l.unitCost) }
+        return totalCost.divide(totalQty, 6, RoundingMode.HALF_UP)
+    }
+
+    private fun applyWeightedAverage(movement: StockMovement) {
+        val q = movement.quantity
+        when (movement.type) {
+            StockMovementType.RECEIPT,
+            StockMovementType.OPENING_BALANCE,
+            -> addToWa(movement, movement.warehouseId, q, movement.unitCost ?: BigDecimal.ZERO)
+            StockMovementType.ISSUE -> consumeWa(movement, movement.warehouseId, q)
+            StockMovementType.ADJUSTMENT ->
+                if (q.signum() > 0) {
+                    addToWa(movement, movement.warehouseId, q, movement.unitCost ?: avgWa(movement, movement.warehouseId))
+                } else {
+                    consumeWa(movement, movement.warehouseId, q.abs())
+                }
+            StockMovementType.TRANSFER -> {
+                val consumedCost = consumeWa(movement, movement.warehouseId, q)
+                if (movement.transferToWarehouseId != null) {
+                    val unitCost =
+                        if (q.signum() > 0) consumedCost.divide(q, 6, RoundingMode.HALF_UP) else BigDecimal.ZERO
+                    addToWa(movement, movement.transferToWarehouseId, q, unitCost)
+                }
+            }
+        }
+    }
+
+    private fun addToWa(
+        movement: StockMovement,
+        warehouseId: String,
+        quantity: BigDecimal,
+        unitCost: BigDecimal,
+    ) {
+        val existing =
+            waSnapshotRepository.findByOrganizationIdAndProductIdAndWarehouseId(
+                movement.organizationId,
+                movement.productId,
+                warehouseId,
+            )
+        val newQty = existing.map { it.quantity }.orElse(BigDecimal.ZERO) + quantity
+        val newTotal = existing.map { it.totalCost }.orElse(BigDecimal.ZERO) + quantity.multiply(unitCost)
+        val snapshot =
+            existing
+                .map { it.copy(quantity = newQty, totalCost = newTotal) }
+                .orElseGet {
+                    InventoryWaSnapshot(
+                        organizationId = movement.organizationId,
+                        productId = movement.productId,
+                        warehouseId = warehouseId,
+                        quantity = newQty,
+                        totalCost = newTotal,
+                    )
+                }
+        waSnapshotRepository.save(snapshot)
+    }
+
+    private fun consumeWa(
+        movement: StockMovement,
+        warehouseId: String,
+        quantity: BigDecimal,
+    ): BigDecimal {
+        val existing =
+            waSnapshotRepository
+                .findByOrganizationIdAndProductIdAndWarehouseId(
+                    movement.organizationId,
+                    movement.productId,
+                    warehouseId,
+                ).orElse(null) ?: return BigDecimal.ZERO
+        val avgCost =
+            if (existing.quantity.signum() > 0) {
+                existing.totalCost.divide(existing.quantity, 6, RoundingMode.HALF_UP)
+            } else {
+                BigDecimal.ZERO
+            }
+        val consumedCost = quantity.multiply(avgCost)
+        val newQty = existing.quantity - quantity
+        val newTotal = (existing.totalCost - consumedCost).max(BigDecimal.ZERO)
+        waSnapshotRepository.save(existing.copy(quantity = newQty, totalCost = newTotal))
+        return consumedCost
+    }
+
+    private fun avgWa(
+        movement: StockMovement,
+        warehouseId: String,
+    ): BigDecimal {
+        val existing =
+            waSnapshotRepository
+                .findByOrganizationIdAndProductIdAndWarehouseId(
+                    movement.organizationId,
+                    movement.productId,
+                    warehouseId,
+                ).orElse(null) ?: return BigDecimal.ZERO
+        if (existing.quantity.signum() <= 0) return BigDecimal.ZERO
+        return existing.totalCost.divide(existing.quantity, 6, RoundingMode.HALF_UP)
+    }
+
+    @Suppress("unused")
+    private fun unreachable(): Nothing = throw BusinessRuleException("unreachable")
+}

--- a/src/main/kotlin/com/froilan/synectix/service/InventoryValuationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InventoryValuationService.kt
@@ -1,0 +1,40 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.ValuationLineResponse
+import com.froilan.synectix.dto.ValuationReportResponse
+import com.froilan.synectix.repository.OnHandKey
+import com.froilan.synectix.repository.StockMovementRepository
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+
+@Service
+class InventoryValuationService(
+    private val stockMovementRepository: StockMovementRepository,
+    private val inventoryCostingService: InventoryCostingService,
+) {
+    fun valuation(organizationId: String): ValuationReportResponse {
+        val method = inventoryCostingService.costingMethodFor(organizationId)
+        val onHand = stockMovementRepository.onHandByProductWarehouse(organizationId)
+        val lines =
+            onHand
+                .filter { it.value.signum() != 0 }
+                .map { (key, qty) ->
+                    val value = inventoryCostingService.valuationCost(organizationId, key.productId, key.warehouseId)
+                    ValuationLineResponse(
+                        productId = key.productId,
+                        warehouseId = key.warehouseId,
+                        quantity = qty,
+                        totalValue = value,
+                    )
+                }.sortedWith(compareBy({ it.productId }, { it.warehouseId }))
+        val total = lines.fold(BigDecimal.ZERO) { acc, l -> acc + l.totalValue }
+        return ValuationReportResponse(
+            costingMethod = method,
+            lines = lines,
+            totalValue = total,
+        )
+    }
+
+    @Suppress("unused")
+    private fun unusedKey(): OnHandKey = OnHandKey("", "")
+}

--- a/src/main/kotlin/com/froilan/synectix/service/StockMovementService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/StockMovementService.kt
@@ -19,6 +19,7 @@ class StockMovementService(
     private val stockMovementRepository: StockMovementRepository,
     private val warehouseRepository: WarehouseRepository,
     private val stockOnHandRepository: StockOnHandRepository,
+    private val inventoryCostingService: InventoryCostingService,
 ) {
     @Transactional
     fun createMovement(
@@ -54,7 +55,9 @@ class StockMovementService(
                 occurredAt = request.occurredAt ?: LocalDateTime.now(),
                 createdBy = userId,
             )
-        return stockMovementRepository.save(movement)
+        val saved = stockMovementRepository.save(movement)
+        inventoryCostingService.apply(saved)
+        return saved
     }
 
     fun listMovements(

--- a/src/test/kotlin/com/froilan/synectix/controller/InventoryValuationControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InventoryValuationControllerTest.kt
@@ -1,0 +1,145 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.dto.ValuationLineResponse
+import com.froilan.synectix.dto.ValuationReportResponse
+import com.froilan.synectix.model.InventoryCostingMethod
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.InventoryValuationService
+import com.froilan.synectix.service.JournalEntryService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+
+@WebMvcTest(controllers = [InventoryValuationController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class InventoryValuationControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
+
+    @MockitoBean
+    private lateinit var inventoryValuationService: InventoryValuationService
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("inventory:read")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    @Test
+    fun `GET valuation should return 200 with report`() {
+        `when`(inventoryValuationService.valuation(any())).thenReturn(
+            ValuationReportResponse(
+                costingMethod = InventoryCostingMethod.WEIGHTED_AVERAGE,
+                lines = listOf(ValuationLineResponse("p-1", "wh-1", BigDecimal("10"), BigDecimal("50"))),
+                totalValue = BigDecimal("50"),
+            ),
+        )
+
+        mockMvc
+            .perform(get("/inventory/reports/valuation"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.costingMethod").value("WEIGHTED_AVERAGE"))
+            .andExpect(jsonPath("$.totalValue").value(50))
+            .andExpect(jsonPath("$.lines.length()").value(1))
+    }
+
+    @Test
+    fun `GET valuation requires inventory read`() {
+        setupAuthWithPermissions("inventory:write")
+
+        mockMvc
+            .perform(get("/inventory/reports/valuation"))
+            .andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/InventoryCostingServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InventoryCostingServiceTest.kt
@@ -1,0 +1,259 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.InventoryCostLayer
+import com.froilan.synectix.model.InventoryCostingMethod
+import com.froilan.synectix.model.InventoryWaSnapshot
+import com.froilan.synectix.model.Organizations
+import com.froilan.synectix.model.StockMovement
+import com.froilan.synectix.model.StockMovementType
+import com.froilan.synectix.repository.InventoryCostLayerRepository
+import com.froilan.synectix.repository.InventoryWaSnapshotRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+
+class InventoryCostingServiceTest {
+    private lateinit var service: InventoryCostingService
+    private lateinit var layerRepository: InventoryCostLayerRepository
+    private lateinit var waRepository: InventoryWaSnapshotRepository
+    private lateinit var organizationRepository: OrganizationRepository
+
+    private val orgId = "org-123"
+    private val productId = "prod-1"
+    private val warehouseId = "wh-1"
+    private val otherWarehouseId = "wh-2"
+
+    @BeforeEach
+    fun setup() {
+        layerRepository = mock(InventoryCostLayerRepository::class.java)
+        waRepository = mock(InventoryWaSnapshotRepository::class.java)
+        organizationRepository = mock(OrganizationRepository::class.java)
+        service = InventoryCostingService(layerRepository, waRepository, organizationRepository)
+    }
+
+    private fun mockOrg(method: InventoryCostingMethod) {
+        `when`(organizationRepository.findById(orgId)).thenReturn(
+            Optional.of(
+                Organizations(
+                    uuid = orgId,
+                    orgSlug = "org",
+                    name = "Org",
+                    legalName = "Org LLC",
+                    tradeName = "Org",
+                    fiscalYearStart = LocalDateTime.now(),
+                    timezone = "UTC",
+                    inventoryCostingMethod = method,
+                ),
+            ),
+        )
+    }
+
+    private fun movement(
+        type: StockMovementType,
+        quantity: BigDecimal,
+        unitCost: BigDecimal? = null,
+        warehouse: String = warehouseId,
+        transferTo: String? = null,
+        id: String = "mov-1",
+        occurredAt: LocalDateTime = LocalDateTime.now(),
+    ) = StockMovement(
+        id = id,
+        organizationId = orgId,
+        type = type,
+        productId = productId,
+        warehouseId = warehouse,
+        transferToWarehouseId = transferTo,
+        quantity = quantity,
+        unitCost = unitCost,
+        occurredAt = occurredAt,
+        createdBy = "user-1",
+    )
+
+    // ─── FIFO ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `FIFO RECEIPT adds a new cost layer`() {
+        mockOrg(InventoryCostingMethod.FIFO)
+        `when`(layerRepository.save(any<InventoryCostLayer>())).thenAnswer { it.arguments[0] }
+        service.apply(movement(StockMovementType.RECEIPT, BigDecimal("10"), BigDecimal("5")))
+
+        // Now mock that the new layer exists, and valuation reads it back
+        `when`(
+            layerRepository.findByOrganizationIdAndProductIdAndWarehouseIdOrderByOccurredAtAsc(
+                orgId,
+                productId,
+                warehouseId,
+            ),
+        ).thenReturn(
+            listOf(makeLayer(BigDecimal("10"), BigDecimal("10"), BigDecimal("5"))),
+        )
+        assertThat(service.valuationCost(orgId, productId, warehouseId)).isEqualByComparingTo("50")
+    }
+
+    @Test
+    fun `FIFO ISSUE consumes oldest layers first`() {
+        mockOrg(InventoryCostingMethod.FIFO)
+        val older = makeLayer(BigDecimal("4"), BigDecimal("4"), BigDecimal("2"), id = "l1", occurredOffsetSec = -1000)
+        val newer = makeLayer(BigDecimal("6"), BigDecimal("6"), BigDecimal("3"), id = "l2", occurredOffsetSec = 0)
+        `when`(
+            layerRepository.findByOrganizationIdAndProductIdAndWarehouseIdOrderByOccurredAtAsc(
+                orgId,
+                productId,
+                warehouseId,
+            ),
+        ).thenReturn(listOf(older, newer))
+        `when`(layerRepository.save(any<InventoryCostLayer>())).thenAnswer { it.arguments[0] }
+
+        service.apply(movement(StockMovementType.ISSUE, BigDecimal("5")))
+
+        val captor = org.mockito.ArgumentCaptor.forClass(InventoryCostLayer::class.java)
+        org.mockito.Mockito
+            .verify(layerRepository, org.mockito.Mockito.atLeast(2))
+            .save(captor.capture())
+        val saved = captor.allValues
+        assertThat(saved.first { it.id == "l1" }.remainingQuantity).isEqualByComparingTo("0")
+        assertThat(saved.first { it.id == "l2" }.remainingQuantity).isEqualByComparingTo("5")
+    }
+
+    @Test
+    fun `FIFO TRANSFER consumes source layers and creates destination layer at weighted cost`() {
+        mockOrg(InventoryCostingMethod.FIFO)
+        val layer = makeLayer(BigDecimal("10"), BigDecimal("10"), BigDecimal("4"))
+        `when`(
+            layerRepository.findByOrganizationIdAndProductIdAndWarehouseIdOrderByOccurredAtAsc(
+                orgId,
+                productId,
+                warehouseId,
+            ),
+        ).thenReturn(listOf(layer))
+        `when`(layerRepository.save(any<InventoryCostLayer>())).thenAnswer { it.arguments[0] }
+
+        service.apply(movement(StockMovementType.TRANSFER, BigDecimal("3"), transferTo = otherWarehouseId))
+
+        val captor = org.mockito.ArgumentCaptor.forClass(InventoryCostLayer::class.java)
+        org.mockito.Mockito
+            .verify(layerRepository, org.mockito.Mockito.atLeast(2))
+            .save(captor.capture())
+        val destLayer = captor.allValues.first { it.warehouseId == otherWarehouseId }
+        assertThat(destLayer.unitCost).isEqualByComparingTo("4")
+        assertThat(destLayer.originalQuantity).isEqualByComparingTo("3")
+    }
+
+    // ─── Weighted Average ─────────────────────────────────────────────────
+
+    @Test
+    fun `WA RECEIPT updates snapshot quantity and total cost`() {
+        mockOrg(InventoryCostingMethod.WEIGHTED_AVERAGE)
+        `when`(
+            waRepository.findByOrganizationIdAndProductIdAndWarehouseId(orgId, productId, warehouseId),
+        ).thenReturn(Optional.empty())
+        `when`(waRepository.save(any<InventoryWaSnapshot>())).thenAnswer { it.arguments[0] }
+
+        service.apply(movement(StockMovementType.RECEIPT, BigDecimal("10"), BigDecimal("5")))
+
+        val captor = org.mockito.ArgumentCaptor.forClass(InventoryWaSnapshot::class.java)
+        org.mockito.Mockito
+            .verify(waRepository)
+            .save(captor.capture())
+        assertThat(captor.value.quantity).isEqualByComparingTo("10")
+        assertThat(captor.value.totalCost).isEqualByComparingTo("50")
+    }
+
+    @Test
+    fun `WA second RECEIPT blends avg cost across batches`() {
+        mockOrg(InventoryCostingMethod.WEIGHTED_AVERAGE)
+        val existing =
+            InventoryWaSnapshot(
+                organizationId = orgId,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("10"),
+                totalCost = BigDecimal("50"),
+            )
+        `when`(
+            waRepository.findByOrganizationIdAndProductIdAndWarehouseId(orgId, productId, warehouseId),
+        ).thenReturn(Optional.of(existing))
+        `when`(waRepository.save(any<InventoryWaSnapshot>())).thenAnswer { it.arguments[0] }
+
+        // Add 10 units at 7 → total 20 units, total cost 50 + 70 = 120, avg = 6
+        service.apply(movement(StockMovementType.RECEIPT, BigDecimal("10"), BigDecimal("7")))
+
+        val captor = org.mockito.ArgumentCaptor.forClass(InventoryWaSnapshot::class.java)
+        org.mockito.Mockito
+            .verify(waRepository)
+            .save(captor.capture())
+        assertThat(captor.value.quantity).isEqualByComparingTo("20")
+        assertThat(captor.value.totalCost).isEqualByComparingTo("120")
+    }
+
+    @Test
+    fun `WA ISSUE consumes at current avg cost`() {
+        mockOrg(InventoryCostingMethod.WEIGHTED_AVERAGE)
+        val existing =
+            InventoryWaSnapshot(
+                organizationId = orgId,
+                productId = productId,
+                warehouseId = warehouseId,
+                quantity = BigDecimal("20"),
+                totalCost = BigDecimal("120"),
+            )
+        `when`(
+            waRepository.findByOrganizationIdAndProductIdAndWarehouseId(orgId, productId, warehouseId),
+        ).thenReturn(Optional.of(existing))
+        `when`(waRepository.save(any<InventoryWaSnapshot>())).thenAnswer { it.arguments[0] }
+
+        // Issue 5 units; avg = 6; consumed cost = 30; new qty 15, new total 90
+        service.apply(movement(StockMovementType.ISSUE, BigDecimal("5")))
+
+        val captor = org.mockito.ArgumentCaptor.forClass(InventoryWaSnapshot::class.java)
+        org.mockito.Mockito
+            .verify(waRepository)
+            .save(captor.capture())
+        assertThat(captor.value.quantity).isEqualByComparingTo("15")
+        assertThat(captor.value.totalCost).isEqualByComparingTo("90")
+    }
+
+    @Test
+    fun `WA valuation returns snapshot totalCost`() {
+        mockOrg(InventoryCostingMethod.WEIGHTED_AVERAGE)
+        `when`(
+            waRepository.findByOrganizationIdAndProductIdAndWarehouseId(orgId, productId, warehouseId),
+        ).thenReturn(
+            Optional.of(
+                InventoryWaSnapshot(
+                    organizationId = orgId,
+                    productId = productId,
+                    warehouseId = warehouseId,
+                    quantity = BigDecimal("15"),
+                    totalCost = BigDecimal("90"),
+                ),
+            ),
+        )
+        assertThat(service.valuationCost(orgId, productId, warehouseId)).isEqualByComparingTo("90")
+    }
+
+    private fun makeLayer(
+        original: BigDecimal,
+        remaining: BigDecimal,
+        unitCost: BigDecimal,
+        id: String = "layer-1",
+        occurredOffsetSec: Long = 0,
+    ) = InventoryCostLayer(
+        id = id,
+        organizationId = orgId,
+        productId = productId,
+        warehouseId = warehouseId,
+        originalQuantity = original,
+        remainingQuantity = remaining,
+        unitCost = unitCost,
+        sourceMovementId = "mov-x",
+        occurredAt = LocalDateTime.now().plusSeconds(occurredOffsetSec),
+    )
+}

--- a/src/test/kotlin/com/froilan/synectix/service/InventoryValuationServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InventoryValuationServiceTest.kt
@@ -1,0 +1,74 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.model.InventoryCostingMethod
+import com.froilan.synectix.repository.OnHandKey
+import com.froilan.synectix.repository.StockMovementRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.math.BigDecimal
+
+class InventoryValuationServiceTest {
+    private lateinit var service: InventoryValuationService
+    private lateinit var stockMovementRepository: StockMovementRepository
+    private lateinit var costingService: InventoryCostingService
+
+    private val orgId = "org-123"
+
+    @BeforeEach
+    fun setup() {
+        stockMovementRepository = mock(StockMovementRepository::class.java)
+        costingService = mock(InventoryCostingService::class.java)
+        service = InventoryValuationService(stockMovementRepository, costingService)
+    }
+
+    @Test
+    fun `valuation aggregates per-pair quantities and costs`() {
+        `when`(costingService.costingMethodFor(orgId)).thenReturn(InventoryCostingMethod.WEIGHTED_AVERAGE)
+        `when`(stockMovementRepository.onHandByProductWarehouse(orgId)).thenReturn(
+            mapOf(
+                OnHandKey("p-1", "wh-1") to BigDecimal("10"),
+                OnHandKey("p-2", "wh-1") to BigDecimal("5"),
+            ),
+        )
+        `when`(costingService.valuationCost(orgId, "p-1", "wh-1")).thenReturn(BigDecimal("100"))
+        `when`(costingService.valuationCost(orgId, "p-2", "wh-1")).thenReturn(BigDecimal("25"))
+
+        val report = service.valuation(orgId)
+
+        assertThat(report.costingMethod).isEqualTo(InventoryCostingMethod.WEIGHTED_AVERAGE)
+        assertThat(report.lines).hasSize(2)
+        assertThat(report.totalValue).isEqualByComparingTo("125")
+    }
+
+    @Test
+    fun `valuation omits zero-quantity pairs`() {
+        `when`(costingService.costingMethodFor(orgId)).thenReturn(InventoryCostingMethod.FIFO)
+        `when`(stockMovementRepository.onHandByProductWarehouse(orgId)).thenReturn(
+            mapOf(
+                OnHandKey("p-1", "wh-1") to BigDecimal("0"),
+                OnHandKey("p-2", "wh-1") to BigDecimal("3"),
+            ),
+        )
+        `when`(costingService.valuationCost(orgId, "p-2", "wh-1")).thenReturn(BigDecimal("9"))
+
+        val report = service.valuation(orgId)
+
+        assertThat(report.lines).hasSize(1)
+        assertThat(report.lines[0].productId).isEqualTo("p-2")
+        assertThat(report.totalValue).isEqualByComparingTo("9")
+    }
+
+    @Test
+    fun `valuation returns empty report for org with no stock`() {
+        `when`(costingService.costingMethodFor(orgId)).thenReturn(InventoryCostingMethod.WEIGHTED_AVERAGE)
+        `when`(stockMovementRepository.onHandByProductWarehouse(orgId)).thenReturn(emptyMap())
+
+        val report = service.valuation(orgId)
+
+        assertThat(report.lines).isEmpty()
+        assertThat(report.totalValue).isEqualByComparingTo("0")
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/service/StockMovementServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/StockMovementServiceTest.kt
@@ -29,6 +29,7 @@ class StockMovementServiceTest {
     private lateinit var stockMovementRepository: StockMovementRepository
     private lateinit var warehouseRepository: WarehouseRepository
     private lateinit var stockOnHandRepository: StockOnHandRepository
+    private lateinit var inventoryCostingService: InventoryCostingService
 
     private val orgId = "org-123"
     private val userId = "user-123"
@@ -41,9 +42,15 @@ class StockMovementServiceTest {
         stockMovementRepository = mock(StockMovementRepository::class.java)
         warehouseRepository = mock(WarehouseRepository::class.java)
         stockOnHandRepository = mock(StockOnHandRepository::class.java)
+        inventoryCostingService = mock(InventoryCostingService::class.java)
         whenever(stockOnHandRepository.applyDelta(any(), any(), any(), any(), any())).thenReturn(true)
         stockMovementService =
-            StockMovementService(stockMovementRepository, warehouseRepository, stockOnHandRepository)
+            StockMovementService(
+                stockMovementRepository,
+                warehouseRepository,
+                stockOnHandRepository,
+                inventoryCostingService,
+            )
     }
 
     private fun mockWarehouse(


### PR DESCRIPTION
## Summary
Fourth issue of the Inventory epic (#8). Adds **costing state + valuation report**: per-pair stock value computed from movements, accessed via `GET /inventory/reports/valuation`. Both costing methods from the spec are implemented (FIFO + Weighted Average), selectable per organization.

**Phase 1 of #42.** GL auto-posting (Dr Inventory / Cr suspense; Dr COGS / Cr Inventory; Dr/Cr Adjustments) is intentionally deferred to a small follow-on PR — it requires deeper integration with `JournalEntryService` (fiscal-period validation, entry-number generation, GL account seeding) and warrants its own reviewable scope.

## What's included
- `InventoryCostingMethod` enum (`FIFO` | `WEIGHTED_AVERAGE`) added to `Organizations` (default: `WEIGHTED_AVERAGE`)
- **`InventoryCostLayer`** model + repo — FIFO state, one row per inbound movement, sorted by `occurredAt`
- **`InventoryWaSnapshot`** model + repo — WA state, one row per `(orgId, productId, warehouseId)` with running quantity + totalCost
- **`InventoryCostingService.apply(movement)`** dispatches per `Organizations.inventoryCostingMethod`:
  - FIFO: `RECEIPT`/`OPENING_BALANCE`/positive `ADJUSTMENT` → new layer; `ISSUE`/negative `ADJUSTMENT` → consume oldest layers first; `TRANSFER` → consume source FIFO, create destination layer at the consumed-weighted cost
  - WA: inbound updates snapshot quantity + totalCost; outbound consumes at current avg; `TRANSFER` moves cost from source snapshot to destination snapshot
- **`InventoryValuationService.valuation(orgId)`** — iterates per-pair on-hand (from #41's `onHandByProductWarehouse`), computes value via the costing service, returns lines + grand total
- `GET /inventory/reports/valuation` (inventory:read) → `ValuationReportResponse { costingMethod, lines[], totalValue }`
- `StockMovementService.createMovement` now calls `inventoryCostingService.apply(saved)` after persisting the movement
- 14 new tests: FIFO/WA branches in costing service, valuation aggregation, controller perms

## Out of scope (this issue, deferred to follow-on)
- **Auto-posting journal entries** on movements — needs JournalEntryService wiring + fiscal-period handling; will be PR #42.1
- **GL inventory account seeding** (1300/5100/5900) — same follow-on as above
- **`asOfDate` historical valuation** — #119 spec mentions it for the reports endpoint; can be added there or here as a follow-up using movement replay
- **Costing-method change reconciliation** — switching FIFO ↔ WA mid-stream on a populated org needs a migration job; defer until needed

## Merge direction
Targets `41-stock-movements` (PR #124). Stack:

```
staging
└── #121  38-product-item-catalog-crud
    └── #123  40-warehouses
        └── #124  41-stock-movements
            └── this PR  42-stock-valuation     ← retargets to staging after #124 merges
                ├── 119-reports                 (next)
                └── 43-reorder                  (parallel)
```

After #121/#123/#124 cascade-merge into `staging`, this PR rebases onto `staging`.

## CI note
Stacked on a feature branch; CI workflow only triggers on PRs to `production`/`staging`. Locally verified: ktlint clean + 14 new tests pass + StockMovementService tests still pass after the constructor change.

## Test plan
- [ ] FIFO org: receive 4@2, receive 6@3, issue 5 → first layer consumed (4u, $8), second partially consumed (1u, $3). Valuation = 5 × $3 = $15.
- [ ] WA org: receive 10@5, receive 10@7 → snapshot 20 units, totalCost $120, avg $6. Issue 5 → snapshot 15 units, totalCost $90.
- [ ] `GET /inventory/reports/valuation` reflects either method per Organizations.inventoryCostingMethod
- [ ] Valuation total reconciles with on-hand × cost for every pair
- [ ] VIEWER: GET works, POST/PATCH/DELETE elsewhere → 403

Part of #42 (phase 1)
