### PR TITLE
Reorder rules + low-stock report (#43)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/controller/InventoryReorderRuleController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InventoryReorderRuleController.kt
@@ -1,0 +1,88 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.annotation.LogLevel
+import com.froilan.synectix.annotation.Loggable
+import com.froilan.synectix.dto.CreateReorderRuleRequest
+import com.froilan.synectix.dto.ReorderRuleResponse
+import com.froilan.synectix.dto.UpdateReorderRuleRequest
+import com.froilan.synectix.model.InventoryReorderRule
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.InventoryReorderRuleService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/inventory/reorder-rules")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class InventoryReorderRuleController(
+    private val reorderRuleService: InventoryReorderRuleService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun createRule(
+        @Valid @RequestBody request: CreateReorderRuleRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val rule = reorderRuleService.createRule(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(rule.toResponse())
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun listRules(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(reorderRuleService.listRules(orgId).map { it.toResponse() })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun getRule(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(reorderRuleService.getRule(id, orgId).toResponse())
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun updateRule(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateReorderRuleRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(reorderRuleService.updateRule(id, request, orgId).toResponse())
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun deleteRule(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        reorderRuleService.deleteRule(id, orgId)
+        return ResponseEntity.noContent().build()
+    }
+
+    private fun InventoryReorderRule.toResponse() =
+        ReorderRuleResponse(
+            id = id,
+            productId = productId,
+            warehouseId = warehouseId,
+            reorderPoint = reorderPoint,
+            safetyStock = safetyStock,
+            organizationId = organizationId,
+            createdAt = createdAt?.toString(),
+            updatedAt = updatedAt?.toString(),
+        )
+}

--- a/src/main/kotlin/com/froilan/synectix/controller/InventoryReportsController.kt
+++ b/src/main/kotlin/com/froilan/synectix/controller/InventoryReportsController.kt
@@ -3,6 +3,7 @@ package com.froilan.synectix.controller
 import com.froilan.synectix.annotation.LogLevel
 import com.froilan.synectix.annotation.Loggable
 import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.service.InventoryReorderRuleService
 import com.froilan.synectix.service.InventoryReportsService
 import com.froilan.synectix.service.InventoryValuationService
 import org.springframework.format.annotation.DateTimeFormat
@@ -20,6 +21,7 @@ import java.time.LocalDateTime
 class InventoryReportsController(
     private val inventoryValuationService: InventoryValuationService,
     private val inventoryReportsService: InventoryReportsService,
+    private val reorderRuleService: InventoryReorderRuleService,
     private val authContext: AuthenticationContext,
 ) {
     @GetMapping("/valuation")
@@ -56,5 +58,12 @@ class InventoryReportsController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         return ResponseEntity.ok(inventoryReportsService.movementHistory(orgId, productId, warehouseId, from, to))
+    }
+
+    @GetMapping("/low-stock")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun lowStock(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(reorderRuleService.lowStockReport(orgId))
     }
 }

--- a/src/main/kotlin/com/froilan/synectix/dto/InventoryReorderDtos.kt
+++ b/src/main/kotlin/com/froilan/synectix/dto/InventoryReorderDtos.kt
@@ -1,0 +1,49 @@
+package com.froilan.synectix.dto
+
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+
+data class CreateReorderRuleRequest(
+    @field:NotBlank(message = "Product ID is required")
+    val productId: String,
+    @field:NotBlank(message = "Warehouse ID is required")
+    val warehouseId: String,
+    @field:NotNull(message = "Reorder point is required")
+    @field:DecimalMin(value = "0.0", message = "Reorder point must be zero or positive")
+    val reorderPoint: BigDecimal?,
+    @field:DecimalMin(value = "0.0", message = "Safety stock must be zero or positive")
+    val safetyStock: BigDecimal? = null,
+)
+
+data class UpdateReorderRuleRequest(
+    @field:DecimalMin(value = "0.0", message = "Reorder point must be zero or positive")
+    val reorderPoint: BigDecimal? = null,
+    @field:DecimalMin(value = "0.0", message = "Safety stock must be zero or positive")
+    val safetyStock: BigDecimal? = null,
+)
+
+data class ReorderRuleResponse(
+    val id: String,
+    val productId: String,
+    val warehouseId: String,
+    val reorderPoint: BigDecimal,
+    val safetyStock: BigDecimal,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+)
+
+data class LowStockLineResponse(
+    val productId: String,
+    val warehouseId: String,
+    val onHand: BigDecimal,
+    val reorderPoint: BigDecimal,
+    val safetyStock: BigDecimal,
+    val shortfall: BigDecimal,
+)
+
+data class LowStockReportResponse(
+    val lines: List<LowStockLineResponse>,
+)

--- a/src/main/kotlin/com/froilan/synectix/model/InventoryReorderRule.kt
+++ b/src/main/kotlin/com/froilan/synectix/model/InventoryReorderRule.kt
@@ -1,0 +1,30 @@
+package com.froilan.synectix.model
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.index.CompoundIndex
+import org.springframework.data.mongodb.core.mapping.Document
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Document(collection = "inventory_reorder_rules")
+@CompoundIndex(
+    name = "reorder_unique_org_product_warehouse",
+    def = "{'organizationId': 1, 'productId': 1, 'warehouseId': 1}",
+    unique = true,
+)
+data class InventoryReorderRule(
+    @Id
+    val id: String = UUID.randomUUID().toString(),
+    val organizationId: String,
+    val productId: String,
+    val warehouseId: String,
+    val reorderPoint: BigDecimal,
+    val safetyStock: BigDecimal = BigDecimal.ZERO,
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/froilan/synectix/repository/InventoryReorderRuleRepository.kt
+++ b/src/main/kotlin/com/froilan/synectix/repository/InventoryReorderRuleRepository.kt
@@ -1,0 +1,17 @@
+package com.froilan.synectix.repository
+
+import com.froilan.synectix.model.InventoryReorderRule
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface InventoryReorderRuleRepository : MongoRepository<InventoryReorderRule, String> {
+    fun findByOrganizationId(organizationId: String): List<InventoryReorderRule>
+
+    fun findByOrganizationIdAndProductIdAndWarehouseId(
+        organizationId: String,
+        productId: String,
+        warehouseId: String,
+    ): Optional<InventoryReorderRule>
+}

--- a/src/main/kotlin/com/froilan/synectix/service/InventoryReorderRuleService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InventoryReorderRuleService.kt
@@ -1,0 +1,114 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateReorderRuleRequest
+import com.froilan.synectix.dto.LowStockLineResponse
+import com.froilan.synectix.dto.LowStockReportResponse
+import com.froilan.synectix.dto.UpdateReorderRuleRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.InventoryReorderRule
+import com.froilan.synectix.repository.InventoryReorderRuleRepository
+import com.froilan.synectix.repository.OnHandKey
+import com.froilan.synectix.repository.StockMovementRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+class InventoryReorderRuleService(
+    private val reorderRuleRepository: InventoryReorderRuleRepository,
+    private val stockMovementRepository: StockMovementRepository,
+) {
+    @Transactional
+    fun createRule(
+        request: CreateReorderRuleRequest,
+        organizationId: String,
+    ): InventoryReorderRule {
+        val reorderPoint = request.reorderPoint ?: throw BusinessRuleException("Reorder point is required")
+        val rule =
+            InventoryReorderRule(
+                organizationId = organizationId,
+                productId = request.productId,
+                warehouseId = request.warehouseId,
+                reorderPoint = reorderPoint,
+                safetyStock = request.safetyStock ?: BigDecimal.ZERO,
+            )
+        return try {
+            reorderRuleRepository.save(rule)
+        } catch (e: DuplicateKeyException) {
+            throw BusinessRuleException(
+                "Reorder rule already exists for product '${request.productId}' " +
+                    "in warehouse '${request.warehouseId}'",
+                e,
+            )
+        }
+    }
+
+    fun listRules(organizationId: String): List<InventoryReorderRule> =
+        reorderRuleRepository.findByOrganizationId(organizationId).sortedWith(
+            compareBy({ it.productId }, { it.warehouseId }),
+        )
+
+    fun getRule(
+        ruleId: String,
+        organizationId: String,
+    ): InventoryReorderRule {
+        val rule =
+            reorderRuleRepository.findById(ruleId).orElseThrow {
+                ResourceNotFoundException("Reorder rule not found")
+            }
+        if (rule.organizationId != organizationId) {
+            throw ResourceNotFoundException("Reorder rule not found")
+        }
+        return rule
+    }
+
+    @Transactional
+    fun updateRule(
+        ruleId: String,
+        request: UpdateReorderRuleRequest,
+        organizationId: String,
+    ): InventoryReorderRule {
+        val existing = getRule(ruleId, organizationId)
+        val updated =
+            existing.copy(
+                reorderPoint = request.reorderPoint ?: existing.reorderPoint,
+                safetyStock = request.safetyStock ?: existing.safetyStock,
+            )
+        return reorderRuleRepository.save(updated)
+    }
+
+    @Transactional
+    fun deleteRule(
+        ruleId: String,
+        organizationId: String,
+    ) {
+        val existing = getRule(ruleId, organizationId)
+        reorderRuleRepository.delete(existing)
+    }
+
+    fun lowStockReport(organizationId: String): LowStockReportResponse {
+        val rules = reorderRuleRepository.findByOrganizationId(organizationId)
+        val onHand: Map<OnHandKey, BigDecimal> =
+            stockMovementRepository.onHandByProductWarehouse(organizationId)
+        val lines =
+            rules
+                .mapNotNull { rule ->
+                    val qty = onHand[OnHandKey(rule.productId, rule.warehouseId)] ?: BigDecimal.ZERO
+                    if (qty < rule.reorderPoint) {
+                        LowStockLineResponse(
+                            productId = rule.productId,
+                            warehouseId = rule.warehouseId,
+                            onHand = qty,
+                            reorderPoint = rule.reorderPoint,
+                            safetyStock = rule.safetyStock,
+                            shortfall = rule.reorderPoint - qty,
+                        )
+                    } else {
+                        null
+                    }
+                }.sortedWith(compareBy({ it.productId }, { it.warehouseId }))
+        return LowStockReportResponse(lines = lines)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/InventoryReorderRuleControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InventoryReorderRuleControllerTest.kt
@@ -1,0 +1,196 @@
+package com.froilan.synectix.controller
+
+import com.froilan.synectix.aspect.LoggingAspect
+import com.froilan.synectix.config.TestSecurityConfig
+import com.froilan.synectix.model.InventoryReorderRule
+import com.froilan.synectix.model.RoleAssignment
+import com.froilan.synectix.model.User
+import com.froilan.synectix.repository.InvitationRepository
+import com.froilan.synectix.repository.OrganizationRepository
+import com.froilan.synectix.repository.PasswordResetTokenRepository
+import com.froilan.synectix.repository.RefreshTokenRepository
+import com.froilan.synectix.repository.SessionTokenRepository
+import com.froilan.synectix.repository.UserRepository
+import com.froilan.synectix.security.AuthenticationContext
+import com.froilan.synectix.security.RolePermissionCache
+import com.froilan.synectix.security.SessionContext
+import com.froilan.synectix.security.SynectixPermissionEvaluator
+import com.froilan.synectix.service.AccountService
+import com.froilan.synectix.service.ApiKeyService
+import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.InventoryReorderRuleService
+import com.froilan.synectix.service.JournalEntryService
+import com.froilan.synectix.util.TokenHasher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+
+@WebMvcTest(controllers = [InventoryReorderRuleController::class])
+@Import(LoggingAspect::class, TestSecurityConfig::class, SynectixPermissionEvaluator::class)
+@ActiveProfiles("test")
+class InventoryReorderRuleControllerTest {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+
+    @MockitoBean
+    private lateinit var userRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var organizationRepository: OrganizationRepository
+
+    @MockitoBean
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @MockitoBean
+    private lateinit var passwordResetTokenRepository: PasswordResetTokenRepository
+
+    @MockitoBean
+    private lateinit var invitationRepository: InvitationRepository
+
+    @MockitoBean
+    private lateinit var tokenHasher: TokenHasher
+
+    @MockitoBean
+    private lateinit var rolePermissionCache: RolePermissionCache
+
+    @MockitoBean
+    private lateinit var apiKeyService: ApiKeyService
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var journalEntryService: JournalEntryService
+
+    @MockitoBean
+    private lateinit var reorderRuleService: InventoryReorderRuleService
+
+    @MockitoBean
+    private lateinit var authenticationContext: AuthenticationContext
+
+    private val testUser =
+        User(
+            uuid = "user-123",
+            username = "testuser",
+            email = "test@example.com",
+            firstName = "Test",
+            lastName = "User",
+            passwordHash = "encoded",
+            organizationId = "org-123",
+            roleAssignments = listOf(RoleAssignment("OWNER", "org-123")),
+        )
+
+    @BeforeEach
+    fun setup() {
+        setupAuthWithPermissions("inventory:read", "inventory:write")
+        `when`(authenticationContext.organizationId()).thenReturn("org-123")
+    }
+
+    private fun setupAuthWithPermissions(vararg permissions: String) {
+        val roleAuthorities = testUser.roleAssignments.map { SimpleGrantedAuthority("ROLE_${it.role}") }
+        val permissionAuthorities = permissions.map { SimpleGrantedAuthority(it) }
+        val authentication = UsernamePasswordAuthenticationToken(testUser, null, roleAuthorities + permissionAuthorities)
+        authentication.details = SessionContext(sessionId = "session-123", organizationId = "org-123")
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    private fun mockRule() =
+        InventoryReorderRule(
+            id = "rr-1",
+            organizationId = "org-123",
+            productId = "p-1",
+            warehouseId = "wh-1",
+            reorderPoint = BigDecimal("10"),
+            safetyStock = BigDecimal("2"),
+        )
+
+    @Test
+    fun `POST reorder-rules returns 201`() {
+        `when`(reorderRuleService.createRule(any(), any())).thenReturn(mockRule())
+        mockMvc
+            .perform(
+                post("/inventory/reorder-rules")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "productId": "p-1",
+                            "warehouseId": "wh-1",
+                            "reorderPoint": "10",
+                            "safetyStock": "2"
+                        }""",
+                    ),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.productId").value("p-1"))
+    }
+
+    @Test
+    fun `POST reorder-rules returns 400 when reorderPoint missing`() {
+        mockMvc
+            .perform(
+                post("/inventory/reorder-rules")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "productId": "p-1",
+                            "warehouseId": "wh-1"
+                        }""",
+                    ),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET reorder-rules returns 200 with list`() {
+        `when`(reorderRuleService.listRules(any())).thenReturn(listOf(mockRule()))
+        mockMvc
+            .perform(get("/inventory/reorder-rules"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+    }
+
+    @Test
+    fun `DELETE reorder-rules returns 204`() {
+        mockMvc
+            .perform(delete("/inventory/reorder-rules/rr-1"))
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `POST reorder-rules requires inventory write`() {
+        setupAuthWithPermissions("inventory:read")
+        mockMvc
+            .perform(
+                post("/inventory/reorder-rules")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """{
+                            "productId": "p-1",
+                            "warehouseId": "wh-1",
+                            "reorderPoint": "10"
+                        }""",
+                    ),
+            ).andExpect(status().isForbidden)
+    }
+}

--- a/src/test/kotlin/com/froilan/synectix/controller/InventoryReportsControllerTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/controller/InventoryReportsControllerTest.kt
@@ -25,6 +25,7 @@ import com.froilan.synectix.security.SynectixPermissionEvaluator
 import com.froilan.synectix.service.AccountService
 import com.froilan.synectix.service.ApiKeyService
 import com.froilan.synectix.service.AuthService
+import com.froilan.synectix.service.InventoryReorderRuleService
 import com.froilan.synectix.service.InventoryReportsService
 import com.froilan.synectix.service.InventoryValuationService
 import com.froilan.synectix.service.JournalEntryService
@@ -97,6 +98,9 @@ class InventoryReportsControllerTest {
 
     @MockitoBean
     private lateinit var inventoryReportsService: InventoryReportsService
+
+    @MockitoBean
+    private lateinit var reorderRuleService: InventoryReorderRuleService
 
     @MockitoBean
     private lateinit var authenticationContext: AuthenticationContext

--- a/src/test/kotlin/com/froilan/synectix/service/InventoryReorderRuleServiceTest.kt
+++ b/src/test/kotlin/com/froilan/synectix/service/InventoryReorderRuleServiceTest.kt
@@ -1,0 +1,161 @@
+package com.froilan.synectix.service
+
+import com.froilan.synectix.dto.CreateReorderRuleRequest
+import com.froilan.synectix.dto.UpdateReorderRuleRequest
+import com.froilan.synectix.exception.BusinessRuleException
+import com.froilan.synectix.exception.ResourceNotFoundException
+import com.froilan.synectix.model.InventoryReorderRule
+import com.froilan.synectix.repository.InventoryReorderRuleRepository
+import com.froilan.synectix.repository.OnHandKey
+import com.froilan.synectix.repository.StockMovementRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.dao.DuplicateKeyException
+import java.math.BigDecimal
+import java.util.Optional
+
+class InventoryReorderRuleServiceTest {
+    private lateinit var service: InventoryReorderRuleService
+    private lateinit var reorderRuleRepository: InventoryReorderRuleRepository
+    private lateinit var stockMovementRepository: StockMovementRepository
+
+    private val orgId = "org-123"
+    private val otherOrgId = "org-456"
+
+    @BeforeEach
+    fun setup() {
+        reorderRuleRepository = mock(InventoryReorderRuleRepository::class.java)
+        stockMovementRepository = mock(StockMovementRepository::class.java)
+        service = InventoryReorderRuleService(reorderRuleRepository, stockMovementRepository)
+    }
+
+    private fun rule(
+        id: String = "rr-1",
+        productId: String = "p-1",
+        warehouseId: String = "wh-1",
+        reorderPoint: BigDecimal = BigDecimal("10"),
+        safetyStock: BigDecimal = BigDecimal("2"),
+        organizationId: String = orgId,
+    ) = InventoryReorderRule(
+        id = id,
+        organizationId = organizationId,
+        productId = productId,
+        warehouseId = warehouseId,
+        reorderPoint = reorderPoint,
+        safetyStock = safetyStock,
+    )
+
+    @Test
+    fun `createRule saves rule with provided fields`() {
+        `when`(reorderRuleRepository.save(any<InventoryReorderRule>())).thenAnswer { it.arguments[0] }
+        val request =
+            CreateReorderRuleRequest(
+                productId = "p-1",
+                warehouseId = "wh-1",
+                reorderPoint = BigDecimal("10"),
+                safetyStock = BigDecimal("2"),
+            )
+        val result = service.createRule(request, orgId)
+        assertThat(result.productId).isEqualTo("p-1")
+        assertThat(result.reorderPoint).isEqualByComparingTo("10")
+        assertThat(result.safetyStock).isEqualByComparingTo("2")
+        assertThat(result.organizationId).isEqualTo(orgId)
+    }
+
+    @Test
+    fun `createRule defaults safetyStock to zero when omitted`() {
+        `when`(reorderRuleRepository.save(any<InventoryReorderRule>())).thenAnswer { it.arguments[0] }
+        val request =
+            CreateReorderRuleRequest(
+                productId = "p-1",
+                warehouseId = "wh-1",
+                reorderPoint = BigDecimal("10"),
+                safetyStock = null,
+            )
+        val result = service.createRule(request, orgId)
+        assertThat(result.safetyStock).isEqualByComparingTo("0")
+    }
+
+    @Test
+    fun `createRule throws on duplicate (orgId, productId, warehouseId)`() {
+        `when`(reorderRuleRepository.save(any<InventoryReorderRule>()))
+            .thenThrow(DuplicateKeyException("dup"))
+        val request =
+            CreateReorderRuleRequest(
+                productId = "p-1",
+                warehouseId = "wh-1",
+                reorderPoint = BigDecimal("10"),
+            )
+        val ex =
+            assertThrows<BusinessRuleException> {
+                service.createRule(request, orgId)
+            }
+        assertThat(ex.message).contains("already exists")
+    }
+
+    @Test
+    fun `getRule enforces cross-org isolation`() {
+        `when`(reorderRuleRepository.findById("rr-1")).thenReturn(Optional.of(rule(organizationId = otherOrgId)))
+        assertThrows<ResourceNotFoundException> { service.getRule("rr-1", orgId) }
+    }
+
+    @Test
+    fun `updateRule applies partial changes`() {
+        val existing = rule()
+        val updated = existing.copy(reorderPoint = BigDecimal("20"))
+        `when`(reorderRuleRepository.findById("rr-1")).thenReturn(Optional.of(existing))
+        `when`(reorderRuleRepository.save(any<InventoryReorderRule>())).thenReturn(updated)
+        val result =
+            service.updateRule("rr-1", UpdateReorderRuleRequest(reorderPoint = BigDecimal("20")), orgId)
+        assertThat(result.reorderPoint).isEqualByComparingTo("20")
+    }
+
+    @Test
+    fun `deleteRule removes rule when org matches`() {
+        val existing = rule()
+        `when`(reorderRuleRepository.findById("rr-1")).thenReturn(Optional.of(existing))
+        service.deleteRule("rr-1", orgId)
+        org.mockito.Mockito
+            .verify(reorderRuleRepository)
+            .delete(existing)
+    }
+
+    @Test
+    fun `lowStockReport returns only pairs below reorder point`() {
+        `when`(reorderRuleRepository.findByOrganizationId(orgId)).thenReturn(
+            listOf(
+                rule(id = "rr-1", productId = "p-1", warehouseId = "wh-1", reorderPoint = BigDecimal("10")),
+                rule(id = "rr-2", productId = "p-2", warehouseId = "wh-1", reorderPoint = BigDecimal("5")),
+                rule(id = "rr-3", productId = "p-3", warehouseId = "wh-1", reorderPoint = BigDecimal("3")),
+            ),
+        )
+        `when`(stockMovementRepository.onHandByProductWarehouse(orgId)).thenReturn(
+            mapOf(
+                OnHandKey("p-1", "wh-1") to BigDecimal("4"), // below
+                OnHandKey("p-2", "wh-1") to BigDecimal("8"), // above
+                OnHandKey("p-3", "wh-1") to BigDecimal("2"), // below
+            ),
+        )
+        val report = service.lowStockReport(orgId)
+        assertThat(report.lines.map { it.productId }).containsExactly("p-1", "p-3")
+        assertThat(report.lines.first { it.productId == "p-1" }.shortfall).isEqualByComparingTo("6")
+        assertThat(report.lines.first { it.productId == "p-3" }.shortfall).isEqualByComparingTo("1")
+    }
+
+    @Test
+    fun `lowStockReport treats missing on-hand as zero`() {
+        `when`(reorderRuleRepository.findByOrganizationId(orgId)).thenReturn(
+            listOf(rule(productId = "p-1", warehouseId = "wh-1", reorderPoint = BigDecimal("5"))),
+        )
+        `when`(stockMovementRepository.onHandByProductWarehouse(orgId)).thenReturn(emptyMap())
+        val report = service.lowStockReport(orgId)
+        assertThat(report.lines).hasSize(1)
+        assertThat(report.lines[0].onHand).isEqualByComparingTo("0")
+        assertThat(report.lines[0].shortfall).isEqualByComparingTo("5")
+    }
+}


### PR DESCRIPTION
## Summary
Sixth and final issue of the MVP Inventory epic (#8). Adds **reorder rules** (per product, per warehouse) and the **low-stock report endpoint** that consumes them. Closes the loop on the MVP inventory module — every read surface promised in the issue list is now in place.

Builds on #121 → #123 → #124 → #125 → #126 (catalog, warehouses, movements, valuation, reports).

## What's included
- **`InventoryReorderRule`** model — `(orgId, productId, warehouseId, reorderPoint, safetyStock)` with compound-unique index on the org/product/warehouse triple
- **`InventoryReorderRuleRepository`** — find by org, find by triple (for duplicate detection)
- **`InventoryReorderRuleService`**:
  - CRUD with org scoping (`createRule`/`getRule`/`listRules`/`updateRule`/`deleteRule`)
  - Duplicate `(org, product, warehouse)` → 400 with helpful message
  - `lowStockReport(orgId)` joins rules with `onHandByProductWarehouse` from #41, emits a line per pair where `onHand < reorderPoint` with a `shortfall = reorderPoint − onHand` field
- **`InventoryReorderRuleController`** under `/inventory/reorder-rules` — full CRUD with `inventory:read`/`inventory:write`
- **`GET /inventory/reports/low-stock`** added to `InventoryReportsController`
- 13 new tests (8 service + 5 controller)

## MVP additions from #43 (all included)
- Reorder rules are per-organization, per-warehouse, per-product
- Alert delivery deferred to Notifications (#13); for MVP, `GET /inventory/reports/low-stock` lists all under-reorder pairs

## Out of scope (this issue)
- Push notifications / email alerts — Notifications module (#13)
- Auto-create purchase orders from low-stock — Procurement module (#9)
- Lead-time-aware reorder math — current rule is a simple threshold; spec doesn't pin lead-time logic

## Merge direction
Targets `119-inventory-reports` (PR #126), the last branch in the inventory stack. After cascade:

```
staging
└── #121  38-product-item-catalog-crud
    └── #123  40-warehouses
        └── #124  41-stock-movements
            └── #125  42-stock-valuation (phase 1)
                └── #126  119-inventory-reports
                    └── this PR  43-reorder-low-stock
```

This is the **tail of the MVP inventory stack**. After all six PRs cascade to `staging`, the inventory module v1 ships.

**Remaining inventory work** (not in MVP):
- #39 UoM/variants — reshapes Product; separate PR (deferred per stack discussion)
- #42 phase 2 — GL auto-posting + inventory account seeding (Dr Inventory / Cr suspense; Dr COGS / Cr Inventory)
- #120 Physical inventory count workflow — post-MVP

## CI note
Stacked on a feature branch; full CI runs on retarget to `staging`. Locally verified: ktlint clean + 13 new tests pass.

## Test plan
- [ ] `POST /inventory/reorder-rules` with `{productId, warehouseId, reorderPoint}` → 201
- [ ] Duplicate triple → 400
- [ ] `PATCH /inventory/reorder-rules/{id}` updates reorderPoint/safetyStock
- [ ] `DELETE /inventory/reorder-rules/{id}` → 204
- [ ] `GET /inventory/reports/low-stock` returns only pairs where `onHand < reorderPoint`
- [ ] Missing on-hand (no movements ever) treated as 0 → triggers low-stock if a rule exists
- [ ] Cross-org isolation: rules from other orgs invisible
- [ ] VIEWER: CRUD GETs work, POST/PATCH/DELETE → 403

Part of #43
