### PR TITLE
fix(ci): disable docker-compose auto-discovery; seeders idempotent under race

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/config/CurrencySeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/CurrencySeeder.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.core.annotation.Order
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Component
 
 @Component
@@ -28,8 +29,12 @@ class CurrencySeeder(
         seeded.forEach { currency ->
             val existing = currencyRepository.findById(currency.code)
             if (existing.isEmpty) {
-                currencyRepository.save(currency)
-                log.info("Seeded currency: {} ({})", currency.code, currency.name)
+                try {
+                    currencyRepository.save(currency)
+                    log.info("Seeded currency: {} ({})", currency.code, currency.name)
+                } catch (_: DataIntegrityViolationException) {
+                    // Race with another seeder run; the row is now present.
+                }
             } else if (existing.get() != currency) {
                 currencyRepository.save(currency)
                 log.info("Updated currency: {}", currency.code)

--- a/src/main/kotlin/com/froilan/synectix/config/CurrencySeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/CurrencySeeder.kt
@@ -32,8 +32,12 @@ class CurrencySeeder(
                 try {
                     currencyRepository.save(currency)
                     log.info("Seeded currency: {} ({})", currency.code, currency.name)
-                } catch (_: DataIntegrityViolationException) {
-                    // Race with another seeder run; the row is now present.
+                } catch (e: DataIntegrityViolationException) {
+                    // Only treat as a race-loss if the row is now present;
+                    // otherwise this is a real constraint problem worth surfacing.
+                    if (currencyRepository.findById(currency.code).isEmpty) {
+                        throw e
+                    }
                 }
             } else if (existing.get() != currency) {
                 currencyRepository.save(currency)

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.core.annotation.Order
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Component
 
 @Component
@@ -165,9 +166,13 @@ class RoleSeeder(
         defaultRoles.forEach { role ->
             val existing = roleRepository.findByName(role.name)
             if (existing.isEmpty) {
-                roleRepository.save(role)
-                log.info("Seeded role: {} ({})", role.name, role.level)
-                changed = true
+                try {
+                    roleRepository.save(role)
+                    log.info("Seeded role: {} ({})", role.name, role.level)
+                    changed = true
+                } catch (_: DataIntegrityViolationException) {
+                    // Race with another seeder run; the row is now present.
+                }
             } else {
                 val current = existing.get()
                 if (current.description != role.description ||

--- a/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/froilan/synectix/config/RoleSeeder.kt
@@ -170,8 +170,15 @@ class RoleSeeder(
                     roleRepository.save(role)
                     log.info("Seeded role: {} ({})", role.name, role.level)
                     changed = true
-                } catch (_: DataIntegrityViolationException) {
-                    // Race with another seeder run; the row is now present.
+                } catch (e: DataIntegrityViolationException) {
+                    // A constraint failed. Only treat as a race-loss if the row is
+                    // now present; otherwise this is a real schema/data problem.
+                    if (roleRepository.findByName(role.name).isEmpty) {
+                        throw e
+                    }
+                    // Roles were inserted by another startup; our @PostConstruct
+                    // cache load ran before that, so flag for refresh.
+                    changed = true
                 }
             } else {
                 val current = existing.get()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,11 @@ spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 spring.flyway.baseline-on-migrate=true
 
+# Don't auto-discover compose.yaml at app boot — DataSource is driven by
+# DATABASE_URL env / application.properties. Devs that want compose
+# integration can re-enable via -Dspring.docker.compose.enabled=true.
+spring.docker.compose.enabled=false
+
 # Actuator configuration for health endpoints
 management.endpoints.web.exposure.include=${MANAGEMENT_ENDPOINTS_INCLUDE:health,info,metrics}
 management.endpoint.health.show-details=${MANAGEMENT_HEALTH_SHOW_DETAILS:when-authorized}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -15,6 +15,8 @@ spring.jpa.open-in-view=false
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 
+spring.docker.compose.enabled=false
+
 # Enhanced logging for testing
 logging.level.root=${LOG_LEVEL_ROOT:INFO}
 logging.level.com.froilan.synectix=${LOG_LEVEL_SYNECTIX:DEBUG}


### PR DESCRIPTION
Surfaced by PR #130's CI:

- **`database "loom" does not exist`** at app boot — Spring Boot's docker-compose support auto-reads `compose.yaml` (which has `POSTGRES_DB=loom` for local dev), and that overrides the CI's `DATABASE_URL=...loom_test` env var. Disabled via `spring.docker.compose.enabled=false` in both `application.properties` and `application-test.properties`.
- **`duplicate key value violates unique constraint "roles_name_key"`** in the `@SpringBootTest` context startup — parallel test classes start contexts concurrently; both `RoleSeeder`s pass the `findByName`-empty check and race on insert. Wrapped both seeders' save calls in `try/catch DataIntegrityViolationException` — intent is 'ensure row exists', so losing the race is success.

Once this merges to `staging`, PR #130's next CI run should pick up the fixes automatically.