### PR TITLE
fix: address review feedback (ddl-auto comment, history warehouse label, dead code)

### DIFF
--- a/src/main/kotlin/com/froilan/synectix/service/InventoryReportsService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InventoryReportsService.kt
@@ -58,7 +58,8 @@ class InventoryReportsService(
         val runningByPair = mutableMapOf<OnHandKey, BigDecimal>()
         val lines =
             movements.map { m ->
-                val pair = OnHandKey(m.productId, primaryAffectedWarehouse(m, warehouseId))
+                val affectedWarehouseId = primaryAffectedWarehouse(m, warehouseId)
+                val pair = OnHandKey(m.productId, affectedWarehouseId)
                 val current = runningByPair[pair] ?: BigDecimal.ZERO
                 val newBalance = current + signedQuantity(m, pair.warehouseId)
                 runningByPair[pair] = newBalance
@@ -66,7 +67,10 @@ class InventoryReportsService(
                     id = m.id,
                     type = m.type,
                     productId = m.productId,
-                    warehouseId = m.warehouseId,
+                    // Report the warehouse the running balance is keyed on so a
+                    // caller filtering by a destination warehouse sees that
+                    // warehouse on the line, not the TRANSFER's source side.
+                    warehouseId = affectedWarehouseId,
                     transferToWarehouseId = m.transferToWarehouseId,
                     quantity = m.quantity,
                     unitCost = m.unitCost,

--- a/src/main/kotlin/com/froilan/synectix/service/InventoryValuationService.kt
+++ b/src/main/kotlin/com/froilan/synectix/service/InventoryValuationService.kt
@@ -2,7 +2,6 @@ package com.froilan.synectix.service
 
 import com.froilan.synectix.dto.ValuationLineResponse
 import com.froilan.synectix.dto.ValuationReportResponse
-import com.froilan.synectix.repository.OnHandKey
 import com.froilan.synectix.repository.StockMovementRepository
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -34,7 +33,4 @@ class InventoryValuationService(
             totalValue = total,
         )
     }
-
-    @Suppress("unused")
-    private fun unusedKey(): OnHandKey = OnHandKey("", "")
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,12 +10,17 @@ spring.datasource.username=${DATABASE_USERNAME:loom}
 spring.datasource.password=${DATABASE_PASSWORD:loom}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+# Schema is canonical in Flyway, not in JPA. We do NOT run Hibernate's
+# schema validator (validate) because the project uses native PG types
+# (uuid columns + a varchar→uuid implicit cast, jsonb-shaped child tables,
+# char(3) currency PKs) that Hibernate's reflection-based validator
+# flags as mismatches even though they work at query time. Drift would
+# show up as a SQL error on the first failing query, not silently.
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 spring.jpa.open-in-view=false
 
-# Flyway owns the schema; validate that JPA entities match.
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 spring.flyway.baseline-on-migrate=true


### PR DESCRIPTION
Three review points on staging:

1. **ddl-auto comment vs value mismatch** — the comment claimed Flyway owns the schema and JPA should `validate`, but the value was `none`. Kept `none` (Hibernate's validator doesn't grok our native uuid columns + the varchar→uuid implicit cast + char(3) currency PKs) and rewrote the comment to be honest about why. Drift now surfaces as a SQL error at query time, not silently.

2. **`InventoryReportsService.movementHistory`** — when filtering by a destination warehouse on a TRANSFER, the running balance was correctly keyed on the destination but the line was labeled with the source warehouse, leaving API consumers with an inconsistent record. Now emits the effective/affected warehouse id consistent with the running balance.

3. **Dead code in `InventoryValuationService`** — removed the `@Suppress("unused") private fun unusedKey()` and its `OnHandKey` import that only existed to keep the import alive.