### PR TITLE
feat: HR / People module — departments + employees (#145)

### DIFF
--- a/src/main/kotlin/com/loom/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/loom/synectix/config/RoleSeeder.kt
@@ -74,6 +74,8 @@ class RoleSeeder(
                             Permissions.FX_CREATE,
                             Permissions.INVENTORY_READ,
                             Permissions.INVENTORY_WRITE,
+                            Permissions.HR_READ,
+                            Permissions.HR_WRITE,
                         ),
                 ),
                 Role(
@@ -115,6 +117,8 @@ class RoleSeeder(
                             Permissions.FX_CREATE,
                             Permissions.INVENTORY_READ,
                             Permissions.INVENTORY_WRITE,
+                            Permissions.HR_READ,
+                            Permissions.HR_WRITE,
                         ),
                 ),
                 Role(
@@ -140,6 +144,8 @@ class RoleSeeder(
                             Permissions.FX_READ,
                             Permissions.INVENTORY_READ,
                             Permissions.INVENTORY_WRITE,
+                            Permissions.HR_READ,
+                            Permissions.HR_WRITE,
                         ),
                 ),
                 Role(
@@ -158,6 +164,7 @@ class RoleSeeder(
                             Permissions.TAX_READ,
                             Permissions.FX_READ,
                             Permissions.INVENTORY_READ,
+                            Permissions.HR_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/loom/synectix/controller/DepartmentController.kt
+++ b/src/main/kotlin/com/loom/synectix/controller/DepartmentController.kt
@@ -1,0 +1,77 @@
+package com.loom.synectix.controller
+
+import com.loom.synectix.annotation.LogLevel
+import com.loom.synectix.annotation.Loggable
+import com.loom.synectix.dto.CreateDepartmentRequest
+import com.loom.synectix.dto.DepartmentResponse
+import com.loom.synectix.dto.UpdateDepartmentRequest
+import com.loom.synectix.security.AuthenticationContext
+import com.loom.synectix.service.DepartmentService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/hr/departments")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class DepartmentController(
+    private val departmentService: DepartmentService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createDepartment(
+        @Valid @RequestBody request: CreateDepartmentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val department = departmentService.createDepartment(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(DepartmentResponse.from(department))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listDepartments(
+        @RequestParam(required = false, defaultValue = "false") activeOnly: Boolean,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(departmentService.listDepartments(orgId, activeOnly).map { DepartmentResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getDepartment(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(DepartmentResponse.from(departmentService.getDepartment(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updateDepartment(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateDepartmentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(DepartmentResponse.from(departmentService.updateDepartment(id, request, orgId)))
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun deactivateDepartment(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(DepartmentResponse.from(departmentService.deactivateDepartment(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/controller/EmployeeController.kt
+++ b/src/main/kotlin/com/loom/synectix/controller/EmployeeController.kt
@@ -1,0 +1,120 @@
+package com.loom.synectix.controller
+
+import com.loom.synectix.annotation.LogLevel
+import com.loom.synectix.annotation.Loggable
+import com.loom.synectix.dto.CreateEmployeeRequest
+import com.loom.synectix.dto.EmployeeResponse
+import com.loom.synectix.dto.TerminateEmployeeRequest
+import com.loom.synectix.dto.UpdateEmployeeRequest
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.security.AuthenticationContext
+import com.loom.synectix.service.EmployeeService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/hr/employees")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class EmployeeController(
+    private val employeeService: EmployeeService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createEmployee(
+        @Valid @RequestBody request: CreateEmployeeRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val employee = employeeService.createEmployee(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(EmployeeResponse.from(employee))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listEmployees(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) departmentId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val employmentStatus =
+            if (status != null) {
+                try {
+                    EmploymentStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(employeeService.listEmployees(orgId, employmentStatus, departmentId).map { EmployeeResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getEmployee(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.getEmployee(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updateEmployee(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateEmployeeRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.updateEmployee(id, request, orgId)))
+    }
+
+    @PostMapping("/{id}/assign-department")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun assignDepartment(
+        @PathVariable id: String,
+        @RequestParam(required = false) departmentId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.assignDepartment(id, departmentId, orgId)))
+    }
+
+    @PostMapping("/{id}/leave")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun placeOnLeave(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.placeOnLeave(id, orgId)))
+    }
+
+    @PostMapping("/{id}/return")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun returnFromLeave(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.returnFromLeave(id, orgId)))
+    }
+
+    @PostMapping("/{id}/terminate")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun terminate(
+        @PathVariable id: String,
+        @Valid @RequestBody request: TerminateEmployeeRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val date = request.terminationDate ?: return ResponseEntity.badRequest().body(mapOf("error" to "terminationDate is required"))
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.terminate(id, date, orgId)))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/dto/DepartmentDtos.kt
+++ b/src/main/kotlin/com/loom/synectix/dto/DepartmentDtos.kt
@@ -1,0 +1,44 @@
+package com.loom.synectix.dto
+
+import com.loom.synectix.model.Department
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateDepartmentRequest(
+    @field:NotBlank(message = "Code is required")
+    @field:Size(max = 32, message = "Code must be 32 characters or fewer")
+    val code: String,
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    val description: String? = null,
+)
+
+data class UpdateDepartmentRequest(
+    val name: String? = null,
+    val description: String? = null,
+)
+
+data class DepartmentResponse(
+    val id: String,
+    val code: String,
+    val name: String,
+    val description: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(department: Department) =
+            DepartmentResponse(
+                id = department.id,
+                code = department.code,
+                name = department.name,
+                description = department.description,
+                organizationId = department.organizationId,
+                isActive = department.isActive,
+                createdAt = department.createdAt?.toString(),
+                updatedAt = department.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/dto/EmployeeDtos.kt
+++ b/src/main/kotlin/com/loom/synectix/dto/EmployeeDtos.kt
@@ -1,0 +1,69 @@
+package com.loom.synectix.dto
+
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class CreateEmployeeRequest(
+    @field:NotBlank(message = "First name is required")
+    val firstName: String,
+    @field:NotBlank(message = "Last name is required")
+    val lastName: String,
+    @field:Email(message = "Email must be valid")
+    val email: String? = null,
+    val jobTitle: String? = null,
+    val departmentId: String? = null,
+    @field:NotNull(message = "Hire date is required")
+    val hireDate: LocalDate?,
+)
+
+data class UpdateEmployeeRequest(
+    val firstName: String? = null,
+    val lastName: String? = null,
+    @field:Email(message = "Email must be valid")
+    val email: String? = null,
+    val jobTitle: String? = null,
+)
+
+data class TerminateEmployeeRequest(
+    @field:NotNull(message = "Termination date is required")
+    val terminationDate: LocalDate?,
+)
+
+data class EmployeeResponse(
+    val id: String,
+    val employeeNumber: String,
+    val firstName: String,
+    val lastName: String,
+    val email: String?,
+    val jobTitle: String?,
+    val departmentId: String?,
+    val hireDate: String,
+    val status: EmploymentStatus,
+    val terminationDate: String?,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(employee: Employee) =
+            EmployeeResponse(
+                id = employee.id,
+                employeeNumber = employee.employeeNumber,
+                firstName = employee.firstName,
+                lastName = employee.lastName,
+                email = employee.email,
+                jobTitle = employee.jobTitle,
+                departmentId = employee.departmentId,
+                hireDate = employee.hireDate.toString(),
+                status = employee.status,
+                terminationDate = employee.terminationDate?.toString(),
+                organizationId = employee.organizationId,
+                createdAt = employee.createdAt?.toString(),
+                updatedAt = employee.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/model/Department.kt
+++ b/src/main/kotlin/com/loom/synectix/model/Department.kt
@@ -1,0 +1,34 @@
+package com.loom.synectix.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "departments")
+@EntityListeners(AuditingEntityListener::class)
+data class Department(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    val code: String,
+    val name: String,
+    val description: String? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Column(name = "is_active")
+    val isActive: Boolean = true,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/loom/synectix/model/Employee.kt
+++ b/src/main/kotlin/com/loom/synectix/model/Employee.kt
@@ -1,0 +1,55 @@
+package com.loom.synectix.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class EmploymentStatus {
+    ACTIVE,
+    ON_LEAVE,
+    TERMINATED,
+}
+
+@Entity
+@Table(name = "employees")
+@EntityListeners(AuditingEntityListener::class)
+data class Employee(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "employee_number")
+    val employeeNumber: String,
+    @Column(name = "first_name")
+    val firstName: String,
+    @Column(name = "last_name")
+    val lastName: String,
+    val email: String? = null,
+    @Column(name = "job_title")
+    val jobTitle: String? = null,
+    @Column(name = "department_id", columnDefinition = "uuid")
+    val departmentId: String? = null,
+    @Column(name = "hire_date")
+    val hireDate: LocalDate,
+    @Enumerated(EnumType.STRING)
+    val status: EmploymentStatus = EmploymentStatus.ACTIVE,
+    @Column(name = "termination_date")
+    val terminationDate: LocalDate? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/loom/synectix/repository/DepartmentRepository.kt
+++ b/src/main/kotlin/com/loom/synectix/repository/DepartmentRepository.kt
@@ -1,0 +1,21 @@
+package com.loom.synectix.repository
+
+import com.loom.synectix.model.Department
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface DepartmentRepository : JpaRepository<Department, String> {
+    fun findByOrganizationId(organizationId: String): List<Department>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Department>
+
+    fun findByOrganizationIdAndCode(
+        organizationId: String,
+        code: String,
+    ): Optional<Department>
+}

--- a/src/main/kotlin/com/loom/synectix/repository/EmployeeRepository.kt
+++ b/src/main/kotlin/com/loom/synectix/repository/EmployeeRepository.kt
@@ -1,0 +1,23 @@
+package com.loom.synectix.repository
+
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface EmployeeRepository : JpaRepository<Employee, String> {
+    fun findByOrganizationId(organizationId: String): List<Employee>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: EmploymentStatus,
+    ): List<Employee>
+
+    fun findByOrganizationIdAndDepartmentId(
+        organizationId: String,
+        departmentId: String,
+    ): List<Employee>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/loom/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/loom/synectix/security/Permissions.kt
@@ -55,6 +55,9 @@ object Permissions {
     const val INVENTORY_READ = "inventory:read"
     const val INVENTORY_WRITE = "inventory:write"
 
+    const val HR_READ = "hr:read"
+    const val HR_WRITE = "hr:write"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -97,5 +100,7 @@ object Permissions {
             FX_CREATE,
             INVENTORY_READ,
             INVENTORY_WRITE,
+            HR_READ,
+            HR_WRITE,
         )
 }

--- a/src/main/kotlin/com/loom/synectix/service/DepartmentService.kt
+++ b/src/main/kotlin/com/loom/synectix/service/DepartmentService.kt
@@ -1,0 +1,85 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateDepartmentRequest
+import com.loom.synectix.dto.UpdateDepartmentRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.Department
+import com.loom.synectix.repository.DepartmentRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DepartmentService(
+    private val departmentRepository: DepartmentRepository,
+) {
+    @Transactional
+    fun createDepartment(
+        request: CreateDepartmentRequest,
+        organizationId: String,
+    ): Department {
+        val code = request.code.trim()
+        if (departmentRepository.findByOrganizationIdAndCode(organizationId, code).isPresent) {
+            throw BusinessRuleException("Department code '$code' already exists")
+        }
+        return departmentRepository.save(
+            Department(
+                code = code,
+                name = request.name.trim(),
+                description = request.description,
+                organizationId = organizationId,
+            ),
+        )
+    }
+
+    fun getDepartment(
+        id: String,
+        organizationId: String,
+    ): Department {
+        val department =
+            departmentRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Department not found")
+            }
+        if (department.organizationId != organizationId) {
+            throw ResourceNotFoundException("Department not found")
+        }
+        return department
+    }
+
+    fun listDepartments(
+        organizationId: String,
+        activeOnly: Boolean = false,
+    ): List<Department> =
+        if (activeOnly) {
+            departmentRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        } else {
+            departmentRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateDepartment(
+        id: String,
+        request: UpdateDepartmentRequest,
+        organizationId: String,
+    ): Department {
+        val department = getDepartment(id, organizationId)
+        return departmentRepository.save(
+            department.copy(
+                name = request.name?.trim() ?: department.name,
+                description = request.description ?: department.description,
+            ),
+        )
+    }
+
+    @Transactional
+    fun deactivateDepartment(
+        id: String,
+        organizationId: String,
+    ): Department {
+        val department = getDepartment(id, organizationId)
+        if (!department.isActive) {
+            throw BusinessRuleException("Department is already inactive")
+        }
+        return departmentRepository.save(department.copy(isActive = false))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/service/EmployeeService.kt
+++ b/src/main/kotlin/com/loom/synectix/service/EmployeeService.kt
@@ -1,0 +1,167 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateEmployeeRequest
+import com.loom.synectix.dto.UpdateEmployeeRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.repository.EmployeeRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class EmployeeService(
+    private val employeeRepository: EmployeeRepository,
+    private val departmentService: DepartmentService,
+) {
+    @Transactional
+    fun createEmployee(
+        request: CreateEmployeeRequest,
+        organizationId: String,
+    ): Employee {
+        val hireDate = request.hireDate ?: throw BusinessRuleException("Hire date is required")
+        request.departmentId?.let { requireActiveDepartment(it, organizationId) }
+        return saveWithRetry(organizationId) { number ->
+            Employee(
+                employeeNumber = number,
+                firstName = request.firstName.trim(),
+                lastName = request.lastName.trim(),
+                email = request.email?.trim(),
+                jobTitle = request.jobTitle?.trim(),
+                departmentId = request.departmentId,
+                hireDate = hireDate,
+                organizationId = organizationId,
+            )
+        }
+    }
+
+    fun getEmployee(
+        id: String,
+        organizationId: String,
+    ): Employee {
+        val employee =
+            employeeRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Employee not found")
+            }
+        if (employee.organizationId != organizationId) {
+            throw ResourceNotFoundException("Employee not found")
+        }
+        return employee
+    }
+
+    fun listEmployees(
+        organizationId: String,
+        status: EmploymentStatus? = null,
+        departmentId: String? = null,
+    ): List<Employee> =
+        when {
+            status != null -> employeeRepository.findByOrganizationIdAndStatus(organizationId, status)
+            departmentId != null -> employeeRepository.findByOrganizationIdAndDepartmentId(organizationId, departmentId)
+            else -> employeeRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateEmployee(
+        id: String,
+        request: UpdateEmployeeRequest,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        return employeeRepository.save(
+            employee.copy(
+                firstName = request.firstName?.trim() ?: employee.firstName,
+                lastName = request.lastName?.trim() ?: employee.lastName,
+                email = request.email?.trim() ?: employee.email,
+                jobTitle = request.jobTitle?.trim() ?: employee.jobTitle,
+            ),
+        )
+    }
+
+    @Transactional
+    fun assignDepartment(
+        id: String,
+        departmentId: String?,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        if (employee.status == EmploymentStatus.TERMINATED) {
+            throw BusinessRuleException("Cannot reassign a terminated employee")
+        }
+        departmentId?.let { requireActiveDepartment(it, organizationId) }
+        return employeeRepository.save(employee.copy(departmentId = departmentId))
+    }
+
+    @Transactional
+    fun placeOnLeave(
+        id: String,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        if (employee.status != EmploymentStatus.ACTIVE) {
+            throw BusinessRuleException("Only active employees can be placed on leave")
+        }
+        return employeeRepository.save(employee.copy(status = EmploymentStatus.ON_LEAVE))
+    }
+
+    @Transactional
+    fun returnFromLeave(
+        id: String,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        if (employee.status != EmploymentStatus.ON_LEAVE) {
+            throw BusinessRuleException("Only employees on leave can return")
+        }
+        return employeeRepository.save(employee.copy(status = EmploymentStatus.ACTIVE))
+    }
+
+    @Transactional
+    fun terminate(
+        id: String,
+        terminationDate: LocalDate,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        if (employee.status == EmploymentStatus.TERMINATED) {
+            throw BusinessRuleException("Employee is already terminated")
+        }
+        if (terminationDate.isBefore(employee.hireDate)) {
+            throw BusinessRuleException("Termination date cannot be before the hire date")
+        }
+        return employeeRepository.save(
+            employee.copy(status = EmploymentStatus.TERMINATED, terminationDate = terminationDate),
+        )
+    }
+
+    private fun requireActiveDepartment(
+        departmentId: String,
+        organizationId: String,
+    ) {
+        val department = departmentService.getDepartment(departmentId, organizationId)
+        if (!department.isActive) {
+            throw BusinessRuleException("Department '${department.code}' is inactive")
+        }
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        build: (String) -> Employee,
+    ): Employee {
+        repeat(maxRetries) { attempt ->
+            val count = employeeRepository.countByOrganizationId(organizationId)
+            val number = "EMP-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return employeeRepository.save(build(number))
+            } catch (e: DuplicateKeyException) {
+                if (attempt == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique employee number: $number", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique employee number")
+    }
+}

--- a/src/main/resources/db/migration/V0003__hr_departments.sql
+++ b/src/main/resources/db/migration/V0003__hr_departments.sql
@@ -1,0 +1,13 @@
+-- HR module: departments.
+CREATE TABLE departments (
+    id                uuid PRIMARY KEY,
+    code              text NOT NULL,
+    name              text NOT NULL,
+    description       text,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    is_active         boolean NOT NULL DEFAULT true,
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT departments_unique_code_per_org UNIQUE (organization_id, code)
+);
+CREATE INDEX departments_org_active_idx ON departments(organization_id, is_active);

--- a/src/main/resources/db/migration/V0004__hr_employees.sql
+++ b/src/main/resources/db/migration/V0004__hr_employees.sql
@@ -1,0 +1,20 @@
+-- HR module: employees.
+CREATE TABLE employees (
+    id                uuid PRIMARY KEY,
+    employee_number   text NOT NULL,
+    first_name        text NOT NULL,
+    last_name         text NOT NULL,
+    email             text,
+    job_title         text,
+    department_id     uuid REFERENCES departments(id) ON DELETE SET NULL,
+    hire_date         date NOT NULL,
+    status            text NOT NULL DEFAULT 'ACTIVE',
+    termination_date  date,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT employees_status_chk CHECK (status IN ('ACTIVE','ON_LEAVE','TERMINATED')),
+    CONSTRAINT employees_unique_number_per_org UNIQUE (organization_id, employee_number)
+);
+CREATE INDEX employees_org_status_idx ON employees(organization_id, status);
+CREATE INDEX employees_org_department_idx ON employees(organization_id, department_id);

--- a/src/test/kotlin/com/loom/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/loom/synectix/config/RoleSeederTest.kt
@@ -93,6 +93,8 @@ class RoleSeederTest {
                         Permissions.FX_CREATE,
                         Permissions.INVENTORY_READ,
                         Permissions.INVENTORY_WRITE,
+                        Permissions.HR_READ,
+                        Permissions.HR_WRITE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -286,6 +288,8 @@ class RoleSeederTest {
                         Permissions.FX_CREATE,
                         Permissions.INVENTORY_READ,
                         Permissions.INVENTORY_WRITE,
+                        Permissions.HR_READ,
+                        Permissions.HR_WRITE,
                     ),
             )
         val admin =
@@ -328,6 +332,8 @@ class RoleSeederTest {
                         Permissions.FX_CREATE,
                         Permissions.INVENTORY_READ,
                         Permissions.INVENTORY_WRITE,
+                        Permissions.HR_READ,
+                        Permissions.HR_WRITE,
                     ),
             )
         val member =
@@ -354,6 +360,8 @@ class RoleSeederTest {
                         Permissions.FX_READ,
                         Permissions.INVENTORY_READ,
                         Permissions.INVENTORY_WRITE,
+                        Permissions.HR_READ,
+                        Permissions.HR_WRITE,
                     ),
             )
         val viewer =
@@ -373,6 +381,7 @@ class RoleSeederTest {
                         Permissions.TAX_READ,
                         Permissions.FX_READ,
                         Permissions.INVENTORY_READ,
+                        Permissions.HR_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/loom/synectix/service/DepartmentServiceTest.kt
+++ b/src/test/kotlin/com/loom/synectix/service/DepartmentServiceTest.kt
@@ -1,0 +1,79 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateDepartmentRequest
+import com.loom.synectix.dto.UpdateDepartmentRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.Department
+import com.loom.synectix.repository.DepartmentRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+class DepartmentServiceTest {
+    private lateinit var repository: DepartmentRepository
+    private lateinit var service: DepartmentService
+
+    private val orgId = "org-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(DepartmentRepository::class.java)
+        whenever(repository.save(any<Department>())).thenAnswer { it.arguments[0] }
+        whenever(repository.findByOrganizationIdAndCode(any(), any())).thenReturn(Optional.empty())
+        service = DepartmentService(repository)
+    }
+
+    @Test
+    fun `create trims and persists an active department`() {
+        val dept = service.createDepartment(CreateDepartmentRequest(code = " ENG ", name = " Engineering "), orgId)
+
+        assertThat(dept.code).isEqualTo("ENG")
+        assertThat(dept.name).isEqualTo("Engineering")
+        assertThat(dept.isActive).isTrue()
+        assertThat(dept.organizationId).isEqualTo(orgId)
+    }
+
+    @Test
+    fun `create rejects a duplicate code`() {
+        whenever(repository.findByOrganizationIdAndCode(orgId, "ENG"))
+            .thenReturn(Optional.of(Department(code = "ENG", name = "Engineering", organizationId = orgId)))
+
+        assertThatThrownBy { service.createDepartment(CreateDepartmentRequest(code = "ENG", name = "Eng"), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("d1"))
+            .thenReturn(Optional.of(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = "other")))
+
+        assertThatThrownBy { service.getDepartment("d1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `update changes name and description only`() {
+        whenever(repository.findById("d1"))
+            .thenReturn(Optional.of(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId)))
+
+        val updated = service.updateDepartment("d1", UpdateDepartmentRequest(name = "R&D"), orgId)
+
+        assertThat(updated.name).isEqualTo("R&D")
+        assertThat(updated.code).isEqualTo("ENG")
+    }
+
+    @Test
+    fun `deactivate flips the active flag and rejects double-deactivation`() {
+        whenever(repository.findById("d1"))
+            .thenReturn(Optional.of(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId, isActive = false)))
+
+        assertThatThrownBy { service.deactivateDepartment("d1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+}

--- a/src/test/kotlin/com/loom/synectix/service/EmployeeServiceTest.kt
+++ b/src/test/kotlin/com/loom/synectix/service/EmployeeServiceTest.kt
@@ -1,0 +1,104 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateEmployeeRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.model.Department
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.repository.EmployeeRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.util.Optional
+
+class EmployeeServiceTest {
+    private lateinit var repository: EmployeeRepository
+    private lateinit var departmentService: DepartmentService
+    private lateinit var service: EmployeeService
+
+    private val orgId = "org-1"
+    private val hireDate = LocalDate.of(2026, 1, 6)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(EmployeeRepository::class.java)
+        departmentService = mock(DepartmentService::class.java)
+        whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
+        whenever(repository.save(any<Employee>())).thenAnswer { it.arguments[0] }
+        service = EmployeeService(repository, departmentService)
+    }
+
+    private fun employee(
+        status: EmploymentStatus = EmploymentStatus.ACTIVE,
+        id: String = "e1",
+        org: String = orgId,
+    ) = Employee(
+        id = id,
+        employeeNumber = "EMP-0001",
+        firstName = "Ada",
+        lastName = "Lovelace",
+        hireDate = hireDate,
+        status = status,
+        organizationId = org,
+    )
+
+    @Test
+    fun `create assigns a number and starts ACTIVE`() {
+        val emp = service.createEmployee(CreateEmployeeRequest(firstName = "Ada", lastName = "Lovelace", hireDate = hireDate), orgId)
+
+        assertThat(emp.employeeNumber).isEqualTo("EMP-0001")
+        assertThat(emp.status).isEqualTo(EmploymentStatus.ACTIVE)
+    }
+
+    @Test
+    fun `create validates an inactive department`() {
+        whenever(departmentService.getDepartment("d1", orgId))
+            .thenReturn(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId, isActive = false))
+
+        assertThatThrownBy {
+            service.createEmployee(
+                CreateEmployeeRequest(firstName = "Ada", lastName = "Lovelace", departmentId = "d1", hireDate = hireDate),
+                orgId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `leave and return follow the lifecycle`() {
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee()))
+        assertThat(service.placeOnLeave("e1", orgId).status).isEqualTo(EmploymentStatus.ON_LEAVE)
+
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee(status = EmploymentStatus.ON_LEAVE)))
+        assertThat(service.returnFromLeave("e1", orgId).status).isEqualTo(EmploymentStatus.ACTIVE)
+    }
+
+    @Test
+    fun `cannot place a terminated employee on leave`() {
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee(status = EmploymentStatus.TERMINATED)))
+        assertThatThrownBy { service.placeOnLeave("e1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `terminate sets status and date and rejects a date before hire`() {
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee()))
+        val terminated = service.terminate("e1", LocalDate.of(2026, 6, 30), orgId)
+        assertThat(terminated.status).isEqualTo(EmploymentStatus.TERMINATED)
+        assertThat(terminated.terminationDate).isEqualTo(LocalDate.of(2026, 6, 30))
+
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee()))
+        assertThatThrownBy { service.terminate("e1", LocalDate.of(2025, 1, 1), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `assign department rejects a terminated employee`() {
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee(status = EmploymentStatus.TERMINATED)))
+        assertThatThrownBy { service.assignDepartment("e1", "d1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+}


### PR DESCRIPTION
First slice of the HR / People module (epic #145). **Branches off staging — fully isolated from the PO/SO and inventory-GL stacks.** Three atomic commits.

## Commits
1. `hr:read` / `hr:write` permissions, granted across the default roles (part of #145).
2. **Department CRUD** (`/hr/departments`) — create, list (optional active-only), get, update, deactivate; unique code per org. (Closes #146)
3. **Employee records + lifecycle** (`/hr/employees`) — EMP-#### numbering; hire → ACTIVE, place on leave, return, terminate (date validated ≥ hire date); department assignment (validated active + same org); list filtering by status/department. (Closes #147)

All org-scoped + RBAC, mirroring existing module conventions. Migrations `V0003` (departments) and `V0004` (employees).

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin` — clean
- [x] `DepartmentServiceTest` — create/trim, duplicate-code, cross-org guard, update, deactivate
- [x] `EmployeeServiceTest` — numbering, inactive-dept guard, leave/return lifecycle, terminate (status/date + pre-hire rejection), assign on terminated
- [x] `RoleSeederTest` updated for the new permissions; ktlint clean
- [x] Postgres-dependent integration tests + V0003/V0004 migrations validated in CI

## Notes
- Isolated module; no dependency on finance/inventory. Future slices on the epic: time-off/leave management, and payroll → GL (which will tie HR into the finance core).
- Migration numbers `V0003`/`V0004` are also used by other unmerged branches (#141, PO/SO stack) — whichever merges later will renumber. Independent of those features otherwise.