### PR TITLE
feat: HR positions & compensation (#151)

### DIFF
--- a/src/main/kotlin/com/loom/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/loom/synectix/config/RoleSeeder.kt
@@ -74,6 +74,8 @@ class RoleSeeder(
                             Permissions.FX_CREATE,
                             Permissions.INVENTORY_READ,
                             Permissions.INVENTORY_WRITE,
+                            Permissions.HR_READ,
+                            Permissions.HR_WRITE,
                         ),
                 ),
                 Role(
@@ -115,6 +117,8 @@ class RoleSeeder(
                             Permissions.FX_CREATE,
                             Permissions.INVENTORY_READ,
                             Permissions.INVENTORY_WRITE,
+                            Permissions.HR_READ,
+                            Permissions.HR_WRITE,
                         ),
                 ),
                 Role(
@@ -140,6 +144,8 @@ class RoleSeeder(
                             Permissions.FX_READ,
                             Permissions.INVENTORY_READ,
                             Permissions.INVENTORY_WRITE,
+                            Permissions.HR_READ,
+                            Permissions.HR_WRITE,
                         ),
                 ),
                 Role(
@@ -158,6 +164,7 @@ class RoleSeeder(
                             Permissions.TAX_READ,
                             Permissions.FX_READ,
                             Permissions.INVENTORY_READ,
+                            Permissions.HR_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/loom/synectix/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/loom/synectix/config/RoleSeeder.kt
@@ -76,6 +76,7 @@ class RoleSeeder(
                             Permissions.INVENTORY_WRITE,
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
+                            Permissions.HR_APPROVE,
                         ),
                 ),
                 Role(
@@ -119,6 +120,7 @@ class RoleSeeder(
                             Permissions.INVENTORY_WRITE,
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
+                            Permissions.HR_APPROVE,
                         ),
                 ),
                 Role(

--- a/src/main/kotlin/com/loom/synectix/controller/DepartmentController.kt
+++ b/src/main/kotlin/com/loom/synectix/controller/DepartmentController.kt
@@ -1,0 +1,77 @@
+package com.loom.synectix.controller
+
+import com.loom.synectix.annotation.LogLevel
+import com.loom.synectix.annotation.Loggable
+import com.loom.synectix.dto.CreateDepartmentRequest
+import com.loom.synectix.dto.DepartmentResponse
+import com.loom.synectix.dto.UpdateDepartmentRequest
+import com.loom.synectix.security.AuthenticationContext
+import com.loom.synectix.service.DepartmentService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/hr/departments")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class DepartmentController(
+    private val departmentService: DepartmentService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createDepartment(
+        @Valid @RequestBody request: CreateDepartmentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val department = departmentService.createDepartment(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(DepartmentResponse.from(department))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listDepartments(
+        @RequestParam(required = false, defaultValue = "false") activeOnly: Boolean,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(departmentService.listDepartments(orgId, activeOnly).map { DepartmentResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getDepartment(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(DepartmentResponse.from(departmentService.getDepartment(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updateDepartment(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateDepartmentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(DepartmentResponse.from(departmentService.updateDepartment(id, request, orgId)))
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun deactivateDepartment(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(DepartmentResponse.from(departmentService.deactivateDepartment(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/controller/EmployeeCompensationController.kt
+++ b/src/main/kotlin/com/loom/synectix/controller/EmployeeCompensationController.kt
@@ -1,0 +1,61 @@
+package com.loom.synectix.controller
+
+import com.loom.synectix.annotation.LogLevel
+import com.loom.synectix.annotation.Loggable
+import com.loom.synectix.dto.CreateEmployeeCompensationRequest
+import com.loom.synectix.dto.EmployeeCompensationResponse
+import com.loom.synectix.security.AuthenticationContext
+import com.loom.synectix.service.EmployeeCompensationService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+@RestController
+@RequestMapping("/hr/employees/{employeeId}/compensation")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class EmployeeCompensationController(
+    private val compensationService: EmployeeCompensationService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun addCompensation(
+        @PathVariable employeeId: String,
+        @Valid @RequestBody request: CreateEmployeeCompensationRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
+        val comp = compensationService.addCompensation(employeeId, request, orgId, createdBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(EmployeeCompensationResponse.from(comp))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listCompensation(
+        @PathVariable employeeId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(compensationService.listCompensation(employeeId, orgId).map { EmployeeCompensationResponse.from(it) })
+    }
+
+    @GetMapping("/current")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun currentCompensation(
+        @PathVariable employeeId: String,
+        @RequestParam(required = false) asOf: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val resolved = asOf ?: LocalDate.now(ZoneOffset.UTC)
+        return ResponseEntity.ok(EmployeeCompensationResponse.from(compensationService.currentCompensation(employeeId, orgId, resolved)))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/controller/EmployeeController.kt
+++ b/src/main/kotlin/com/loom/synectix/controller/EmployeeController.kt
@@ -1,0 +1,120 @@
+package com.loom.synectix.controller
+
+import com.loom.synectix.annotation.LogLevel
+import com.loom.synectix.annotation.Loggable
+import com.loom.synectix.dto.CreateEmployeeRequest
+import com.loom.synectix.dto.EmployeeResponse
+import com.loom.synectix.dto.TerminateEmployeeRequest
+import com.loom.synectix.dto.UpdateEmployeeRequest
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.security.AuthenticationContext
+import com.loom.synectix.service.EmployeeService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/hr/employees")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class EmployeeController(
+    private val employeeService: EmployeeService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createEmployee(
+        @Valid @RequestBody request: CreateEmployeeRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val employee = employeeService.createEmployee(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(EmployeeResponse.from(employee))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listEmployees(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) departmentId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val employmentStatus =
+            if (status != null) {
+                try {
+                    EmploymentStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(employeeService.listEmployees(orgId, employmentStatus, departmentId).map { EmployeeResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getEmployee(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.getEmployee(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updateEmployee(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateEmployeeRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.updateEmployee(id, request, orgId)))
+    }
+
+    @PostMapping("/{id}/assign-department")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun assignDepartment(
+        @PathVariable id: String,
+        @RequestParam(required = false) departmentId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.assignDepartment(id, departmentId, orgId)))
+    }
+
+    @PostMapping("/{id}/leave")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun placeOnLeave(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.placeOnLeave(id, orgId)))
+    }
+
+    @PostMapping("/{id}/return")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun returnFromLeave(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.returnFromLeave(id, orgId)))
+    }
+
+    @PostMapping("/{id}/terminate")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun terminate(
+        @PathVariable id: String,
+        @Valid @RequestBody request: TerminateEmployeeRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val date = request.terminationDate ?: return ResponseEntity.badRequest().body(mapOf("error" to "terminationDate is required"))
+        return ResponseEntity.ok(EmployeeResponse.from(employeeService.terminate(id, date, orgId)))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/controller/LeaveRequestController.kt
+++ b/src/main/kotlin/com/loom/synectix/controller/LeaveRequestController.kt
@@ -1,0 +1,118 @@
+package com.loom.synectix.controller
+
+import com.loom.synectix.annotation.LogLevel
+import com.loom.synectix.annotation.Loggable
+import com.loom.synectix.dto.CreateLeaveRequestRequest
+import com.loom.synectix.dto.LeaveRequestResponse
+import com.loom.synectix.dto.RejectLeaveRequestRequest
+import com.loom.synectix.model.LeaveRequestStatus
+import com.loom.synectix.security.AuthenticationContext
+import com.loom.synectix.service.LeaveRequestService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.Locale
+
+@RestController
+@RequestMapping("/hr/leave-requests")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class LeaveRequestController(
+    private val leaveRequestService: LeaveRequestService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createLeaveRequest(
+        @Valid @RequestBody request: CreateLeaveRequestRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val requestedBy = authContext.userId() ?: "api-key"
+        val created = leaveRequestService.createLeaveRequest(request, orgId, requestedBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(LeaveRequestResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listLeaveRequests(
+        @RequestParam(required = false) employeeId: String?,
+        @RequestParam(required = false) status: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val leaveStatus =
+            if (status != null) {
+                try {
+                    LeaveRequestStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(
+            leaveRequestService.listLeaveRequests(orgId, employeeId, leaveStatus).map { LeaveRequestResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getLeaveRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(LeaveRequestResponse.from(leaveRequestService.getLeaveRequest(id, orgId)))
+    }
+
+    @GetMapping("/balance")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun balance(
+        @RequestParam employeeId: String,
+        @RequestParam leaveTypeId: String,
+        @RequestParam(required = false) year: Int?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val resolvedYear = year ?: LocalDate.now(ZoneOffset.UTC).year
+        return ResponseEntity.ok(leaveRequestService.balance(employeeId, leaveTypeId, resolvedYear, orgId))
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('hr:approve')")
+    fun approveLeaveRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val decidedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(LeaveRequestResponse.from(leaveRequestService.approveLeaveRequest(id, orgId, decidedBy)))
+    }
+
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasAuthority('hr:approve')")
+    fun rejectLeaveRequest(
+        @PathVariable id: String,
+        @RequestBody(required = false) request: RejectLeaveRequestRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val decidedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(
+            LeaveRequestResponse.from(leaveRequestService.rejectLeaveRequest(id, request?.reason, orgId, decidedBy)),
+        )
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun cancelLeaveRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(LeaveRequestResponse.from(leaveRequestService.cancelLeaveRequest(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/controller/LeaveTypeController.kt
+++ b/src/main/kotlin/com/loom/synectix/controller/LeaveTypeController.kt
@@ -1,0 +1,76 @@
+package com.loom.synectix.controller
+
+import com.loom.synectix.annotation.LogLevel
+import com.loom.synectix.annotation.Loggable
+import com.loom.synectix.dto.CreateLeaveTypeRequest
+import com.loom.synectix.dto.LeaveTypeResponse
+import com.loom.synectix.dto.UpdateLeaveTypeRequest
+import com.loom.synectix.security.AuthenticationContext
+import com.loom.synectix.service.LeaveTypeService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/hr/leave-types")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class LeaveTypeController(
+    private val leaveTypeService: LeaveTypeService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createLeaveType(
+        @Valid @RequestBody request: CreateLeaveTypeRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.status(HttpStatus.CREATED).body(LeaveTypeResponse.from(leaveTypeService.createLeaveType(request, orgId)))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listLeaveTypes(
+        @RequestParam(required = false, defaultValue = "false") activeOnly: Boolean,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(leaveTypeService.listLeaveTypes(orgId, activeOnly).map { LeaveTypeResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getLeaveType(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(LeaveTypeResponse.from(leaveTypeService.getLeaveType(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updateLeaveType(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateLeaveTypeRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(LeaveTypeResponse.from(leaveTypeService.updateLeaveType(id, request, orgId)))
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun deactivateLeaveType(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(LeaveTypeResponse.from(leaveTypeService.deactivateLeaveType(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/controller/PositionController.kt
+++ b/src/main/kotlin/com/loom/synectix/controller/PositionController.kt
@@ -1,0 +1,76 @@
+package com.loom.synectix.controller
+
+import com.loom.synectix.annotation.LogLevel
+import com.loom.synectix.annotation.Loggable
+import com.loom.synectix.dto.CreatePositionRequest
+import com.loom.synectix.dto.PositionResponse
+import com.loom.synectix.dto.UpdatePositionRequest
+import com.loom.synectix.security.AuthenticationContext
+import com.loom.synectix.service.PositionService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/hr/positions")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class PositionController(
+    private val positionService: PositionService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createPosition(
+        @Valid @RequestBody request: CreatePositionRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.status(HttpStatus.CREATED).body(PositionResponse.from(positionService.createPosition(request, orgId)))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listPositions(
+        @RequestParam(required = false, defaultValue = "false") activeOnly: Boolean,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(positionService.listPositions(orgId, activeOnly).map { PositionResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getPosition(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PositionResponse.from(positionService.getPosition(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updatePosition(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdatePositionRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PositionResponse.from(positionService.updatePosition(id, request, orgId)))
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun deactivatePosition(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PositionResponse.from(positionService.deactivatePosition(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/dto/DepartmentDtos.kt
+++ b/src/main/kotlin/com/loom/synectix/dto/DepartmentDtos.kt
@@ -1,0 +1,44 @@
+package com.loom.synectix.dto
+
+import com.loom.synectix.model.Department
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateDepartmentRequest(
+    @field:NotBlank(message = "Code is required")
+    @field:Size(max = 32, message = "Code must be 32 characters or fewer")
+    val code: String,
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    val description: String? = null,
+)
+
+data class UpdateDepartmentRequest(
+    val name: String? = null,
+    val description: String? = null,
+)
+
+data class DepartmentResponse(
+    val id: String,
+    val code: String,
+    val name: String,
+    val description: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(department: Department) =
+            DepartmentResponse(
+                id = department.id,
+                code = department.code,
+                name = department.name,
+                description = department.description,
+                organizationId = department.organizationId,
+                isActive = department.isActive,
+                createdAt = department.createdAt?.toString(),
+                updatedAt = department.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/dto/EmployeeCompensationDtos.kt
+++ b/src/main/kotlin/com/loom/synectix/dto/EmployeeCompensationDtos.kt
@@ -1,0 +1,51 @@
+package com.loom.synectix.dto
+
+import com.loom.synectix.model.EmployeeCompensation
+import com.loom.synectix.model.PayPeriod
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreateEmployeeCompensationRequest(
+    val positionId: String? = null,
+    @field:NotNull(message = "Pay rate is required")
+    @field:Positive(message = "Pay rate must be positive")
+    val payRate: BigDecimal?,
+    @field:Size(min = 3, max = 3, message = "Currency must be a 3-letter code")
+    val currency: String,
+    @field:NotNull(message = "Pay period is required")
+    val payPeriod: PayPeriod?,
+    @field:NotNull(message = "Effective date is required")
+    val effectiveDate: LocalDate?,
+)
+
+data class EmployeeCompensationResponse(
+    val id: String,
+    val employeeId: String,
+    val positionId: String?,
+    val payRate: BigDecimal,
+    val currency: String,
+    val payPeriod: PayPeriod,
+    val effectiveDate: String,
+    val organizationId: String,
+    val createdBy: String,
+    val createdAt: String?,
+) {
+    companion object {
+        fun from(comp: EmployeeCompensation) =
+            EmployeeCompensationResponse(
+                id = comp.id,
+                employeeId = comp.employeeId,
+                positionId = comp.positionId,
+                payRate = comp.payRate,
+                currency = comp.currency,
+                payPeriod = comp.payPeriod,
+                effectiveDate = comp.effectiveDate.toString(),
+                organizationId = comp.organizationId,
+                createdBy = comp.createdBy,
+                createdAt = comp.createdAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/dto/EmployeeDtos.kt
+++ b/src/main/kotlin/com/loom/synectix/dto/EmployeeDtos.kt
@@ -1,0 +1,69 @@
+package com.loom.synectix.dto
+
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class CreateEmployeeRequest(
+    @field:NotBlank(message = "First name is required")
+    val firstName: String,
+    @field:NotBlank(message = "Last name is required")
+    val lastName: String,
+    @field:Email(message = "Email must be valid")
+    val email: String? = null,
+    val jobTitle: String? = null,
+    val departmentId: String? = null,
+    @field:NotNull(message = "Hire date is required")
+    val hireDate: LocalDate?,
+)
+
+data class UpdateEmployeeRequest(
+    val firstName: String? = null,
+    val lastName: String? = null,
+    @field:Email(message = "Email must be valid")
+    val email: String? = null,
+    val jobTitle: String? = null,
+)
+
+data class TerminateEmployeeRequest(
+    @field:NotNull(message = "Termination date is required")
+    val terminationDate: LocalDate?,
+)
+
+data class EmployeeResponse(
+    val id: String,
+    val employeeNumber: String,
+    val firstName: String,
+    val lastName: String,
+    val email: String?,
+    val jobTitle: String?,
+    val departmentId: String?,
+    val hireDate: String,
+    val status: EmploymentStatus,
+    val terminationDate: String?,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(employee: Employee) =
+            EmployeeResponse(
+                id = employee.id,
+                employeeNumber = employee.employeeNumber,
+                firstName = employee.firstName,
+                lastName = employee.lastName,
+                email = employee.email,
+                jobTitle = employee.jobTitle,
+                departmentId = employee.departmentId,
+                hireDate = employee.hireDate.toString(),
+                status = employee.status,
+                terminationDate = employee.terminationDate?.toString(),
+                organizationId = employee.organizationId,
+                createdAt = employee.createdAt?.toString(),
+                updatedAt = employee.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/dto/LeaveRequestDtos.kt
+++ b/src/main/kotlin/com/loom/synectix/dto/LeaveRequestDtos.kt
@@ -1,0 +1,71 @@
+package com.loom.synectix.dto
+
+import com.loom.synectix.model.LeaveRequest
+import com.loom.synectix.model.LeaveRequestStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class CreateLeaveRequestRequest(
+    @field:NotBlank(message = "Employee ID is required")
+    val employeeId: String,
+    @field:NotBlank(message = "Leave type ID is required")
+    val leaveTypeId: String,
+    @field:NotNull(message = "Start date is required")
+    val startDate: LocalDate?,
+    @field:NotNull(message = "End date is required")
+    val endDate: LocalDate?,
+    val reason: String? = null,
+)
+
+data class RejectLeaveRequestRequest(
+    val reason: String? = null,
+)
+
+data class LeaveRequestResponse(
+    val id: String,
+    val employeeId: String,
+    val leaveTypeId: String,
+    val startDate: String,
+    val endDate: String,
+    val days: Int,
+    val reason: String?,
+    val status: LeaveRequestStatus,
+    val decisionReason: String?,
+    val decidedBy: String?,
+    val decidedAt: String?,
+    val organizationId: String,
+    val requestedBy: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(request: LeaveRequest) =
+            LeaveRequestResponse(
+                id = request.id,
+                employeeId = request.employeeId,
+                leaveTypeId = request.leaveTypeId,
+                startDate = request.startDate.toString(),
+                endDate = request.endDate.toString(),
+                days = request.days,
+                reason = request.reason,
+                status = request.status,
+                decisionReason = request.decisionReason,
+                decidedBy = request.decidedBy,
+                decidedAt = request.decidedAt?.toString(),
+                organizationId = request.organizationId,
+                requestedBy = request.requestedBy,
+                createdAt = request.createdAt?.toString(),
+                updatedAt = request.updatedAt?.toString(),
+            )
+    }
+}
+
+data class LeaveBalanceResponse(
+    val employeeId: String,
+    val leaveTypeId: String,
+    val year: Int,
+    val entitlementDays: Int,
+    val usedDays: Int,
+    val remainingDays: Int,
+)

--- a/src/main/kotlin/com/loom/synectix/dto/LeaveTypeDtos.kt
+++ b/src/main/kotlin/com/loom/synectix/dto/LeaveTypeDtos.kt
@@ -1,0 +1,51 @@
+package com.loom.synectix.dto
+
+import com.loom.synectix.model.LeaveType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.PositiveOrZero
+import jakarta.validation.constraints.Size
+
+data class CreateLeaveTypeRequest(
+    @field:NotBlank(message = "Code is required")
+    @field:Size(max = 32, message = "Code must be 32 characters or fewer")
+    val code: String,
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    val paid: Boolean = true,
+    @field:PositiveOrZero(message = "Default annual days must be zero or positive")
+    val defaultAnnualDays: Int = 0,
+)
+
+data class UpdateLeaveTypeRequest(
+    val name: String? = null,
+    val paid: Boolean? = null,
+    @field:PositiveOrZero(message = "Default annual days must be zero or positive")
+    val defaultAnnualDays: Int? = null,
+)
+
+data class LeaveTypeResponse(
+    val id: String,
+    val code: String,
+    val name: String,
+    val paid: Boolean,
+    val defaultAnnualDays: Int,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(leaveType: LeaveType) =
+            LeaveTypeResponse(
+                id = leaveType.id,
+                code = leaveType.code,
+                name = leaveType.name,
+                paid = leaveType.paid,
+                defaultAnnualDays = leaveType.defaultAnnualDays,
+                organizationId = leaveType.organizationId,
+                isActive = leaveType.isActive,
+                createdAt = leaveType.createdAt?.toString(),
+                updatedAt = leaveType.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/dto/PositionDtos.kt
+++ b/src/main/kotlin/com/loom/synectix/dto/PositionDtos.kt
@@ -1,0 +1,48 @@
+package com.loom.synectix.dto
+
+import com.loom.synectix.model.Position
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreatePositionRequest(
+    @field:NotBlank(message = "Code is required")
+    @field:Size(max = 32, message = "Code must be 32 characters or fewer")
+    val code: String,
+    @field:NotBlank(message = "Title is required")
+    val title: String,
+    val departmentId: String? = null,
+    val payGrade: String? = null,
+)
+
+data class UpdatePositionRequest(
+    val title: String? = null,
+    val departmentId: String? = null,
+    val payGrade: String? = null,
+)
+
+data class PositionResponse(
+    val id: String,
+    val code: String,
+    val title: String,
+    val departmentId: String?,
+    val payGrade: String?,
+    val organizationId: String,
+    val isActive: Boolean,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(position: Position) =
+            PositionResponse(
+                id = position.id,
+                code = position.code,
+                title = position.title,
+                departmentId = position.departmentId,
+                payGrade = position.payGrade,
+                organizationId = position.organizationId,
+                isActive = position.isActive,
+                createdAt = position.createdAt?.toString(),
+                updatedAt = position.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/model/Department.kt
+++ b/src/main/kotlin/com/loom/synectix/model/Department.kt
@@ -1,0 +1,34 @@
+package com.loom.synectix.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "departments")
+@EntityListeners(AuditingEntityListener::class)
+data class Department(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    val code: String,
+    val name: String,
+    val description: String? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Column(name = "is_active")
+    val isActive: Boolean = true,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/loom/synectix/model/Employee.kt
+++ b/src/main/kotlin/com/loom/synectix/model/Employee.kt
@@ -1,0 +1,55 @@
+package com.loom.synectix.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class EmploymentStatus {
+    ACTIVE,
+    ON_LEAVE,
+    TERMINATED,
+}
+
+@Entity
+@Table(name = "employees")
+@EntityListeners(AuditingEntityListener::class)
+data class Employee(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "employee_number")
+    val employeeNumber: String,
+    @Column(name = "first_name")
+    val firstName: String,
+    @Column(name = "last_name")
+    val lastName: String,
+    val email: String? = null,
+    @Column(name = "job_title")
+    val jobTitle: String? = null,
+    @Column(name = "department_id", columnDefinition = "uuid")
+    val departmentId: String? = null,
+    @Column(name = "hire_date")
+    val hireDate: LocalDate,
+    @Enumerated(EnumType.STRING)
+    val status: EmploymentStatus = EmploymentStatus.ACTIVE,
+    @Column(name = "termination_date")
+    val terminationDate: LocalDate? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/loom/synectix/model/EmployeeCompensation.kt
+++ b/src/main/kotlin/com/loom/synectix/model/EmployeeCompensation.kt
@@ -1,0 +1,49 @@
+package com.loom.synectix.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class PayPeriod {
+    ANNUAL,
+    MONTHLY,
+    HOURLY,
+}
+
+@Entity
+@Table(name = "employee_compensation")
+@EntityListeners(AuditingEntityListener::class)
+data class EmployeeCompensation(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "employee_id", columnDefinition = "uuid")
+    val employeeId: String,
+    @Column(name = "position_id", columnDefinition = "uuid")
+    val positionId: String? = null,
+    @Column(name = "pay_rate")
+    val payRate: BigDecimal,
+    val currency: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pay_period")
+    val payPeriod: PayPeriod,
+    @Column(name = "effective_date")
+    val effectiveDate: LocalDate,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Column(name = "created_by", columnDefinition = "uuid")
+    val createdBy: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/loom/synectix/model/LeaveRequest.kt
+++ b/src/main/kotlin/com/loom/synectix/model/LeaveRequest.kt
@@ -1,0 +1,59 @@
+package com.loom.synectix.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class LeaveRequestStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    CANCELLED,
+}
+
+@Entity
+@Table(name = "leave_requests")
+@EntityListeners(AuditingEntityListener::class)
+data class LeaveRequest(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "employee_id", columnDefinition = "uuid")
+    val employeeId: String,
+    @Column(name = "leave_type_id", columnDefinition = "uuid")
+    val leaveTypeId: String,
+    @Column(name = "start_date")
+    val startDate: LocalDate,
+    @Column(name = "end_date")
+    val endDate: LocalDate,
+    val days: Int,
+    val reason: String? = null,
+    @Enumerated(EnumType.STRING)
+    val status: LeaveRequestStatus = LeaveRequestStatus.PENDING,
+    @Column(name = "decision_reason")
+    val decisionReason: String? = null,
+    @Column(name = "decided_by", columnDefinition = "uuid")
+    val decidedBy: String? = null,
+    @Column(name = "decided_at")
+    val decidedAt: LocalDateTime? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Column(name = "requested_by", columnDefinition = "uuid")
+    val requestedBy: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/loom/synectix/model/LeaveType.kt
+++ b/src/main/kotlin/com/loom/synectix/model/LeaveType.kt
@@ -1,0 +1,36 @@
+package com.loom.synectix.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "leave_types")
+@EntityListeners(AuditingEntityListener::class)
+data class LeaveType(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    val code: String,
+    val name: String,
+    val paid: Boolean = true,
+    @Column(name = "default_annual_days")
+    val defaultAnnualDays: Int = 0,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Column(name = "is_active")
+    val isActive: Boolean = true,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/loom/synectix/model/Position.kt
+++ b/src/main/kotlin/com/loom/synectix/model/Position.kt
@@ -1,0 +1,37 @@
+package com.loom.synectix.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "positions")
+@EntityListeners(AuditingEntityListener::class)
+data class Position(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    val code: String,
+    val title: String,
+    @Column(name = "department_id", columnDefinition = "uuid")
+    val departmentId: String? = null,
+    @Column(name = "pay_grade")
+    val payGrade: String? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Column(name = "is_active")
+    val isActive: Boolean = true,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/loom/synectix/repository/DepartmentRepository.kt
+++ b/src/main/kotlin/com/loom/synectix/repository/DepartmentRepository.kt
@@ -1,0 +1,21 @@
+package com.loom.synectix.repository
+
+import com.loom.synectix.model.Department
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface DepartmentRepository : JpaRepository<Department, String> {
+    fun findByOrganizationId(organizationId: String): List<Department>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Department>
+
+    fun findByOrganizationIdAndCode(
+        organizationId: String,
+        code: String,
+    ): Optional<Department>
+}

--- a/src/main/kotlin/com/loom/synectix/repository/EmployeeCompensationRepository.kt
+++ b/src/main/kotlin/com/loom/synectix/repository/EmployeeCompensationRepository.kt
@@ -1,0 +1,13 @@
+package com.loom.synectix.repository
+
+import com.loom.synectix.model.EmployeeCompensation
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface EmployeeCompensationRepository : JpaRepository<EmployeeCompensation, String> {
+    fun findByOrganizationIdAndEmployeeIdOrderByEffectiveDateDesc(
+        organizationId: String,
+        employeeId: String,
+    ): List<EmployeeCompensation>
+}

--- a/src/main/kotlin/com/loom/synectix/repository/EmployeeRepository.kt
+++ b/src/main/kotlin/com/loom/synectix/repository/EmployeeRepository.kt
@@ -1,0 +1,23 @@
+package com.loom.synectix.repository
+
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface EmployeeRepository : JpaRepository<Employee, String> {
+    fun findByOrganizationId(organizationId: String): List<Employee>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: EmploymentStatus,
+    ): List<Employee>
+
+    fun findByOrganizationIdAndDepartmentId(
+        organizationId: String,
+        departmentId: String,
+    ): List<Employee>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/loom/synectix/repository/LeaveRequestRepository.kt
+++ b/src/main/kotlin/com/loom/synectix/repository/LeaveRequestRepository.kt
@@ -1,0 +1,28 @@
+package com.loom.synectix.repository
+
+import com.loom.synectix.model.LeaveRequest
+import com.loom.synectix.model.LeaveRequestStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface LeaveRequestRepository : JpaRepository<LeaveRequest, String> {
+    fun findByOrganizationId(organizationId: String): List<LeaveRequest>
+
+    fun findByOrganizationIdAndEmployeeId(
+        organizationId: String,
+        employeeId: String,
+    ): List<LeaveRequest>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: LeaveRequestStatus,
+    ): List<LeaveRequest>
+
+    fun findByOrganizationIdAndEmployeeIdAndLeaveTypeIdAndStatus(
+        organizationId: String,
+        employeeId: String,
+        leaveTypeId: String,
+        status: LeaveRequestStatus,
+    ): List<LeaveRequest>
+}

--- a/src/main/kotlin/com/loom/synectix/repository/LeaveTypeRepository.kt
+++ b/src/main/kotlin/com/loom/synectix/repository/LeaveTypeRepository.kt
@@ -1,0 +1,21 @@
+package com.loom.synectix.repository
+
+import com.loom.synectix.model.LeaveType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface LeaveTypeRepository : JpaRepository<LeaveType, String> {
+    fun findByOrganizationId(organizationId: String): List<LeaveType>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<LeaveType>
+
+    fun findByOrganizationIdAndCode(
+        organizationId: String,
+        code: String,
+    ): Optional<LeaveType>
+}

--- a/src/main/kotlin/com/loom/synectix/repository/PositionRepository.kt
+++ b/src/main/kotlin/com/loom/synectix/repository/PositionRepository.kt
@@ -1,0 +1,21 @@
+package com.loom.synectix.repository
+
+import com.loom.synectix.model.Position
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface PositionRepository : JpaRepository<Position, String> {
+    fun findByOrganizationId(organizationId: String): List<Position>
+
+    fun findByOrganizationIdAndIsActive(
+        organizationId: String,
+        isActive: Boolean,
+    ): List<Position>
+
+    fun findByOrganizationIdAndCode(
+        organizationId: String,
+        code: String,
+    ): Optional<Position>
+}

--- a/src/main/kotlin/com/loom/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/loom/synectix/security/Permissions.kt
@@ -55,6 +55,9 @@ object Permissions {
     const val INVENTORY_READ = "inventory:read"
     const val INVENTORY_WRITE = "inventory:write"
 
+    const val HR_READ = "hr:read"
+    const val HR_WRITE = "hr:write"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -97,5 +100,7 @@ object Permissions {
             FX_CREATE,
             INVENTORY_READ,
             INVENTORY_WRITE,
+            HR_READ,
+            HR_WRITE,
         )
 }

--- a/src/main/kotlin/com/loom/synectix/security/Permissions.kt
+++ b/src/main/kotlin/com/loom/synectix/security/Permissions.kt
@@ -57,6 +57,7 @@ object Permissions {
 
     const val HR_READ = "hr:read"
     const val HR_WRITE = "hr:write"
+    const val HR_APPROVE = "hr:approve"
 
     val ALL_PERMISSIONS =
         listOf(
@@ -102,5 +103,6 @@ object Permissions {
             INVENTORY_WRITE,
             HR_READ,
             HR_WRITE,
+            HR_APPROVE,
         )
 }

--- a/src/main/kotlin/com/loom/synectix/service/DepartmentService.kt
+++ b/src/main/kotlin/com/loom/synectix/service/DepartmentService.kt
@@ -1,0 +1,85 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateDepartmentRequest
+import com.loom.synectix.dto.UpdateDepartmentRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.Department
+import com.loom.synectix.repository.DepartmentRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DepartmentService(
+    private val departmentRepository: DepartmentRepository,
+) {
+    @Transactional
+    fun createDepartment(
+        request: CreateDepartmentRequest,
+        organizationId: String,
+    ): Department {
+        val code = request.code.trim()
+        if (departmentRepository.findByOrganizationIdAndCode(organizationId, code).isPresent) {
+            throw BusinessRuleException("Department code '$code' already exists")
+        }
+        return departmentRepository.save(
+            Department(
+                code = code,
+                name = request.name.trim(),
+                description = request.description,
+                organizationId = organizationId,
+            ),
+        )
+    }
+
+    fun getDepartment(
+        id: String,
+        organizationId: String,
+    ): Department {
+        val department =
+            departmentRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Department not found")
+            }
+        if (department.organizationId != organizationId) {
+            throw ResourceNotFoundException("Department not found")
+        }
+        return department
+    }
+
+    fun listDepartments(
+        organizationId: String,
+        activeOnly: Boolean = false,
+    ): List<Department> =
+        if (activeOnly) {
+            departmentRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        } else {
+            departmentRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateDepartment(
+        id: String,
+        request: UpdateDepartmentRequest,
+        organizationId: String,
+    ): Department {
+        val department = getDepartment(id, organizationId)
+        return departmentRepository.save(
+            department.copy(
+                name = request.name?.trim() ?: department.name,
+                description = request.description ?: department.description,
+            ),
+        )
+    }
+
+    @Transactional
+    fun deactivateDepartment(
+        id: String,
+        organizationId: String,
+    ): Department {
+        val department = getDepartment(id, organizationId)
+        if (!department.isActive) {
+            throw BusinessRuleException("Department is already inactive")
+        }
+        return departmentRepository.save(department.copy(isActive = false))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/service/EmployeeCompensationService.kt
+++ b/src/main/kotlin/com/loom/synectix/service/EmployeeCompensationService.kt
@@ -1,0 +1,68 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateEmployeeCompensationRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.EmployeeCompensation
+import com.loom.synectix.repository.EmployeeCompensationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class EmployeeCompensationService(
+    private val compensationRepository: EmployeeCompensationRepository,
+    private val employeeService: EmployeeService,
+    private val positionService: PositionService,
+    private val currencyService: CurrencyService,
+) {
+    @Transactional
+    fun addCompensation(
+        employeeId: String,
+        request: CreateEmployeeCompensationRequest,
+        organizationId: String,
+        createdBy: String,
+    ): EmployeeCompensation {
+        val employee = employeeService.getEmployee(employeeId, organizationId)
+        val payRate = request.payRate ?: throw BusinessRuleException("Pay rate is required")
+        val payPeriod = request.payPeriod ?: throw BusinessRuleException("Pay period is required")
+        val effectiveDate = request.effectiveDate ?: throw BusinessRuleException("Effective date is required")
+        val currency = request.currency.uppercase()
+        currencyService.getCurrency(currency)
+        request.positionId?.let { positionService.getPosition(it, organizationId) }
+
+        return compensationRepository.save(
+            EmployeeCompensation(
+                employeeId = employee.id,
+                positionId = request.positionId,
+                payRate = payRate,
+                currency = currency,
+                payPeriod = payPeriod,
+                effectiveDate = effectiveDate,
+                organizationId = organizationId,
+                createdBy = createdBy,
+            ),
+        )
+    }
+
+    fun listCompensation(
+        employeeId: String,
+        organizationId: String,
+    ): List<EmployeeCompensation> {
+        employeeService.getEmployee(employeeId, organizationId)
+        return compensationRepository.findByOrganizationIdAndEmployeeIdOrderByEffectiveDateDesc(organizationId, employeeId)
+    }
+
+    /** The compensation record in effect on [asOf] — the latest with effectiveDate on or before it. */
+    fun currentCompensation(
+        employeeId: String,
+        organizationId: String,
+        asOf: LocalDate,
+    ): EmployeeCompensation {
+        employeeService.getEmployee(employeeId, organizationId)
+        return compensationRepository
+            .findByOrganizationIdAndEmployeeIdOrderByEffectiveDateDesc(organizationId, employeeId)
+            .firstOrNull { !it.effectiveDate.isAfter(asOf) }
+            ?: throw ResourceNotFoundException("No compensation effective on or before $asOf for this employee")
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/service/EmployeeService.kt
+++ b/src/main/kotlin/com/loom/synectix/service/EmployeeService.kt
@@ -1,0 +1,167 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateEmployeeRequest
+import com.loom.synectix.dto.UpdateEmployeeRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.repository.EmployeeRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class EmployeeService(
+    private val employeeRepository: EmployeeRepository,
+    private val departmentService: DepartmentService,
+) {
+    @Transactional
+    fun createEmployee(
+        request: CreateEmployeeRequest,
+        organizationId: String,
+    ): Employee {
+        val hireDate = request.hireDate ?: throw BusinessRuleException("Hire date is required")
+        request.departmentId?.let { requireActiveDepartment(it, organizationId) }
+        return saveWithRetry(organizationId) { number ->
+            Employee(
+                employeeNumber = number,
+                firstName = request.firstName.trim(),
+                lastName = request.lastName.trim(),
+                email = request.email?.trim(),
+                jobTitle = request.jobTitle?.trim(),
+                departmentId = request.departmentId,
+                hireDate = hireDate,
+                organizationId = organizationId,
+            )
+        }
+    }
+
+    fun getEmployee(
+        id: String,
+        organizationId: String,
+    ): Employee {
+        val employee =
+            employeeRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Employee not found")
+            }
+        if (employee.organizationId != organizationId) {
+            throw ResourceNotFoundException("Employee not found")
+        }
+        return employee
+    }
+
+    fun listEmployees(
+        organizationId: String,
+        status: EmploymentStatus? = null,
+        departmentId: String? = null,
+    ): List<Employee> =
+        when {
+            status != null -> employeeRepository.findByOrganizationIdAndStatus(organizationId, status)
+            departmentId != null -> employeeRepository.findByOrganizationIdAndDepartmentId(organizationId, departmentId)
+            else -> employeeRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateEmployee(
+        id: String,
+        request: UpdateEmployeeRequest,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        return employeeRepository.save(
+            employee.copy(
+                firstName = request.firstName?.trim() ?: employee.firstName,
+                lastName = request.lastName?.trim() ?: employee.lastName,
+                email = request.email?.trim() ?: employee.email,
+                jobTitle = request.jobTitle?.trim() ?: employee.jobTitle,
+            ),
+        )
+    }
+
+    @Transactional
+    fun assignDepartment(
+        id: String,
+        departmentId: String?,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        if (employee.status == EmploymentStatus.TERMINATED) {
+            throw BusinessRuleException("Cannot reassign a terminated employee")
+        }
+        departmentId?.let { requireActiveDepartment(it, organizationId) }
+        return employeeRepository.save(employee.copy(departmentId = departmentId))
+    }
+
+    @Transactional
+    fun placeOnLeave(
+        id: String,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        if (employee.status != EmploymentStatus.ACTIVE) {
+            throw BusinessRuleException("Only active employees can be placed on leave")
+        }
+        return employeeRepository.save(employee.copy(status = EmploymentStatus.ON_LEAVE))
+    }
+
+    @Transactional
+    fun returnFromLeave(
+        id: String,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        if (employee.status != EmploymentStatus.ON_LEAVE) {
+            throw BusinessRuleException("Only employees on leave can return")
+        }
+        return employeeRepository.save(employee.copy(status = EmploymentStatus.ACTIVE))
+    }
+
+    @Transactional
+    fun terminate(
+        id: String,
+        terminationDate: LocalDate,
+        organizationId: String,
+    ): Employee {
+        val employee = getEmployee(id, organizationId)
+        if (employee.status == EmploymentStatus.TERMINATED) {
+            throw BusinessRuleException("Employee is already terminated")
+        }
+        if (terminationDate.isBefore(employee.hireDate)) {
+            throw BusinessRuleException("Termination date cannot be before the hire date")
+        }
+        return employeeRepository.save(
+            employee.copy(status = EmploymentStatus.TERMINATED, terminationDate = terminationDate),
+        )
+    }
+
+    private fun requireActiveDepartment(
+        departmentId: String,
+        organizationId: String,
+    ) {
+        val department = departmentService.getDepartment(departmentId, organizationId)
+        if (!department.isActive) {
+            throw BusinessRuleException("Department '${department.code}' is inactive")
+        }
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        build: (String) -> Employee,
+    ): Employee {
+        repeat(maxRetries) { attempt ->
+            val count = employeeRepository.countByOrganizationId(organizationId)
+            val number = "EMP-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return employeeRepository.save(build(number))
+            } catch (e: DuplicateKeyException) {
+                if (attempt == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique employee number: $number", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique employee number")
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/service/LeaveRequestService.kt
+++ b/src/main/kotlin/com/loom/synectix/service/LeaveRequestService.kt
@@ -1,0 +1,194 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateLeaveRequestRequest
+import com.loom.synectix.dto.LeaveBalanceResponse
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.model.LeaveRequest
+import com.loom.synectix.model.LeaveRequestStatus
+import com.loom.synectix.repository.LeaveRequestRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+
+@Service
+class LeaveRequestService(
+    private val leaveRequestRepository: LeaveRequestRepository,
+    private val employeeService: EmployeeService,
+    private val leaveTypeService: LeaveTypeService,
+) {
+    @Transactional
+    fun createLeaveRequest(
+        request: CreateLeaveRequestRequest,
+        organizationId: String,
+        requestedBy: String,
+    ): LeaveRequest {
+        val start = request.startDate ?: throw BusinessRuleException("Start date is required")
+        val end = request.endDate ?: throw BusinessRuleException("End date is required")
+        if (end.isBefore(start)) {
+            throw BusinessRuleException("End date must be on or after the start date")
+        }
+        val employee = employeeService.getEmployee(request.employeeId, organizationId)
+        if (employee.status == EmploymentStatus.TERMINATED) {
+            throw BusinessRuleException("Cannot request leave for a terminated employee")
+        }
+        val leaveType = leaveTypeService.getLeaveType(request.leaveTypeId, organizationId)
+        if (!leaveType.isActive) {
+            throw BusinessRuleException("Leave type '${leaveType.code}' is inactive")
+        }
+
+        return leaveRequestRepository.save(
+            LeaveRequest(
+                employeeId = employee.id,
+                leaveTypeId = leaveType.id,
+                startDate = start,
+                endDate = end,
+                days = dayCount(start, end),
+                reason = request.reason,
+                organizationId = organizationId,
+                requestedBy = requestedBy,
+            ),
+        )
+    }
+
+    fun getLeaveRequest(
+        id: String,
+        organizationId: String,
+    ): LeaveRequest {
+        val req =
+            leaveRequestRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Leave request not found")
+            }
+        if (req.organizationId != organizationId) {
+            throw ResourceNotFoundException("Leave request not found")
+        }
+        return req
+    }
+
+    fun listLeaveRequests(
+        organizationId: String,
+        employeeId: String? = null,
+        status: LeaveRequestStatus? = null,
+    ): List<LeaveRequest> =
+        when {
+            employeeId != null -> leaveRequestRepository.findByOrganizationIdAndEmployeeId(organizationId, employeeId)
+            status != null -> leaveRequestRepository.findByOrganizationIdAndStatus(organizationId, status)
+            else -> leaveRequestRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun approveLeaveRequest(
+        id: String,
+        organizationId: String,
+        decidedBy: String,
+    ): LeaveRequest {
+        val req = getLeaveRequest(id, organizationId)
+        if (req.status != LeaveRequestStatus.PENDING) {
+            throw BusinessRuleException("Only pending leave requests can be approved")
+        }
+        val leaveType = leaveTypeService.getLeaveType(req.leaveTypeId, organizationId)
+        val year = req.startDate.year
+        val used = usedDays(organizationId, req.employeeId, req.leaveTypeId, year, excludingRequestId = req.id)
+        if (used + req.days > leaveType.defaultAnnualDays) {
+            throw BusinessRuleException(
+                "Insufficient ${leaveType.code} balance: ${leaveType.defaultAnnualDays - used} day(s) remaining, ${req.days} requested",
+            )
+        }
+
+        val approved =
+            leaveRequestRepository.save(
+                req.copy(
+                    status = LeaveRequestStatus.APPROVED,
+                    decidedBy = decidedBy,
+                    decidedAt = LocalDateTime.now(ZoneOffset.UTC),
+                ),
+            )
+
+        // If the leave covers today, reflect it on the employee record.
+        val today = LocalDate.now(ZoneOffset.UTC)
+        if (!today.isBefore(req.startDate) && !today.isAfter(req.endDate)) {
+            val employee = employeeService.getEmployee(req.employeeId, organizationId)
+            if (employee.status == EmploymentStatus.ACTIVE) {
+                employeeService.placeOnLeave(employee.id, organizationId)
+            }
+        }
+        return approved
+    }
+
+    @Transactional
+    fun rejectLeaveRequest(
+        id: String,
+        reason: String?,
+        organizationId: String,
+        decidedBy: String,
+    ): LeaveRequest {
+        val req = getLeaveRequest(id, organizationId)
+        if (req.status != LeaveRequestStatus.PENDING) {
+            throw BusinessRuleException("Only pending leave requests can be rejected")
+        }
+        return leaveRequestRepository.save(
+            req.copy(
+                status = LeaveRequestStatus.REJECTED,
+                decisionReason = reason,
+                decidedBy = decidedBy,
+                decidedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+
+    @Transactional
+    fun cancelLeaveRequest(
+        id: String,
+        organizationId: String,
+    ): LeaveRequest {
+        val req = getLeaveRequest(id, organizationId)
+        if (req.status != LeaveRequestStatus.PENDING && req.status != LeaveRequestStatus.APPROVED) {
+            throw BusinessRuleException("Only pending or approved leave requests can be cancelled")
+        }
+        return leaveRequestRepository.save(req.copy(status = LeaveRequestStatus.CANCELLED))
+    }
+
+    fun balance(
+        employeeId: String,
+        leaveTypeId: String,
+        year: Int,
+        organizationId: String,
+    ): LeaveBalanceResponse {
+        employeeService.getEmployee(employeeId, organizationId)
+        val leaveType = leaveTypeService.getLeaveType(leaveTypeId, organizationId)
+        val used = usedDays(organizationId, employeeId, leaveTypeId, year, excludingRequestId = null)
+        return LeaveBalanceResponse(
+            employeeId = employeeId,
+            leaveTypeId = leaveTypeId,
+            year = year,
+            entitlementDays = leaveType.defaultAnnualDays,
+            usedDays = used,
+            remainingDays = leaveType.defaultAnnualDays - used,
+        )
+    }
+
+    private fun usedDays(
+        organizationId: String,
+        employeeId: String,
+        leaveTypeId: String,
+        year: Int,
+        excludingRequestId: String?,
+    ): Int =
+        leaveRequestRepository
+            .findByOrganizationIdAndEmployeeIdAndLeaveTypeIdAndStatus(
+                organizationId,
+                employeeId,
+                leaveTypeId,
+                LeaveRequestStatus.APPROVED,
+            ).filter { it.id != excludingRequestId && it.startDate.year == year }
+            .sumOf { it.days }
+
+    private fun dayCount(
+        start: LocalDate,
+        end: LocalDate,
+    ): Int = (ChronoUnit.DAYS.between(start, end) + 1).toInt()
+}

--- a/src/main/kotlin/com/loom/synectix/service/LeaveTypeService.kt
+++ b/src/main/kotlin/com/loom/synectix/service/LeaveTypeService.kt
@@ -1,0 +1,87 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateLeaveTypeRequest
+import com.loom.synectix.dto.UpdateLeaveTypeRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.LeaveType
+import com.loom.synectix.repository.LeaveTypeRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LeaveTypeService(
+    private val leaveTypeRepository: LeaveTypeRepository,
+) {
+    @Transactional
+    fun createLeaveType(
+        request: CreateLeaveTypeRequest,
+        organizationId: String,
+    ): LeaveType {
+        val code = request.code.trim()
+        if (leaveTypeRepository.findByOrganizationIdAndCode(organizationId, code).isPresent) {
+            throw BusinessRuleException("Leave type code '$code' already exists")
+        }
+        return leaveTypeRepository.save(
+            LeaveType(
+                code = code,
+                name = request.name.trim(),
+                paid = request.paid,
+                defaultAnnualDays = request.defaultAnnualDays,
+                organizationId = organizationId,
+            ),
+        )
+    }
+
+    fun getLeaveType(
+        id: String,
+        organizationId: String,
+    ): LeaveType {
+        val leaveType =
+            leaveTypeRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Leave type not found")
+            }
+        if (leaveType.organizationId != organizationId) {
+            throw ResourceNotFoundException("Leave type not found")
+        }
+        return leaveType
+    }
+
+    fun listLeaveTypes(
+        organizationId: String,
+        activeOnly: Boolean = false,
+    ): List<LeaveType> =
+        if (activeOnly) {
+            leaveTypeRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        } else {
+            leaveTypeRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateLeaveType(
+        id: String,
+        request: UpdateLeaveTypeRequest,
+        organizationId: String,
+    ): LeaveType {
+        val leaveType = getLeaveType(id, organizationId)
+        return leaveTypeRepository.save(
+            leaveType.copy(
+                name = request.name?.trim() ?: leaveType.name,
+                paid = request.paid ?: leaveType.paid,
+                defaultAnnualDays = request.defaultAnnualDays ?: leaveType.defaultAnnualDays,
+            ),
+        )
+    }
+
+    @Transactional
+    fun deactivateLeaveType(
+        id: String,
+        organizationId: String,
+    ): LeaveType {
+        val leaveType = getLeaveType(id, organizationId)
+        if (!leaveType.isActive) {
+            throw BusinessRuleException("Leave type is already inactive")
+        }
+        return leaveTypeRepository.save(leaveType.copy(isActive = false))
+    }
+}

--- a/src/main/kotlin/com/loom/synectix/service/PositionService.kt
+++ b/src/main/kotlin/com/loom/synectix/service/PositionService.kt
@@ -1,0 +1,90 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreatePositionRequest
+import com.loom.synectix.dto.UpdatePositionRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.Position
+import com.loom.synectix.repository.PositionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PositionService(
+    private val positionRepository: PositionRepository,
+    private val departmentService: DepartmentService,
+) {
+    @Transactional
+    fun createPosition(
+        request: CreatePositionRequest,
+        organizationId: String,
+    ): Position {
+        val code = request.code.trim()
+        if (positionRepository.findByOrganizationIdAndCode(organizationId, code).isPresent) {
+            throw BusinessRuleException("Position code '$code' already exists")
+        }
+        request.departmentId?.let { departmentService.getDepartment(it, organizationId) }
+        return positionRepository.save(
+            Position(
+                code = code,
+                title = request.title.trim(),
+                departmentId = request.departmentId,
+                payGrade = request.payGrade?.trim(),
+                organizationId = organizationId,
+            ),
+        )
+    }
+
+    fun getPosition(
+        id: String,
+        organizationId: String,
+    ): Position {
+        val position =
+            positionRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Position not found")
+            }
+        if (position.organizationId != organizationId) {
+            throw ResourceNotFoundException("Position not found")
+        }
+        return position
+    }
+
+    fun listPositions(
+        organizationId: String,
+        activeOnly: Boolean = false,
+    ): List<Position> =
+        if (activeOnly) {
+            positionRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        } else {
+            positionRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updatePosition(
+        id: String,
+        request: UpdatePositionRequest,
+        organizationId: String,
+    ): Position {
+        val position = getPosition(id, organizationId)
+        request.departmentId?.let { departmentService.getDepartment(it, organizationId) }
+        return positionRepository.save(
+            position.copy(
+                title = request.title?.trim() ?: position.title,
+                departmentId = request.departmentId ?: position.departmentId,
+                payGrade = request.payGrade?.trim() ?: position.payGrade,
+            ),
+        )
+    }
+
+    @Transactional
+    fun deactivatePosition(
+        id: String,
+        organizationId: String,
+    ): Position {
+        val position = getPosition(id, organizationId)
+        if (!position.isActive) {
+            throw BusinessRuleException("Position is already inactive")
+        }
+        return positionRepository.save(position.copy(isActive = false))
+    }
+}

--- a/src/main/resources/db/migration/V0003__hr_departments.sql
+++ b/src/main/resources/db/migration/V0003__hr_departments.sql
@@ -1,0 +1,13 @@
+-- HR module: departments.
+CREATE TABLE departments (
+    id                uuid PRIMARY KEY,
+    code              text NOT NULL,
+    name              text NOT NULL,
+    description       text,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    is_active         boolean NOT NULL DEFAULT true,
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT departments_unique_code_per_org UNIQUE (organization_id, code)
+);
+CREATE INDEX departments_org_active_idx ON departments(organization_id, is_active);

--- a/src/main/resources/db/migration/V0004__hr_employees.sql
+++ b/src/main/resources/db/migration/V0004__hr_employees.sql
@@ -1,0 +1,20 @@
+-- HR module: employees.
+CREATE TABLE employees (
+    id                uuid PRIMARY KEY,
+    employee_number   text NOT NULL,
+    first_name        text NOT NULL,
+    last_name         text NOT NULL,
+    email             text,
+    job_title         text,
+    department_id     uuid REFERENCES departments(id) ON DELETE SET NULL,
+    hire_date         date NOT NULL,
+    status            text NOT NULL DEFAULT 'ACTIVE',
+    termination_date  date,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT employees_status_chk CHECK (status IN ('ACTIVE','ON_LEAVE','TERMINATED')),
+    CONSTRAINT employees_unique_number_per_org UNIQUE (organization_id, employee_number)
+);
+CREATE INDEX employees_org_status_idx ON employees(organization_id, status);
+CREATE INDEX employees_org_department_idx ON employees(organization_id, department_id);

--- a/src/main/resources/db/migration/V0005__hr_leave_types.sql
+++ b/src/main/resources/db/migration/V0005__hr_leave_types.sql
@@ -1,0 +1,14 @@
+-- HR module: leave types.
+CREATE TABLE leave_types (
+    id                  uuid PRIMARY KEY,
+    code                text NOT NULL,
+    name                text NOT NULL,
+    paid                boolean NOT NULL DEFAULT true,
+    default_annual_days int NOT NULL DEFAULT 0,
+    organization_id     uuid NOT NULL REFERENCES organizations(uuid),
+    is_active           boolean NOT NULL DEFAULT true,
+    created_at          timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at          timestamp,
+    CONSTRAINT leave_types_unique_code_per_org UNIQUE (organization_id, code)
+);
+CREATE INDEX leave_types_org_active_idx ON leave_types(organization_id, is_active);

--- a/src/main/resources/db/migration/V0006__hr_leave_requests.sql
+++ b/src/main/resources/db/migration/V0006__hr_leave_requests.sql
@@ -1,0 +1,21 @@
+-- HR module: leave requests.
+CREATE TABLE leave_requests (
+    id                uuid PRIMARY KEY,
+    employee_id       uuid NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+    leave_type_id     uuid NOT NULL REFERENCES leave_types(id) ON DELETE RESTRICT,
+    start_date        date NOT NULL,
+    end_date          date NOT NULL,
+    days              int NOT NULL,
+    reason            text,
+    status            text NOT NULL DEFAULT 'PENDING',
+    decision_reason   text,
+    decided_by        uuid REFERENCES users(uuid),
+    decided_at        timestamp,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    requested_by      uuid NOT NULL REFERENCES users(uuid),
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT leave_requests_status_chk CHECK (status IN ('PENDING','APPROVED','REJECTED','CANCELLED'))
+);
+CREATE INDEX leave_requests_org_employee_idx ON leave_requests(organization_id, employee_id);
+CREATE INDEX leave_requests_org_status_idx ON leave_requests(organization_id, status);

--- a/src/main/resources/db/migration/V0007__hr_positions.sql
+++ b/src/main/resources/db/migration/V0007__hr_positions.sql
@@ -1,0 +1,14 @@
+-- HR module: position / job catalog.
+CREATE TABLE positions (
+    id                uuid PRIMARY KEY,
+    code              text NOT NULL,
+    title             text NOT NULL,
+    department_id     uuid REFERENCES departments(id) ON DELETE SET NULL,
+    pay_grade         text,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    is_active         boolean NOT NULL DEFAULT true,
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT positions_unique_code_per_org UNIQUE (organization_id, code)
+);
+CREATE INDEX positions_org_active_idx ON positions(organization_id, is_active);

--- a/src/main/resources/db/migration/V0008__hr_employee_compensation.sql
+++ b/src/main/resources/db/migration/V0008__hr_employee_compensation.sql
@@ -1,0 +1,16 @@
+-- HR module: effective-dated employee compensation records.
+CREATE TABLE employee_compensation (
+    id                uuid PRIMARY KEY,
+    employee_id       uuid NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+    position_id       uuid REFERENCES positions(id) ON DELETE SET NULL,
+    pay_rate          numeric(18,4) NOT NULL,
+    currency          char(3) NOT NULL REFERENCES currencies(code),
+    pay_period        text NOT NULL,
+    effective_date    date NOT NULL,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    created_by        uuid NOT NULL REFERENCES users(uuid),
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    CONSTRAINT employee_compensation_pay_period_chk CHECK (pay_period IN ('ANNUAL','MONTHLY','HOURLY'))
+);
+CREATE INDEX employee_compensation_org_employee_idx
+    ON employee_compensation(organization_id, employee_id, effective_date DESC);

--- a/src/test/kotlin/com/loom/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/loom/synectix/config/RoleSeederTest.kt
@@ -93,6 +93,8 @@ class RoleSeederTest {
                         Permissions.FX_CREATE,
                         Permissions.INVENTORY_READ,
                         Permissions.INVENTORY_WRITE,
+                        Permissions.HR_READ,
+                        Permissions.HR_WRITE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -286,6 +288,8 @@ class RoleSeederTest {
                         Permissions.FX_CREATE,
                         Permissions.INVENTORY_READ,
                         Permissions.INVENTORY_WRITE,
+                        Permissions.HR_READ,
+                        Permissions.HR_WRITE,
                     ),
             )
         val admin =
@@ -328,6 +332,8 @@ class RoleSeederTest {
                         Permissions.FX_CREATE,
                         Permissions.INVENTORY_READ,
                         Permissions.INVENTORY_WRITE,
+                        Permissions.HR_READ,
+                        Permissions.HR_WRITE,
                     ),
             )
         val member =
@@ -354,6 +360,8 @@ class RoleSeederTest {
                         Permissions.FX_READ,
                         Permissions.INVENTORY_READ,
                         Permissions.INVENTORY_WRITE,
+                        Permissions.HR_READ,
+                        Permissions.HR_WRITE,
                     ),
             )
         val viewer =
@@ -373,6 +381,7 @@ class RoleSeederTest {
                         Permissions.TAX_READ,
                         Permissions.FX_READ,
                         Permissions.INVENTORY_READ,
+                        Permissions.HR_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/loom/synectix/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/loom/synectix/config/RoleSeederTest.kt
@@ -95,6 +95,7 @@ class RoleSeederTest {
                         Permissions.INVENTORY_WRITE,
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
+                        Permissions.HR_APPROVE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -290,6 +291,7 @@ class RoleSeederTest {
                         Permissions.INVENTORY_WRITE,
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
+                        Permissions.HR_APPROVE,
                     ),
             )
         val admin =
@@ -334,6 +336,7 @@ class RoleSeederTest {
                         Permissions.INVENTORY_WRITE,
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
+                        Permissions.HR_APPROVE,
                     ),
             )
         val member =

--- a/src/test/kotlin/com/loom/synectix/service/DepartmentServiceTest.kt
+++ b/src/test/kotlin/com/loom/synectix/service/DepartmentServiceTest.kt
@@ -1,0 +1,79 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateDepartmentRequest
+import com.loom.synectix.dto.UpdateDepartmentRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.Department
+import com.loom.synectix.repository.DepartmentRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+class DepartmentServiceTest {
+    private lateinit var repository: DepartmentRepository
+    private lateinit var service: DepartmentService
+
+    private val orgId = "org-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(DepartmentRepository::class.java)
+        whenever(repository.save(any<Department>())).thenAnswer { it.arguments[0] }
+        whenever(repository.findByOrganizationIdAndCode(any(), any())).thenReturn(Optional.empty())
+        service = DepartmentService(repository)
+    }
+
+    @Test
+    fun `create trims and persists an active department`() {
+        val dept = service.createDepartment(CreateDepartmentRequest(code = " ENG ", name = " Engineering "), orgId)
+
+        assertThat(dept.code).isEqualTo("ENG")
+        assertThat(dept.name).isEqualTo("Engineering")
+        assertThat(dept.isActive).isTrue()
+        assertThat(dept.organizationId).isEqualTo(orgId)
+    }
+
+    @Test
+    fun `create rejects a duplicate code`() {
+        whenever(repository.findByOrganizationIdAndCode(orgId, "ENG"))
+            .thenReturn(Optional.of(Department(code = "ENG", name = "Engineering", organizationId = orgId)))
+
+        assertThatThrownBy { service.createDepartment(CreateDepartmentRequest(code = "ENG", name = "Eng"), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("d1"))
+            .thenReturn(Optional.of(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = "other")))
+
+        assertThatThrownBy { service.getDepartment("d1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `update changes name and description only`() {
+        whenever(repository.findById("d1"))
+            .thenReturn(Optional.of(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId)))
+
+        val updated = service.updateDepartment("d1", UpdateDepartmentRequest(name = "R&D"), orgId)
+
+        assertThat(updated.name).isEqualTo("R&D")
+        assertThat(updated.code).isEqualTo("ENG")
+    }
+
+    @Test
+    fun `deactivate flips the active flag and rejects double-deactivation`() {
+        whenever(repository.findById("d1"))
+            .thenReturn(Optional.of(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId, isActive = false)))
+
+        assertThatThrownBy { service.deactivateDepartment("d1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+}

--- a/src/test/kotlin/com/loom/synectix/service/EmployeeCompensationServiceTest.kt
+++ b/src/test/kotlin/com/loom/synectix/service/EmployeeCompensationServiceTest.kt
@@ -1,0 +1,107 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateEmployeeCompensationRequest
+import com.loom.synectix.exception.ResourceNotFoundException
+import com.loom.synectix.model.Currency
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmployeeCompensation
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.model.PayPeriod
+import com.loom.synectix.repository.EmployeeCompensationRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class EmployeeCompensationServiceTest {
+    private lateinit var repository: EmployeeCompensationRepository
+    private lateinit var employeeService: EmployeeService
+    private lateinit var positionService: PositionService
+    private lateinit var currencyService: CurrencyService
+    private lateinit var service: EmployeeCompensationService
+
+    private val orgId = "org-1"
+    private val empId = "e1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(EmployeeCompensationRepository::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        positionService = mock(PositionService::class.java)
+        currencyService = mock(CurrencyService::class.java)
+        whenever(repository.save(any<EmployeeCompensation>())).thenAnswer { it.arguments[0] }
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(
+            Employee(
+                id = empId,
+                employeeNumber = "EMP-0001",
+                firstName = "Ada",
+                lastName = "Lovelace",
+                hireDate = LocalDate.of(2020, 1, 1),
+                status = EmploymentStatus.ACTIVE,
+                organizationId = orgId,
+            ),
+        )
+        whenever(currencyService.getCurrency(any())).thenReturn(Currency("USD", "US Dollar", "$", 2))
+        service = EmployeeCompensationService(repository, employeeService, positionService, currencyService)
+    }
+
+    private fun comp(
+        rate: String,
+        effective: LocalDate,
+    ) = EmployeeCompensation(
+        employeeId = empId,
+        payRate = BigDecimal(rate),
+        currency = "USD",
+        payPeriod = PayPeriod.ANNUAL,
+        effectiveDate = effective,
+        organizationId = orgId,
+        createdBy = "u1",
+    )
+
+    @Test
+    fun `add normalizes currency and persists`() {
+        val saved =
+            service.addCompensation(
+                empId,
+                CreateEmployeeCompensationRequest(
+                    payRate = BigDecimal("90000"),
+                    currency = "usd",
+                    payPeriod = PayPeriod.ANNUAL,
+                    effectiveDate = LocalDate.of(2026, 1, 1),
+                ),
+                orgId,
+                "u1",
+            )
+
+        assertThat(saved.currency).isEqualTo("USD")
+        assertThat(saved.payRate).isEqualByComparingTo("90000")
+    }
+
+    @Test
+    fun `current returns the latest record effective on or before the date`() {
+        whenever(repository.findByOrganizationIdAndEmployeeIdOrderByEffectiveDateDesc(orgId, empId))
+            .thenReturn(
+                listOf(
+                    comp("100000", LocalDate.of(2026, 1, 1)),
+                    comp("90000", LocalDate.of(2025, 1, 1)),
+                ),
+            )
+
+        val current = service.currentCompensation(empId, orgId, LocalDate.of(2025, 6, 1))
+        assertThat(current.payRate).isEqualByComparingTo("90000")
+    }
+
+    @Test
+    fun `current throws when no record is effective yet`() {
+        whenever(repository.findByOrganizationIdAndEmployeeIdOrderByEffectiveDateDesc(orgId, empId))
+            .thenReturn(listOf(comp("90000", LocalDate.of(2026, 1, 1))))
+
+        assertThatThrownBy { service.currentCompensation(empId, orgId, LocalDate.of(2025, 6, 1)) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}

--- a/src/test/kotlin/com/loom/synectix/service/EmployeeServiceTest.kt
+++ b/src/test/kotlin/com/loom/synectix/service/EmployeeServiceTest.kt
@@ -1,0 +1,104 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateEmployeeRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.model.Department
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.repository.EmployeeRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.util.Optional
+
+class EmployeeServiceTest {
+    private lateinit var repository: EmployeeRepository
+    private lateinit var departmentService: DepartmentService
+    private lateinit var service: EmployeeService
+
+    private val orgId = "org-1"
+    private val hireDate = LocalDate.of(2026, 1, 6)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(EmployeeRepository::class.java)
+        departmentService = mock(DepartmentService::class.java)
+        whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
+        whenever(repository.save(any<Employee>())).thenAnswer { it.arguments[0] }
+        service = EmployeeService(repository, departmentService)
+    }
+
+    private fun employee(
+        status: EmploymentStatus = EmploymentStatus.ACTIVE,
+        id: String = "e1",
+        org: String = orgId,
+    ) = Employee(
+        id = id,
+        employeeNumber = "EMP-0001",
+        firstName = "Ada",
+        lastName = "Lovelace",
+        hireDate = hireDate,
+        status = status,
+        organizationId = org,
+    )
+
+    @Test
+    fun `create assigns a number and starts ACTIVE`() {
+        val emp = service.createEmployee(CreateEmployeeRequest(firstName = "Ada", lastName = "Lovelace", hireDate = hireDate), orgId)
+
+        assertThat(emp.employeeNumber).isEqualTo("EMP-0001")
+        assertThat(emp.status).isEqualTo(EmploymentStatus.ACTIVE)
+    }
+
+    @Test
+    fun `create validates an inactive department`() {
+        whenever(departmentService.getDepartment("d1", orgId))
+            .thenReturn(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId, isActive = false))
+
+        assertThatThrownBy {
+            service.createEmployee(
+                CreateEmployeeRequest(firstName = "Ada", lastName = "Lovelace", departmentId = "d1", hireDate = hireDate),
+                orgId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `leave and return follow the lifecycle`() {
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee()))
+        assertThat(service.placeOnLeave("e1", orgId).status).isEqualTo(EmploymentStatus.ON_LEAVE)
+
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee(status = EmploymentStatus.ON_LEAVE)))
+        assertThat(service.returnFromLeave("e1", orgId).status).isEqualTo(EmploymentStatus.ACTIVE)
+    }
+
+    @Test
+    fun `cannot place a terminated employee on leave`() {
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee(status = EmploymentStatus.TERMINATED)))
+        assertThatThrownBy { service.placeOnLeave("e1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `terminate sets status and date and rejects a date before hire`() {
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee()))
+        val terminated = service.terminate("e1", LocalDate.of(2026, 6, 30), orgId)
+        assertThat(terminated.status).isEqualTo(EmploymentStatus.TERMINATED)
+        assertThat(terminated.terminationDate).isEqualTo(LocalDate.of(2026, 6, 30))
+
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee()))
+        assertThatThrownBy { service.terminate("e1", LocalDate.of(2025, 1, 1), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `assign department rejects a terminated employee`() {
+        whenever(repository.findById("e1")).thenReturn(Optional.of(employee(status = EmploymentStatus.TERMINATED)))
+        assertThatThrownBy { service.assignDepartment("e1", "d1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+}

--- a/src/test/kotlin/com/loom/synectix/service/LeaveRequestServiceTest.kt
+++ b/src/test/kotlin/com/loom/synectix/service/LeaveRequestServiceTest.kt
@@ -1,0 +1,151 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateLeaveRequestRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.model.Employee
+import com.loom.synectix.model.EmploymentStatus
+import com.loom.synectix.model.LeaveRequest
+import com.loom.synectix.model.LeaveRequestStatus
+import com.loom.synectix.model.LeaveType
+import com.loom.synectix.repository.LeaveRequestRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.util.Optional
+
+class LeaveRequestServiceTest {
+    private lateinit var repository: LeaveRequestRepository
+    private lateinit var employeeService: EmployeeService
+    private lateinit var leaveTypeService: LeaveTypeService
+    private lateinit var service: LeaveRequestService
+
+    private val orgId = "org-1"
+    private val empId = "e1"
+    private val typeId = "lt1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(LeaveRequestRepository::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        leaveTypeService = mock(LeaveTypeService::class.java)
+        whenever(repository.save(any<LeaveRequest>())).thenAnswer { it.arguments[0] }
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(employee())
+        whenever(leaveTypeService.getLeaveType(typeId, orgId)).thenReturn(leaveType(20))
+        whenever(
+            repository.findByOrganizationIdAndEmployeeIdAndLeaveTypeIdAndStatus(any(), any(), any(), any()),
+        ).thenReturn(emptyList())
+        service = LeaveRequestService(repository, employeeService, leaveTypeService)
+    }
+
+    private fun employee(status: EmploymentStatus = EmploymentStatus.ACTIVE) =
+        Employee(
+            id = empId,
+            employeeNumber = "EMP-0001",
+            firstName = "Ada",
+            lastName = "Lovelace",
+            hireDate = LocalDate.of(2020, 1, 1),
+            status = status,
+            organizationId = orgId,
+        )
+
+    private fun leaveType(annualDays: Int) =
+        LeaveType(id = typeId, code = "AL", name = "Annual", defaultAnnualDays = annualDays, organizationId = orgId)
+
+    private fun pending(
+        days: Int,
+        start: LocalDate = LocalDate.of(2020, 3, 2),
+    ) = LeaveRequest(
+        id = "lr1",
+        employeeId = empId,
+        leaveTypeId = typeId,
+        startDate = start,
+        endDate = start.plusDays((days - 1).toLong()),
+        days = days,
+        organizationId = orgId,
+        requestedBy = "u1",
+    )
+
+    @Test
+    fun `create computes the inclusive day count and starts PENDING`() {
+        val req =
+            service.createLeaveRequest(
+                CreateLeaveRequestRequest(
+                    employeeId = empId,
+                    leaveTypeId = typeId,
+                    startDate = LocalDate.of(2020, 3, 2),
+                    endDate = LocalDate.of(2020, 3, 6),
+                ),
+                orgId,
+                "u1",
+            )
+
+        assertThat(req.days).isEqualTo(5)
+        assertThat(req.status).isEqualTo(LeaveRequestStatus.PENDING)
+    }
+
+    @Test
+    fun `create rejects a terminated employee`() {
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(employee(EmploymentStatus.TERMINATED))
+
+        assertThatThrownBy {
+            service.createLeaveRequest(
+                CreateLeaveRequestRequest(empId, typeId, LocalDate.of(2020, 3, 2), LocalDate.of(2020, 3, 6)),
+                orgId,
+                "u1",
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `approve within entitlement marks APPROVED without touching past-dated employee status`() {
+        whenever(repository.findById("lr1")).thenReturn(Optional.of(pending(5)))
+
+        val approved = service.approveLeaveRequest("lr1", orgId, "mgr")
+
+        assertThat(approved.status).isEqualTo(LeaveRequestStatus.APPROVED)
+        assertThat(approved.decidedBy).isEqualTo("mgr")
+        // Past-dated leave does not flip employment status.
+        verify(employeeService, never()).placeOnLeave(any(), any())
+    }
+
+    @Test
+    fun `approve exceeding entitlement is rejected`() {
+        whenever(leaveTypeService.getLeaveType(typeId, orgId)).thenReturn(leaveType(3))
+        whenever(repository.findById("lr1")).thenReturn(Optional.of(pending(5)))
+
+        assertThatThrownBy { service.approveLeaveRequest("lr1", orgId, "mgr") }
+            .isInstanceOf(BusinessRuleException::class.java)
+        verify(repository, never()).save(any<LeaveRequest>())
+    }
+
+    @Test
+    fun `approving leave covering today places the employee on leave`() {
+        val today = LocalDate.now(java.time.ZoneOffset.UTC)
+        whenever(repository.findById("lr1")).thenReturn(Optional.of(pending(1, start = today)))
+
+        service.approveLeaveRequest("lr1", orgId, "mgr")
+
+        verify(employeeService).placeOnLeave(eq(empId), eq(orgId))
+    }
+
+    @Test
+    fun `balance reports entitlement minus approved used days`() {
+        whenever(
+            repository.findByOrganizationIdAndEmployeeIdAndLeaveTypeIdAndStatus(orgId, empId, typeId, LeaveRequestStatus.APPROVED),
+        ).thenReturn(listOf(pending(4).copy(status = LeaveRequestStatus.APPROVED)))
+
+        val balance = service.balance(empId, typeId, 2020, orgId)
+
+        assertThat(balance.entitlementDays).isEqualTo(20)
+        assertThat(balance.usedDays).isEqualTo(4)
+        assertThat(balance.remainingDays).isEqualTo(16)
+    }
+}

--- a/src/test/kotlin/com/loom/synectix/service/LeaveTypeServiceTest.kt
+++ b/src/test/kotlin/com/loom/synectix/service/LeaveTypeServiceTest.kt
@@ -1,0 +1,61 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreateLeaveTypeRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.model.LeaveType
+import com.loom.synectix.repository.LeaveTypeRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+class LeaveTypeServiceTest {
+    private lateinit var repository: LeaveTypeRepository
+    private lateinit var service: LeaveTypeService
+
+    private val orgId = "org-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(LeaveTypeRepository::class.java)
+        whenever(repository.save(any<LeaveType>())).thenAnswer { it.arguments[0] }
+        whenever(repository.findByOrganizationIdAndCode(any(), any())).thenReturn(Optional.empty())
+        service = LeaveTypeService(repository)
+    }
+
+    @Test
+    fun `create persists a leave type`() {
+        val lt =
+            service.createLeaveType(
+                CreateLeaveTypeRequest(code = " AL ", name = " Annual Leave ", paid = true, defaultAnnualDays = 20),
+                orgId,
+            )
+
+        assertThat(lt.code).isEqualTo("AL")
+        assertThat(lt.name).isEqualTo("Annual Leave")
+        assertThat(lt.defaultAnnualDays).isEqualTo(20)
+        assertThat(lt.isActive).isTrue()
+    }
+
+    @Test
+    fun `create rejects a duplicate code`() {
+        whenever(repository.findByOrganizationIdAndCode(orgId, "AL"))
+            .thenReturn(Optional.of(LeaveType(code = "AL", name = "Annual", organizationId = orgId)))
+
+        assertThatThrownBy { service.createLeaveType(CreateLeaveTypeRequest(code = "AL", name = "Annual"), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `deactivate rejects double-deactivation`() {
+        whenever(repository.findById("lt1"))
+            .thenReturn(Optional.of(LeaveType(id = "lt1", code = "AL", name = "Annual", organizationId = orgId, isActive = false)))
+
+        assertThatThrownBy { service.deactivateLeaveType("lt1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+}

--- a/src/test/kotlin/com/loom/synectix/service/PositionServiceTest.kt
+++ b/src/test/kotlin/com/loom/synectix/service/PositionServiceTest.kt
@@ -1,0 +1,67 @@
+package com.loom.synectix.service
+
+import com.loom.synectix.dto.CreatePositionRequest
+import com.loom.synectix.exception.BusinessRuleException
+import com.loom.synectix.model.Department
+import com.loom.synectix.model.Position
+import com.loom.synectix.repository.PositionRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+class PositionServiceTest {
+    private lateinit var repository: PositionRepository
+    private lateinit var departmentService: DepartmentService
+    private lateinit var service: PositionService
+
+    private val orgId = "org-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(PositionRepository::class.java)
+        departmentService = mock(DepartmentService::class.java)
+        whenever(repository.save(any<Position>())).thenAnswer { it.arguments[0] }
+        whenever(repository.findByOrganizationIdAndCode(any(), any())).thenReturn(Optional.empty())
+        service = PositionService(repository, departmentService)
+    }
+
+    @Test
+    fun `create persists a position and validates the department when provided`() {
+        whenever(departmentService.getDepartment("d1", orgId))
+            .thenReturn(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId))
+
+        val pos =
+            service.createPosition(
+                CreatePositionRequest(code = " SE2 ", title = " Software Engineer II ", departmentId = "d1", payGrade = "G5"),
+                orgId,
+            )
+
+        assertThat(pos.code).isEqualTo("SE2")
+        assertThat(pos.title).isEqualTo("Software Engineer II")
+        assertThat(pos.departmentId).isEqualTo("d1")
+        assertThat(pos.payGrade).isEqualTo("G5")
+    }
+
+    @Test
+    fun `create rejects a duplicate code`() {
+        whenever(repository.findByOrganizationIdAndCode(orgId, "SE2"))
+            .thenReturn(Optional.of(Position(code = "SE2", title = "SE II", organizationId = orgId)))
+
+        assertThatThrownBy { service.createPosition(CreatePositionRequest(code = "SE2", title = "SE II"), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `deactivate rejects double-deactivation`() {
+        whenever(repository.findById("p1"))
+            .thenReturn(Optional.of(Position(id = "p1", code = "SE2", title = "SE II", organizationId = orgId, isActive = false)))
+
+        assertThatThrownBy { service.deactivatePosition("p1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+}


### PR DESCRIPTION
Third HR slice (epic #145), the setup for the Payroll capstone. **Stacked on #150** (base `hr-timeoff`) — merge #148 → #150 → this. Two atomic commits. Closes #151.

## Commits
1. **Position / job catalog** (`/hr/positions`) — code unique per org, title, optional department, pay grade; CRUD + deactivate.
2. **Effective-dated employee compensation** (`/hr/employees/{id}/compensation`) — pay rate + currency + pay period (ANNUAL/MONTHLY/HOURLY), optional position link. **Append-only history** (no destructive edits); **current-compensation lookup** returns the latest record effective on or before a date. Currency is validated against the currencies table.

Migrations `V0007` (positions), `V0008` (employee_compensation).

## Test plan
- [x] compile + ktlint clean
- [x] `PositionServiceTest` — create + department validation, duplicate code, double-deactivate
- [x] `EmployeeCompensationServiceTest` — currency normalization, current-as-of selection, no-effective-record error
- [x] Postgres integration tests + V0007/V0008 migrations validated in CI

## Notes
- Effective-dated, append-only design deliberately preserves comp history (important for payroll + audit).
- This unlocks **Payroll → GL** (the capstone): a payroll run can read each employee's current compensation and post to the ledger. That's the next stacked slice.
- HR migration chain: V0003/V0004 (#148) → V0005/V0006 (#150) → V0007/V0008 (this).