### PR TITLE
feat(graphql): bridge purchase/sales orders + HR/payroll routes

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlController.kt
@@ -1,0 +1,296 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.DepartmentController
+import com.aquinofroilan.tessera.controller.EmployeeCompensationController
+import com.aquinofroilan.tessera.controller.EmployeeController
+import com.aquinofroilan.tessera.controller.LeaveRequestController
+import com.aquinofroilan.tessera.controller.LeaveTypeController
+import com.aquinofroilan.tessera.controller.PayrollRunController
+import com.aquinofroilan.tessera.controller.PositionController
+import com.aquinofroilan.tessera.dto.CreateDepartmentRequest
+import com.aquinofroilan.tessera.dto.CreateEmployeeCompensationRequest
+import com.aquinofroilan.tessera.dto.CreateEmployeeRequest
+import com.aquinofroilan.tessera.dto.CreateLeaveRequestRequest
+import com.aquinofroilan.tessera.dto.CreateLeaveTypeRequest
+import com.aquinofroilan.tessera.dto.CreatePayrollRunRequest
+import com.aquinofroilan.tessera.dto.CreatePositionRequest
+import com.aquinofroilan.tessera.dto.RejectLeaveRequestRequest
+import com.aquinofroilan.tessera.dto.TerminateEmployeeRequest
+import com.aquinofroilan.tessera.dto.UpdateDepartmentRequest
+import com.aquinofroilan.tessera.dto.UpdateEmployeeRequest
+import com.aquinofroilan.tessera.dto.UpdateLeaveTypeRequest
+import com.aquinofroilan.tessera.dto.UpdatePositionRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+import java.time.LocalDate
+
+/**
+ * GraphQL bridge for the HR routes — payroll runs, departments, employees,
+ * positions, leave types/requests and employee compensation — delegating to the
+ * existing REST controllers via the shared JSON-scalar pass-through.
+ * Authorization mirrors the REST endpoints (`hr:read`/`hr:write`/`hr:approve`).
+ */
+@Controller
+class HrGraphqlController(
+    private val payrollRunController: PayrollRunController,
+    private val departmentController: DepartmentController,
+    private val employeeController: EmployeeController,
+    private val positionController: PositionController,
+    private val leaveTypeController: LeaveTypeController,
+    private val leaveRequestController: LeaveRequestController,
+    private val employeeCompensationController: EmployeeCompensationController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun payrollRuns(
+        @Argument status: String?,
+    ): Any = support.unwrap(payrollRunController.listPayrollRuns(status))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun payrollRun(
+        @Argument id: String,
+    ): Any = support.unwrap(payrollRunController.getPayrollRun(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createPayrollRun(
+        @Argument input: Any,
+    ): Any = support.unwrap(payrollRunController.createPayrollRun(support.toRequest<CreatePayrollRunRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:approve')")
+    fun approvePayrollRun(
+        @Argument id: String,
+    ): Any = support.unwrap(payrollRunController.approvePayrollRun(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:approve')")
+    fun payPayrollRun(
+        @Argument id: String,
+    ): Any = support.unwrap(payrollRunController.payPayrollRun(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun cancelPayrollRun(
+        @Argument id: String,
+    ): Any = support.unwrap(payrollRunController.cancelPayrollRun(id))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun departments(
+        @Argument activeOnly: Boolean,
+    ): Any = support.unwrap(departmentController.listDepartments(activeOnly))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun department(
+        @Argument id: String,
+    ): Any = support.unwrap(departmentController.getDepartment(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createDepartment(
+        @Argument input: Any,
+    ): Any = support.unwrap(departmentController.createDepartment(support.toRequest<CreateDepartmentRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updateDepartment(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(departmentController.updateDepartment(id, support.toRequest<UpdateDepartmentRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun deactivateDepartment(
+        @Argument id: String,
+    ): Any = support.unwrap(departmentController.deactivateDepartment(id))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun employees(
+        @Argument status: String?,
+        @Argument departmentId: String?,
+    ): Any = support.unwrap(employeeController.listEmployees(status, departmentId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun employee(
+        @Argument id: String,
+    ): Any = support.unwrap(employeeController.getEmployee(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createEmployee(
+        @Argument input: Any,
+    ): Any = support.unwrap(employeeController.createEmployee(support.toRequest<CreateEmployeeRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updateEmployee(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(employeeController.updateEmployee(id, support.toRequest<UpdateEmployeeRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun assignEmployeeDepartment(
+        @Argument id: String,
+        @Argument departmentId: String?,
+    ): Any = support.unwrap(employeeController.assignDepartment(id, departmentId))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun placeEmployeeOnLeave(
+        @Argument id: String,
+    ): Any = support.unwrap(employeeController.placeOnLeave(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun returnEmployeeFromLeave(
+        @Argument id: String,
+    ): Any = support.unwrap(employeeController.returnFromLeave(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun terminateEmployee(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(employeeController.terminate(id, support.toRequest<TerminateEmployeeRequest>(input)))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun positions(
+        @Argument activeOnly: Boolean,
+    ): Any = support.unwrap(positionController.listPositions(activeOnly))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun position(
+        @Argument id: String,
+    ): Any = support.unwrap(positionController.getPosition(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createPosition(
+        @Argument input: Any,
+    ): Any = support.unwrap(positionController.createPosition(support.toRequest<CreatePositionRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updatePosition(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(positionController.updatePosition(id, support.toRequest<UpdatePositionRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun deactivatePosition(
+        @Argument id: String,
+    ): Any = support.unwrap(positionController.deactivatePosition(id))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun leaveTypes(
+        @Argument activeOnly: Boolean,
+    ): Any = support.unwrap(leaveTypeController.listLeaveTypes(activeOnly))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun leaveType(
+        @Argument id: String,
+    ): Any = support.unwrap(leaveTypeController.getLeaveType(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createLeaveType(
+        @Argument input: Any,
+    ): Any = support.unwrap(leaveTypeController.createLeaveType(support.toRequest<CreateLeaveTypeRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun updateLeaveType(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(leaveTypeController.updateLeaveType(id, support.toRequest<UpdateLeaveTypeRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun deactivateLeaveType(
+        @Argument id: String,
+    ): Any = support.unwrap(leaveTypeController.deactivateLeaveType(id))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun leaveRequests(
+        @Argument employeeId: String?,
+        @Argument status: String?,
+    ): Any = support.unwrap(leaveRequestController.listLeaveRequests(employeeId, status))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun leaveRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(leaveRequestController.getLeaveRequest(id))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun leaveBalance(
+        @Argument employeeId: String,
+        @Argument leaveTypeId: String,
+        @Argument year: Int?,
+    ): Any = support.unwrap(leaveRequestController.balance(employeeId, leaveTypeId, year))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun createLeaveRequest(
+        @Argument input: Any,
+    ): Any = support.unwrap(leaveRequestController.createLeaveRequest(support.toRequest<CreateLeaveRequestRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:approve')")
+    fun approveLeaveRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(leaveRequestController.approveLeaveRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:approve')")
+    fun rejectLeaveRequest(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any = support.unwrap(leaveRequestController.rejectLeaveRequest(id, input?.let { support.toRequest<RejectLeaveRequestRequest>(it) }))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun cancelLeaveRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(leaveRequestController.cancelLeaveRequest(id))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun employeeCompensations(
+        @Argument employeeId: String,
+    ): Any = support.unwrap(employeeCompensationController.listCompensation(employeeId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun currentEmployeeCompensation(
+        @Argument employeeId: String,
+        @Argument asOf: String?,
+    ): Any = support.unwrap(employeeCompensationController.currentCompensation(employeeId, asOf?.let(LocalDate::parse)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun addEmployeeCompensation(
+        @Argument employeeId: String,
+        @Argument input: Any,
+    ): Any =
+        support.unwrap(
+            employeeCompensationController.addCompensation(employeeId, support.toRequest<CreateEmployeeCompensationRequest>(input)),
+        )
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/OrderGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/OrderGraphqlController.kt
@@ -1,0 +1,138 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.PurchaseOrderController
+import com.aquinofroilan.tessera.controller.SalesOrderController
+import com.aquinofroilan.tessera.dto.BillMatchRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseOrderRequest
+import com.aquinofroilan.tessera.dto.CreateSalesOrderRequest
+import com.aquinofroilan.tessera.dto.FulfillSalesOrderRequest
+import com.aquinofroilan.tessera.dto.GenerateBillRequest
+import com.aquinofroilan.tessera.dto.GenerateInvoiceRequest
+import com.aquinofroilan.tessera.dto.ReceivePurchaseOrderRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for the procurement (purchase order) and sales order routes,
+ * delegating to the existing REST controllers via the shared JSON-scalar
+ * pass-through. Authorization mirrors the REST endpoints.
+ */
+@Controller
+class OrderGraphqlController(
+    private val purchaseOrderController: PurchaseOrderController,
+    private val salesOrderController: SalesOrderController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun purchaseOrders(
+        @Argument status: String?,
+        @Argument vendorId: String?,
+    ): Any = support.unwrap(purchaseOrderController.listPurchaseOrders(status, vendorId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun purchaseOrder(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseOrderController.getPurchaseOrder(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun createPurchaseOrder(
+        @Argument input: Any,
+    ): Any = support.unwrap(purchaseOrderController.createPurchaseOrder(support.toRequest<CreatePurchaseOrderRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun approvePurchaseOrder(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseOrderController.approvePurchaseOrder(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:receive')")
+    fun receivePurchaseOrder(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any =
+        support.unwrap(purchaseOrderController.receivePurchaseOrder(id, input?.let { support.toRequest<ReceivePurchaseOrderRequest>(it) }))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun matchPurchaseOrderBill(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(purchaseOrderController.matchBill(id, support.toRequest<BillMatchRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:receive')")
+    fun generatePurchaseOrderBill(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any = support.unwrap(purchaseOrderController.generateBill(id, input?.let { support.toRequest<GenerateBillRequest>(it) }))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun closePurchaseOrder(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseOrderController.closePurchaseOrder(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun cancelPurchaseOrder(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseOrderController.cancelPurchaseOrder(id))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('sales:read')")
+    fun salesOrders(
+        @Argument status: String?,
+        @Argument customerId: String?,
+    ): Any = support.unwrap(salesOrderController.listSalesOrders(status, customerId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('sales:read')")
+    fun salesOrder(
+        @Argument id: String,
+    ): Any = support.unwrap(salesOrderController.getSalesOrder(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun createSalesOrder(
+        @Argument input: Any,
+    ): Any = support.unwrap(salesOrderController.createSalesOrder(support.toRequest<CreateSalesOrderRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:approve')")
+    fun approveSalesOrder(
+        @Argument id: String,
+    ): Any = support.unwrap(salesOrderController.approveSalesOrder(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:fulfill')")
+    fun fulfillSalesOrder(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any = support.unwrap(salesOrderController.fulfillSalesOrder(id, input?.let { support.toRequest<FulfillSalesOrderRequest>(it) }))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:fulfill')")
+    fun generateSalesOrderInvoice(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any = support.unwrap(salesOrderController.generateInvoice(id, input?.let { support.toRequest<GenerateInvoiceRequest>(it) }))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun closeSalesOrder(
+        @Argument id: String,
+    ): Any = support.unwrap(salesOrderController.closeSalesOrder(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun cancelSalesOrder(
+        @Argument id: String,
+    ): Any = support.unwrap(salesOrderController.cancelSalesOrder(id))
+}

--- a/src/main/resources/graphql/hr.graphqls
+++ b/src/main/resources/graphql/hr.graphqls
@@ -1,0 +1,56 @@
+extend type Query {
+  payrollRuns(status: String): JSON!
+  payrollRun(id: ID!): JSON!
+
+  departments(activeOnly: Boolean = false): JSON!
+  department(id: ID!): JSON!
+
+  employees(status: String, departmentId: String): JSON!
+  employee(id: ID!): JSON!
+
+  positions(activeOnly: Boolean = false): JSON!
+  position(id: ID!): JSON!
+
+  leaveTypes(activeOnly: Boolean = false): JSON!
+  leaveType(id: ID!): JSON!
+
+  leaveRequests(employeeId: String, status: String): JSON!
+  leaveRequest(id: ID!): JSON!
+  leaveBalance(employeeId: ID!, leaveTypeId: ID!, year: Int): JSON!
+
+  employeeCompensations(employeeId: ID!): JSON!
+  currentEmployeeCompensation(employeeId: ID!, asOf: String): JSON!
+}
+
+extend type Mutation {
+  createPayrollRun(input: JSON!): JSON!
+  approvePayrollRun(id: ID!): JSON!
+  payPayrollRun(id: ID!): JSON!
+  cancelPayrollRun(id: ID!): JSON!
+
+  createDepartment(input: JSON!): JSON!
+  updateDepartment(id: ID!, input: JSON!): JSON!
+  deactivateDepartment(id: ID!): JSON!
+
+  createEmployee(input: JSON!): JSON!
+  updateEmployee(id: ID!, input: JSON!): JSON!
+  assignEmployeeDepartment(id: ID!, departmentId: String): JSON!
+  placeEmployeeOnLeave(id: ID!): JSON!
+  returnEmployeeFromLeave(id: ID!): JSON!
+  terminateEmployee(id: ID!, input: JSON!): JSON!
+
+  createPosition(input: JSON!): JSON!
+  updatePosition(id: ID!, input: JSON!): JSON!
+  deactivatePosition(id: ID!): JSON!
+
+  createLeaveType(input: JSON!): JSON!
+  updateLeaveType(id: ID!, input: JSON!): JSON!
+  deactivateLeaveType(id: ID!): JSON!
+
+  createLeaveRequest(input: JSON!): JSON!
+  approveLeaveRequest(id: ID!): JSON!
+  rejectLeaveRequest(id: ID!, input: JSON): JSON!
+  cancelLeaveRequest(id: ID!): JSON!
+
+  addEmployeeCompensation(employeeId: ID!, input: JSON!): JSON!
+}

--- a/src/main/resources/graphql/orders.graphqls
+++ b/src/main/resources/graphql/orders.graphqls
@@ -1,0 +1,24 @@
+extend type Query {
+  purchaseOrders(status: String, vendorId: String): JSON!
+  purchaseOrder(id: ID!): JSON!
+
+  salesOrders(status: String, customerId: String): JSON!
+  salesOrder(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createPurchaseOrder(input: JSON!): JSON!
+  approvePurchaseOrder(id: ID!): JSON!
+  receivePurchaseOrder(id: ID!, input: JSON): JSON!
+  matchPurchaseOrderBill(id: ID!, input: JSON!): JSON!
+  generatePurchaseOrderBill(id: ID!, input: JSON): JSON!
+  closePurchaseOrder(id: ID!): JSON!
+  cancelPurchaseOrder(id: ID!): JSON!
+
+  createSalesOrder(input: JSON!): JSON!
+  approveSalesOrder(id: ID!): JSON!
+  fulfillSalesOrder(id: ID!, input: JSON): JSON!
+  generateSalesOrderInvoice(id: ID!, input: JSON): JSON!
+  closeSalesOrder(id: ID!): JSON!
+  cancelSalesOrder(id: ID!): JSON!
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlControllerTest.kt
@@ -1,0 +1,112 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.DepartmentController
+import com.aquinofroilan.tessera.controller.EmployeeCompensationController
+import com.aquinofroilan.tessera.controller.EmployeeController
+import com.aquinofroilan.tessera.controller.LeaveRequestController
+import com.aquinofroilan.tessera.controller.LeaveTypeController
+import com.aquinofroilan.tessera.controller.PayrollRunController
+import com.aquinofroilan.tessera.controller.PositionController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [HrGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class HrGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var payrollRunController: PayrollRunController
+
+    @MockitoBean
+    private lateinit var departmentController: DepartmentController
+
+    @MockitoBean
+    private lateinit var employeeController: EmployeeController
+
+    @MockitoBean
+    private lateinit var positionController: PositionController
+
+    @MockitoBean
+    private lateinit var leaveTypeController: LeaveTypeController
+
+    @MockitoBean
+    private lateinit var leaveRequestController: LeaveRequestController
+
+    @MockitoBean
+    private lateinit var employeeCompensationController: EmployeeCompensationController
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `employees query should return json payload`() {
+        `when`(employeeController.listEmployees(null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "emp1", "status" to "ACTIVE"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  employees
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("employees[0].id")
+            .entity(String::class.java)
+            .isEqualTo("emp1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["hr:approve"])
+    fun `approvePayrollRun mutation should bridge to controller`() {
+        `when`(payrollRunController.approvePayrollRun("pr1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "pr1", "status" to "APPROVED")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  approvePayrollRun(id: "pr1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("approvePayrollRun.status")
+            .entity(String::class.java)
+            .isEqualTo("APPROVED")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `createDepartment mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createDepartment(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("name" to "Engineering"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/OrderGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/OrderGraphqlControllerTest.kt
@@ -1,0 +1,90 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.PurchaseOrderController
+import com.aquinofroilan.tessera.controller.SalesOrderController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [OrderGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class OrderGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var purchaseOrderController: PurchaseOrderController
+
+    @MockitoBean
+    private lateinit var salesOrderController: SalesOrderController
+
+    @Test
+    @WithMockUser(authorities = ["procurement:read"])
+    fun `purchaseOrders query should return json payload`() {
+        `when`(purchaseOrderController.listPurchaseOrders(null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "po1", "status" to "DRAFT"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  purchaseOrders
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("purchaseOrders[0].id")
+            .entity(String::class.java)
+            .isEqualTo("po1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["sales:approve"])
+    fun `approveSalesOrder mutation should bridge to controller`() {
+        `when`(salesOrderController.approveSalesOrder("so1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "so1", "status" to "APPROVED")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  approveSalesOrder(id: "so1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("approveSalesOrder.status")
+            .entity(String::class.java)
+            .isEqualTo("APPROVED")
+    }
+
+    @Test
+    fun `purchaseOrders query should be denied without authority`() {
+        graphQlTester
+            .document(
+                """
+                query {
+                  purchaseOrders
+                }
+                """.trimIndent(),
+            ).execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}


### PR DESCRIPTION
**Stacked on #133** (base `graphql-migration`) — depends on its GraphQL infra (`GraphqlBridgeSupport`, JSON scalar, base schema, `/graphql` security). Merge #133 first.

## Why
#133 bridged the finance/fx/inventory surface, but several modules landed afterward (purchase/sales orders via #142–#144, HR + payroll via #148–#154) and were reachable over REST only. This closes that gap so the GraphQL surface matches the REST surface at release.

## What
Same JSON-scalar pass-through pattern as #133 — bridge controllers delegate to the existing REST controllers, with `@PreAuthorize` mirroring each endpoint and input conversion/validation via `GraphqlBridgeSupport.toRequest`.

- **`orders.graphqls` + `OrderGraphqlController`** — purchase orders (list/get/create/approve/receive/match-bill/generate-bill/close/cancel) and sales orders (list/get/create/approve/fulfill/generate-invoice/close/cancel).
- **`hr.graphqls` + `HrGraphqlController`** — payroll runs (create/approve/pay/cancel), departments, employees (incl. assign-dept/leave/return/terminate), positions, leave types, leave requests (incl. balance/approve/reject/cancel), employee compensation.

Authorization mirrors REST exactly: `procurement:*` / `sales:*` for orders, `hr:read|write|approve` for HR.

## Test plan
- [x] `compileKotlin`/`compileTestKotlin` + ktlint clean
- [x] `OrderGraphqlControllerTest` + `HrGraphqlControllerTest` — query delegation, id-only mutation bridging, and authz-denial cases
- [ ] Postgres integration tests in CI (no new migration — pure bridge)

## Notes
- No DB migration; this only adds GraphQL resolvers/schema over existing services.
- GraphiQL remains profile-gated (dev/test) as in #133.