### PR TITLE
feat(hr): department org-chart hierarchy (#33)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/DepartmentController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/DepartmentController.kt
@@ -4,6 +4,7 @@ import com.aquinofroilan.tessera.annotation.LogLevel
 import com.aquinofroilan.tessera.annotation.Loggable
 import com.aquinofroilan.tessera.dto.CreateDepartmentRequest
 import com.aquinofroilan.tessera.dto.DepartmentResponse
+import com.aquinofroilan.tessera.dto.SetDepartmentParentRequest
 import com.aquinofroilan.tessera.dto.UpdateDepartmentRequest
 import com.aquinofroilan.tessera.security.AuthenticationContext
 import com.aquinofroilan.tessera.service.DepartmentService
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -47,6 +49,13 @@ class DepartmentController(
         return ResponseEntity.ok(departmentService.listDepartments(orgId, activeOnly).map { DepartmentResponse.from(it) })
     }
 
+    @GetMapping("/org-chart")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getOrgChart(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(departmentService.getOrgChart(orgId))
+    }
+
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('hr:read')")
     fun getDepartment(
@@ -64,6 +73,16 @@ class DepartmentController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         return ResponseEntity.ok(DepartmentResponse.from(departmentService.updateDepartment(id, request, orgId)))
+    }
+
+    @PutMapping("/{id}/parent")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun setParent(
+        @PathVariable id: String,
+        @Valid @RequestBody request: SetDepartmentParentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(DepartmentResponse.from(departmentService.setParent(id, request.parentId, orgId)))
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/DepartmentDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/DepartmentDtos.kt
@@ -11,6 +11,7 @@ data class CreateDepartmentRequest(
     @field:NotBlank(message = "Name is required")
     val name: String,
     val description: String? = null,
+    val parentId: String? = null,
 )
 
 data class UpdateDepartmentRequest(
@@ -18,11 +19,20 @@ data class UpdateDepartmentRequest(
     val description: String? = null,
 )
 
+/**
+ * Sets (or clears) a department's parent for the org chart. A null [parentId]
+ * promotes the department to a root.
+ */
+data class SetDepartmentParentRequest(
+    val parentId: String? = null,
+)
+
 data class DepartmentResponse(
     val id: String,
     val code: String,
     val name: String,
     val description: String?,
+    val parentId: String?,
     val organizationId: String,
     val isActive: Boolean,
     val createdAt: String?,
@@ -35,10 +45,35 @@ data class DepartmentResponse(
                 code = department.code,
                 name = department.name,
                 description = department.description,
+                parentId = department.parentId,
                 organizationId = department.organizationId,
                 isActive = department.isActive,
                 createdAt = department.createdAt?.toString(),
                 updatedAt = department.updatedAt?.toString(),
             )
+    }
+}
+
+/**
+ * A node in the department org chart: the department plus its nested children.
+ */
+data class DepartmentTreeNode(
+    val id: String,
+    val code: String,
+    val name: String,
+    val isActive: Boolean,
+    val children: List<DepartmentTreeNode>,
+) {
+    companion object {
+        fun from(
+            department: Department,
+            children: List<DepartmentTreeNode>,
+        ) = DepartmentTreeNode(
+            id = department.id,
+            code = department.code,
+            name = department.name,
+            isActive = department.isActive,
+            children = children,
+        )
     }
 }

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Department.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Department.kt
@@ -21,6 +21,8 @@ data class Department(
     val code: String,
     val name: String,
     val description: String? = null,
+    @Column(name = "parent_id", columnDefinition = "uuid")
+    val parentId: String? = null,
     @Column(name = "organization_id", columnDefinition = "uuid")
     val organizationId: String,
     @Column(name = "is_active")

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/DepartmentService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/DepartmentService.kt
@@ -1,6 +1,7 @@
 package com.aquinofroilan.tessera.service
 
 import com.aquinofroilan.tessera.dto.CreateDepartmentRequest
+import com.aquinofroilan.tessera.dto.DepartmentTreeNode
 import com.aquinofroilan.tessera.dto.UpdateDepartmentRequest
 import com.aquinofroilan.tessera.exception.BusinessRuleException
 import com.aquinofroilan.tessera.exception.ResourceNotFoundException
@@ -22,11 +23,13 @@ class DepartmentService(
         if (departmentRepository.findByOrganizationIdAndCode(organizationId, code).isPresent) {
             throw BusinessRuleException("Department code '$code' already exists")
         }
+        request.parentId?.let { requireParentInOrg(it, organizationId) }
         return departmentRepository.save(
             Department(
                 code = code,
                 name = request.name.trim(),
                 description = request.description,
+                parentId = request.parentId,
                 organizationId = organizationId,
             ),
         )
@@ -81,5 +84,70 @@ class DepartmentService(
             throw BusinessRuleException("Department is already inactive")
         }
         return departmentRepository.save(department.copy(isActive = false))
+    }
+
+    /**
+     * Sets or clears a department's parent. A null [parentId] promotes the
+     * department to a root. Rejects self-parenting and any move that would
+     * introduce a cycle (i.e. making a department a child of its own descendant).
+     */
+    @Transactional
+    fun setParent(
+        id: String,
+        parentId: String?,
+        organizationId: String,
+    ): Department {
+        val department = getDepartment(id, organizationId)
+        if (parentId == null) {
+            return departmentRepository.save(department.copy(parentId = null))
+        }
+        if (parentId == id) {
+            throw BusinessRuleException("A department cannot be its own parent")
+        }
+        requireParentInOrg(parentId, organizationId)
+        if (descendantIds(id, organizationId).contains(parentId)) {
+            throw BusinessRuleException("Cannot move a department under one of its own descendants")
+        }
+        return departmentRepository.save(department.copy(parentId = parentId))
+    }
+
+    /**
+     * Builds the department org chart for an organization: root departments
+     * (those without a parent) with their descendants nested beneath them.
+     */
+    fun getOrgChart(organizationId: String): List<DepartmentTreeNode> {
+        val all = departmentRepository.findByOrganizationId(organizationId)
+        val childrenByParent = all.groupBy { it.parentId }
+
+        fun build(department: Department): DepartmentTreeNode =
+            DepartmentTreeNode.from(
+                department,
+                childrenByParent[department.id].orEmpty().sortedBy { it.code }.map(::build),
+            )
+        return childrenByParent[null].orEmpty().sortedBy { it.code }.map(::build)
+    }
+
+    private fun requireParentInOrg(
+        parentId: String,
+        organizationId: String,
+    ) {
+        // Reuses the cross-org guard: a parent in another org surfaces as "not found".
+        getDepartment(parentId, organizationId)
+    }
+
+    private fun descendantIds(
+        id: String,
+        organizationId: String,
+    ): Set<String> {
+        val childrenByParent = departmentRepository.findByOrganizationId(organizationId).groupBy { it.parentId }
+        val descendants = mutableSetOf<String>()
+        val queue = ArrayDeque(childrenByParent[id].orEmpty().map { it.id })
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (descendants.add(current)) {
+                childrenByParent[current].orEmpty().forEach { queue.addLast(it.id) }
+            }
+        }
+        return descendants
     }
 }

--- a/src/main/resources/db/migration/V0014__hr_department_parent.sql
+++ b/src/main/resources/db/migration/V0014__hr_department_parent.sql
@@ -1,0 +1,6 @@
+-- HR module: department org-chart hierarchy.
+-- Adds an optional self-referencing parent so departments can nest into an org chart.
+ALTER TABLE departments
+    ADD COLUMN parent_id uuid REFERENCES departments(id);
+
+CREATE INDEX departments_parent_idx ON departments(parent_id);

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/DepartmentServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/DepartmentServiceTest.kt
@@ -76,4 +76,61 @@ class DepartmentServiceTest {
         assertThatThrownBy { service.deactivateDepartment("d1", orgId) }
             .isInstanceOf(BusinessRuleException::class.java)
     }
+
+    @Test
+    fun `create with a parent validates the parent belongs to the org`() {
+        whenever(repository.findById("p1")).thenReturn(Optional.empty())
+
+        assertThatThrownBy {
+            service.createDepartment(CreateDepartmentRequest(code = "ENG", name = "Eng", parentId = "p1"), orgId)
+        }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `setParent rejects self-parenting`() {
+        whenever(repository.findById("d1"))
+            .thenReturn(Optional.of(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId)))
+
+        assertThatThrownBy { service.setParent("d1", "d1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `setParent rejects a move that would create a cycle`() {
+        val parent = Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId)
+        val child = Department(id = "d2", code = "BE", name = "Backend", organizationId = orgId, parentId = "d1")
+        whenever(repository.findById("d1")).thenReturn(Optional.of(parent))
+        whenever(repository.findById("d2")).thenReturn(Optional.of(child))
+        whenever(repository.findByOrganizationId(orgId)).thenReturn(listOf(parent, child))
+
+        // Making d1 (an ancestor) a child of d2 (its descendant) is a cycle.
+        assertThatThrownBy { service.setParent("d1", "d2", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `setParent clears the parent when null`() {
+        whenever(repository.findById("d2"))
+            .thenReturn(Optional.of(Department(id = "d2", code = "BE", name = "Backend", organizationId = orgId, parentId = "d1")))
+
+        val updated = service.setParent("d2", null, orgId)
+
+        assertThat(updated.parentId).isNull()
+    }
+
+    @Test
+    fun `org chart nests children under their roots`() {
+        val root = Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId)
+        val child = Department(id = "d2", code = "BE", name = "Backend", organizationId = orgId, parentId = "d1")
+        val grandchild = Department(id = "d3", code = "API", name = "API", organizationId = orgId, parentId = "d2")
+        whenever(repository.findByOrganizationId(orgId)).thenReturn(listOf(child, root, grandchild))
+
+        val chart = service.getOrgChart(orgId)
+
+        assertThat(chart).hasSize(1)
+        assertThat(chart[0].id).isEqualTo("d1")
+        assertThat(chart[0].children).hasSize(1)
+        assertThat(chart[0].children[0].id).isEqualTo("d2")
+        assertThat(chart[0].children[0].children[0].id).isEqualTo("d3")
+    }
 }


### PR DESCRIPTION
Completes the org-chart half of #33 (the CRUD half shipped in v0.10.0).

## What
Departments can now nest into a hierarchy via an optional self-referencing parent.

- **Migration** `V0014__hr_department_parent.sql` — adds `departments.parent_id` (self-FK) + index.
- **Model** — `Department.parentId`.
- **Create** — `CreateDepartmentRequest.parentId` (validated to exist in the same org).
- **Reparent** — `PUT /hr/departments/{id}/parent` sets or clears the parent. Rejects self-parenting and any move that would put a department under one of its own descendants (cycle guard).
- **Org chart** — `GET /hr/departments/org-chart` returns roots with their descendants nested (`DepartmentTreeNode`).

## Tests
`DepartmentServiceTest` extended: parent-in-org validation on create, self-parent rejection, descendant-cycle rejection, parent clearing, and nested-tree assembly.

## Notes
Authorization mirrors the existing endpoints (`hr:read` / `hr:write`). Closes the remaining scope on #33.
