### PR TITLE
feat(hr): attendance tracking — clock-in/out + timesheets (#35)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/AttendanceController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/AttendanceController.kt
@@ -1,0 +1,80 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.AttendanceResponse
+import com.aquinofroilan.tessera.dto.ClockRequest
+import com.aquinofroilan.tessera.dto.RecordAttendanceRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.AttendanceService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/hr/attendance")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class AttendanceController(
+    private val attendanceService: AttendanceService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping("/clock-in")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun clockIn(
+        @Valid @RequestBody request: ClockRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val record = attendanceService.clockIn(request.employeeId, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(AttendanceResponse.from(record))
+    }
+
+    @PostMapping("/clock-out")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun clockOut(
+        @Valid @RequestBody request: ClockRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(AttendanceResponse.from(attendanceService.clockOut(request.employeeId, orgId)))
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun recordAttendance(
+        @Valid @RequestBody request: RecordAttendanceRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val record = attendanceService.recordAttendance(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(AttendanceResponse.from(record))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listTimesheet(
+        @RequestParam(required = false) employeeId: String?,
+        @RequestParam(required = false) from: LocalDate?,
+        @RequestParam(required = false) to: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(
+            attendanceService.listTimesheet(orgId, employeeId, from, to).map { AttendanceResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getAttendance(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(AttendanceResponse.from(attendanceService.getAttendance(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/AttendanceDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/AttendanceDtos.kt
@@ -1,0 +1,59 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.AttendanceRecord
+import com.aquinofroilan.tessera.model.AttendanceStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class ClockRequest(
+    @field:NotBlank(message = "Employee ID is required")
+    val employeeId: String,
+)
+
+/**
+ * Manual attendance entry/correction for a given day (e.g. recording an
+ * absence or fixing clock times). [status] defaults to PRESENT when omitted.
+ */
+data class RecordAttendanceRequest(
+    @field:NotBlank(message = "Employee ID is required")
+    val employeeId: String,
+    @field:NotNull(message = "Work date is required")
+    val workDate: LocalDate?,
+    val clockIn: LocalDateTime? = null,
+    val clockOut: LocalDateTime? = null,
+    val status: AttendanceStatus? = null,
+    val notes: String? = null,
+)
+
+data class AttendanceResponse(
+    val id: String,
+    val employeeId: String,
+    val workDate: String,
+    val clockIn: String?,
+    val clockOut: String?,
+    val workedMinutes: Int?,
+    val status: AttendanceStatus,
+    val notes: String?,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(record: AttendanceRecord) =
+            AttendanceResponse(
+                id = record.id,
+                employeeId = record.employeeId,
+                workDate = record.workDate.toString(),
+                clockIn = record.clockIn?.toString(),
+                clockOut = record.clockOut?.toString(),
+                workedMinutes = record.workedMinutes,
+                status = record.status,
+                notes = record.notes,
+                organizationId = record.organizationId,
+                createdAt = record.createdAt?.toString(),
+                updatedAt = record.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/AttendanceRecord.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/AttendanceRecord.kt
@@ -1,0 +1,51 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class AttendanceStatus {
+    PRESENT,
+    ABSENT,
+    ON_LEAVE,
+}
+
+@Entity
+@Table(name = "attendance_records")
+@EntityListeners(AuditingEntityListener::class)
+data class AttendanceRecord(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "employee_id", columnDefinition = "uuid")
+    val employeeId: String,
+    @Column(name = "work_date")
+    val workDate: LocalDate,
+    @Column(name = "clock_in")
+    val clockIn: LocalDateTime? = null,
+    @Column(name = "clock_out")
+    val clockOut: LocalDateTime? = null,
+    @Column(name = "worked_minutes")
+    val workedMinutes: Int? = null,
+    @Enumerated(EnumType.STRING)
+    val status: AttendanceStatus = AttendanceStatus.PRESENT,
+    val notes: String? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/AttendanceRecordRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/AttendanceRecordRepository.kt
@@ -1,0 +1,36 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.AttendanceRecord
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.util.Optional
+
+@Repository
+interface AttendanceRecordRepository : JpaRepository<AttendanceRecord, String> {
+    fun findByOrganizationId(organizationId: String): List<AttendanceRecord>
+
+    fun findByOrganizationIdAndEmployeeId(
+        organizationId: String,
+        employeeId: String,
+    ): List<AttendanceRecord>
+
+    fun findByOrganizationIdAndEmployeeIdAndWorkDate(
+        organizationId: String,
+        employeeId: String,
+        workDate: LocalDate,
+    ): Optional<AttendanceRecord>
+
+    fun findByOrganizationIdAndWorkDateBetween(
+        organizationId: String,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<AttendanceRecord>
+
+    fun findByOrganizationIdAndEmployeeIdAndWorkDateBetween(
+        organizationId: String,
+        employeeId: String,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<AttendanceRecord>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/AttendanceService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/AttendanceService.kt
@@ -1,0 +1,165 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.RecordAttendanceRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.AttendanceRecord
+import com.aquinofroilan.tessera.model.AttendanceStatus
+import com.aquinofroilan.tessera.model.EmploymentStatus
+import com.aquinofroilan.tessera.repository.AttendanceRecordRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+
+@Service
+class AttendanceService(
+    private val attendanceRecordRepository: AttendanceRecordRepository,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun clockIn(
+        employeeId: String,
+        organizationId: String,
+    ): AttendanceRecord {
+        val employee = activeEmployee(employeeId, organizationId)
+        val today = LocalDate.now(ZoneOffset.UTC)
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        val existing = attendanceRecordRepository.findByOrganizationIdAndEmployeeIdAndWorkDate(organizationId, employee.id, today)
+        if (existing.isPresent && existing.get().clockIn != null) {
+            throw BusinessRuleException("Employee has already clocked in today")
+        }
+        val record =
+            existing
+                .map { it.copy(clockIn = now, status = AttendanceStatus.PRESENT) }
+                .orElseGet {
+                    AttendanceRecord(
+                        employeeId = employee.id,
+                        workDate = today,
+                        clockIn = now,
+                        status = AttendanceStatus.PRESENT,
+                        organizationId = organizationId,
+                    )
+                }
+        return attendanceRecordRepository.save(record)
+    }
+
+    @Transactional
+    fun clockOut(
+        employeeId: String,
+        organizationId: String,
+    ): AttendanceRecord {
+        val employee = activeEmployee(employeeId, organizationId)
+        val today = LocalDate.now(ZoneOffset.UTC)
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        val record =
+            attendanceRecordRepository
+                .findByOrganizationIdAndEmployeeIdAndWorkDate(organizationId, employee.id, today)
+                .orElseThrow { BusinessRuleException("Employee has not clocked in today") }
+        val clockIn = record.clockIn ?: throw BusinessRuleException("Employee has not clocked in today")
+        if (record.clockOut != null) {
+            throw BusinessRuleException("Employee has already clocked out today")
+        }
+        return attendanceRecordRepository.save(
+            record.copy(
+                clockOut = now,
+                workedMinutes = ChronoUnit.MINUTES.between(clockIn, now).toInt(),
+            ),
+        )
+    }
+
+    /**
+     * Manually records or corrects an attendance entry for a specific day,
+     * upserting the unique (org, employee, date) record.
+     */
+    @Transactional
+    fun recordAttendance(
+        request: RecordAttendanceRequest,
+        organizationId: String,
+    ): AttendanceRecord {
+        val workDate = request.workDate ?: throw BusinessRuleException("Work date is required")
+        val employee = employeeService.getEmployee(request.employeeId, organizationId)
+        if (request.clockIn != null && request.clockOut != null && request.clockOut.isBefore(request.clockIn)) {
+            throw BusinessRuleException("Clock-out must be on or after clock-in")
+        }
+        val workedMinutes =
+            if (request.clockIn != null && request.clockOut != null) {
+                ChronoUnit.MINUTES.between(request.clockIn, request.clockOut).toInt()
+            } else {
+                null
+            }
+        val status = request.status ?: AttendanceStatus.PRESENT
+        val existing =
+            attendanceRecordRepository.findByOrganizationIdAndEmployeeIdAndWorkDate(organizationId, employee.id, workDate)
+        val record =
+            existing
+                .map {
+                    it.copy(
+                        clockIn = request.clockIn,
+                        clockOut = request.clockOut,
+                        workedMinutes = workedMinutes,
+                        status = status,
+                        notes = request.notes,
+                    )
+                }.orElseGet {
+                    AttendanceRecord(
+                        employeeId = employee.id,
+                        workDate = workDate,
+                        clockIn = request.clockIn,
+                        clockOut = request.clockOut,
+                        workedMinutes = workedMinutes,
+                        status = status,
+                        notes = request.notes,
+                        organizationId = organizationId,
+                    )
+                }
+        return attendanceRecordRepository.save(record)
+    }
+
+    fun getAttendance(
+        id: String,
+        organizationId: String,
+    ): AttendanceRecord {
+        val record =
+            attendanceRecordRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Attendance record not found")
+            }
+        if (record.organizationId != organizationId) {
+            throw ResourceNotFoundException("Attendance record not found")
+        }
+        return record
+    }
+
+    /**
+     * Returns a timesheet: attendance records for the org, optionally narrowed
+     * by employee and/or an inclusive [from]..[to] date range.
+     */
+    fun listTimesheet(
+        organizationId: String,
+        employeeId: String? = null,
+        from: LocalDate? = null,
+        to: LocalDate? = null,
+    ): List<AttendanceRecord> {
+        if (from != null && to != null && to.isBefore(from)) {
+            throw BusinessRuleException("'to' date must be on or after 'from' date")
+        }
+        return when {
+            employeeId != null && from != null && to != null ->
+                attendanceRecordRepository.findByOrganizationIdAndEmployeeIdAndWorkDateBetween(organizationId, employeeId, from, to)
+            employeeId != null -> attendanceRecordRepository.findByOrganizationIdAndEmployeeId(organizationId, employeeId)
+            from != null && to != null -> attendanceRecordRepository.findByOrganizationIdAndWorkDateBetween(organizationId, from, to)
+            else -> attendanceRecordRepository.findByOrganizationId(organizationId)
+        }
+    }
+
+    private fun activeEmployee(
+        employeeId: String,
+        organizationId: String,
+    ) = employeeService.getEmployee(employeeId, organizationId).also {
+        if (it.status == EmploymentStatus.TERMINATED) {
+            throw BusinessRuleException("Cannot record attendance for a terminated employee")
+        }
+    }
+}

--- a/src/main/resources/db/migration/V0015__hr_attendance.sql
+++ b/src/main/resources/db/migration/V0015__hr_attendance.sql
@@ -1,0 +1,18 @@
+-- HR module: attendance records (clock-in / clock-out + daily timesheets).
+-- One record per employee per work date.
+CREATE TABLE attendance_records (
+    id                uuid PRIMARY KEY,
+    employee_id       uuid NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+    work_date         date NOT NULL,
+    clock_in          timestamp,
+    clock_out         timestamp,
+    worked_minutes    int,
+    status            text NOT NULL DEFAULT 'PRESENT',
+    notes             text,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT attendance_records_status_chk CHECK (status IN ('PRESENT','ABSENT','ON_LEAVE')),
+    CONSTRAINT attendance_records_unique_per_day UNIQUE (organization_id, employee_id, work_date)
+);
+CREATE INDEX attendance_records_org_employee_date_idx ON attendance_records(organization_id, employee_id, work_date);

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/AttendanceServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/AttendanceServiceTest.kt
@@ -1,0 +1,167 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.RecordAttendanceRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.AttendanceRecord
+import com.aquinofroilan.tessera.model.AttendanceStatus
+import com.aquinofroilan.tessera.model.Employee
+import com.aquinofroilan.tessera.model.EmploymentStatus
+import com.aquinofroilan.tessera.repository.AttendanceRecordRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.Optional
+
+class AttendanceServiceTest {
+    private lateinit var repository: AttendanceRecordRepository
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: AttendanceService
+
+    private val orgId = "org-1"
+    private val empId = "e1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(AttendanceRecordRepository::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.save(any<AttendanceRecord>())).thenAnswer { it.arguments[0] }
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(employee())
+        whenever(repository.findByOrganizationIdAndEmployeeIdAndWorkDate(any(), any(), any())).thenReturn(Optional.empty())
+        service = AttendanceService(repository, employeeService)
+    }
+
+    private fun employee(status: EmploymentStatus = EmploymentStatus.ACTIVE) =
+        Employee(
+            id = empId,
+            employeeNumber = "EMP-0001",
+            firstName = "Ada",
+            lastName = "Lovelace",
+            hireDate = LocalDate.of(2020, 1, 1),
+            status = status,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `clock-in creates a present record`() {
+        val record = service.clockIn(empId, orgId)
+
+        assertThat(record.clockIn).isNotNull()
+        assertThat(record.clockOut).isNull()
+        assertThat(record.status).isEqualTo(AttendanceStatus.PRESENT)
+        assertThat(record.workDate).isEqualTo(LocalDate.now(ZoneOffset.UTC))
+    }
+
+    @Test
+    fun `clock-in rejects a second clock-in the same day`() {
+        whenever(repository.findByOrganizationIdAndEmployeeIdAndWorkDate(any(), any(), any()))
+            .thenReturn(Optional.of(record(clockIn = LocalDateTime.now(ZoneOffset.UTC))))
+
+        assertThatThrownBy { service.clockIn(empId, orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `clock-in is rejected for a terminated employee`() {
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(employee(EmploymentStatus.TERMINATED))
+
+        assertThatThrownBy { service.clockIn(empId, orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `clock-out sets worked minutes`() {
+        val start = LocalDateTime.now(ZoneOffset.UTC).minusHours(8)
+        whenever(repository.findByOrganizationIdAndEmployeeIdAndWorkDate(any(), any(), any()))
+            .thenReturn(Optional.of(record(clockIn = start)))
+
+        val record = service.clockOut(empId, orgId)
+
+        assertThat(record.clockOut).isNotNull()
+        assertThat(record.workedMinutes).isGreaterThanOrEqualTo(8 * 60)
+    }
+
+    @Test
+    fun `clock-out without a clock-in is rejected`() {
+        assertThatThrownBy { service.clockOut(empId, orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `clock-out twice is rejected`() {
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        whenever(repository.findByOrganizationIdAndEmployeeIdAndWorkDate(any(), any(), any()))
+            .thenReturn(Optional.of(record(clockIn = now.minusHours(8), clockOut = now)))
+
+        assertThatThrownBy { service.clockOut(empId, orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `manual entry computes worked minutes and defaults to present`() {
+        val day = LocalDate.of(2026, 5, 1)
+        val record =
+            service.recordAttendance(
+                RecordAttendanceRequest(
+                    employeeId = empId,
+                    workDate = day,
+                    clockIn = day.atTime(9, 0),
+                    clockOut = day.atTime(17, 30),
+                ),
+                orgId,
+            )
+
+        assertThat(record.status).isEqualTo(AttendanceStatus.PRESENT)
+        assertThat(record.workedMinutes).isEqualTo(8 * 60 + 30)
+    }
+
+    @Test
+    fun `manual entry rejects clock-out before clock-in`() {
+        val day = LocalDate.of(2026, 5, 1)
+        assertThatThrownBy {
+            service.recordAttendance(
+                RecordAttendanceRequest(
+                    employeeId = empId,
+                    workDate = day,
+                    clockIn = day.atTime(17, 0),
+                    clockOut = day.atTime(9, 0),
+                ),
+                orgId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("a1"))
+            .thenReturn(Optional.of(record(clockIn = null).copy(id = "a1", organizationId = "other")))
+
+        assertThatThrownBy { service.getAttendance("a1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `timesheet rejects an inverted date range`() {
+        assertThatThrownBy {
+            service.listTimesheet(orgId, from = LocalDate.of(2026, 5, 10), to = LocalDate.of(2026, 5, 1))
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    private fun record(
+        clockIn: LocalDateTime? = null,
+        clockOut: LocalDateTime? = null,
+    ) = AttendanceRecord(
+        employeeId = empId,
+        workDate = LocalDate.now(ZoneOffset.UTC),
+        clockIn = clockIn,
+        clockOut = clockOut,
+        organizationId = orgId,
+    )
+}


### PR DESCRIPTION
Completes the attendance half of #35 (leave management shipped in v0.10.0).

## What
Daily attendance tracking via clock-in/out plus timesheets.

- **Migration** `V0015__hr_attendance.sql` — `attendance_records`, one row per `(org, employee, work_date)`, status `PRESENT`/`ABSENT`/`ON_LEAVE`.
- **Clock in/out** — `POST /hr/attendance/clock-in` and `/clock-out`. Worked minutes are computed on clock-out. Guards against double clock-in, clock-out without a clock-in, double clock-out, and terminated employees.
- **Manual entry/correction** — `POST /hr/attendance` upserts a day's record (e.g. record an absence or fix times); rejects clock-out before clock-in.
- **Timesheet** — `GET /hr/attendance` filterable by `employeeId`, `from`, `to` (inclusive); rejects an inverted range.
- **Detail** — `GET /hr/attendance/{id}` with cross-org isolation.

## Tests
`AttendanceServiceTest` covers the clock lifecycle, all guard rails, manual-entry worked-minute computation, cross-org isolation, and range validation.

## Notes
Authorization mirrors the HR module (`hr:read` / `hr:write`). Migration is `V0015` to avoid colliding with #158's `V0014`. Closes the remaining scope on #35.
