### PR TITLE
feat(procurement): purchase requests (requisitions) (#45)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/PurchaseRequestController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/PurchaseRequestController.kt
@@ -1,0 +1,133 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.PurchaseOrderResponse
+import com.aquinofroilan.tessera.dto.PurchaseRequestResponse
+import com.aquinofroilan.tessera.dto.RejectPurchaseRequestRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.PurchaseRequestService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/procurement/purchase-requests")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class PurchaseRequestController(
+    private val purchaseRequestService: PurchaseRequestService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun createPurchaseRequest(
+        @Valid @RequestBody request: CreatePurchaseRequestRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val requestedBy = authContext.userId() ?: "api-key"
+        val created = purchaseRequestService.createPurchaseRequest(request, orgId, requestedBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(PurchaseRequestResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun listPurchaseRequests(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) requestedBy: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val prStatus =
+            if (status != null) {
+                try {
+                    PurchaseRequestStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(
+            purchaseRequestService.listPurchaseRequests(orgId, prStatus, requestedBy).map { PurchaseRequestResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun getPurchaseRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PurchaseRequestResponse.from(purchaseRequestService.getPurchaseRequest(id, orgId)))
+    }
+
+    @PostMapping("/{id}/submit")
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun submitPurchaseRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PurchaseRequestResponse.from(purchaseRequestService.submitPurchaseRequest(id, orgId)))
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun approvePurchaseRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val decidedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(PurchaseRequestResponse.from(purchaseRequestService.approvePurchaseRequest(id, orgId, decidedBy)))
+    }
+
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun rejectPurchaseRequest(
+        @PathVariable id: String,
+        @RequestBody(required = false) request: RejectPurchaseRequestRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val decidedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(
+            PurchaseRequestResponse.from(purchaseRequestService.rejectPurchaseRequest(id, request?.reason, orgId, decidedBy)),
+        )
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun cancelPurchaseRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PurchaseRequestResponse.from(purchaseRequestService.cancelPurchaseRequest(id, orgId)))
+    }
+
+    @PostMapping("/{id}/convert")
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun convertPurchaseRequest(
+        @PathVariable id: String,
+        @Valid @RequestBody(required = false) request: ConvertPurchaseRequestRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
+        val po =
+            purchaseRequestService.convertToPurchaseOrder(
+                id,
+                request ?: ConvertPurchaseRequestRequest(),
+                orgId,
+                createdBy,
+            )
+        return ResponseEntity.status(HttpStatus.CREATED).body(PurchaseOrderResponse.from(po))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/PurchaseRequestDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/PurchaseRequestDtos.kt
@@ -1,0 +1,116 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.PurchaseRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreatePurchaseRequestLineRequest(
+    @field:NotBlank(message = "Product ID is required")
+    val productId: String,
+    @field:NotNull(message = "Quantity is required")
+    @field:Positive(message = "Quantity must be positive")
+    val quantity: BigDecimal?,
+    val estimatedUnitCost: BigDecimal? = null,
+    val description: String? = null,
+)
+
+data class CreatePurchaseRequestRequest(
+    val suggestedVendorId: String? = null,
+    val warehouseId: String? = null,
+    val justification: String? = null,
+    @field:NotEmpty(message = "At least one line item is required")
+    @field:Valid
+    val lines: List<CreatePurchaseRequestLineRequest>,
+)
+
+data class RejectPurchaseRequestRequest(
+    val reason: String? = null,
+)
+
+/**
+ * Per-line unit-cost override applied when converting a request into a PO.
+ * Lines without an override fall back to their estimated unit cost.
+ */
+data class ConvertPurchaseRequestLineCost(
+    @field:NotBlank(message = "Line ID is required")
+    val lineId: String,
+    @field:NotNull(message = "Unit cost is required")
+    val unitCost: BigDecimal?,
+)
+
+data class ConvertPurchaseRequestRequest(
+    val vendorId: String? = null,
+    val warehouseId: String? = null,
+    val orderDate: LocalDate? = null,
+    val expectedDate: LocalDate? = null,
+    @field:Valid
+    val lineCosts: List<ConvertPurchaseRequestLineCost>? = null,
+)
+
+data class PurchaseRequestLineResponse(
+    val id: String,
+    val lineNumber: Int,
+    val productId: String,
+    val productSku: String,
+    val productName: String,
+    val quantity: BigDecimal,
+    val estimatedUnitCost: BigDecimal?,
+    val description: String?,
+)
+
+data class PurchaseRequestResponse(
+    val id: String,
+    val prNumber: String,
+    val organizationId: String,
+    val status: PurchaseRequestStatus,
+    val suggestedVendorId: String?,
+    val warehouseId: String?,
+    val justification: String?,
+    val lines: List<PurchaseRequestLineResponse>,
+    val requestedBy: String,
+    val decidedBy: String?,
+    val decidedAt: String?,
+    val decisionReason: String?,
+    val convertedPurchaseOrderId: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(request: PurchaseRequest) =
+            PurchaseRequestResponse(
+                id = request.id,
+                prNumber = request.prNumber,
+                organizationId = request.organizationId,
+                status = request.status,
+                suggestedVendorId = request.suggestedVendorId,
+                warehouseId = request.warehouseId,
+                justification = request.justification,
+                lines =
+                    request.lines.map { line ->
+                        PurchaseRequestLineResponse(
+                            id = line.id,
+                            lineNumber = line.lineNumber,
+                            productId = line.productId,
+                            productSku = line.productSku,
+                            productName = line.productName,
+                            quantity = line.quantity,
+                            estimatedUnitCost = line.estimatedUnitCost,
+                            description = line.description,
+                        )
+                    },
+                requestedBy = request.requestedBy,
+                decidedBy = request.decidedBy,
+                decidedAt = request.decidedAt?.toString(),
+                decisionReason = request.decisionReason,
+                convertedPurchaseOrderId = request.convertedPurchaseOrderId,
+                createdAt = request.createdAt?.toString(),
+                updatedAt = request.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/PurchaseRequest.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/PurchaseRequest.kt
@@ -1,0 +1,89 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class PurchaseRequestStatus {
+    DRAFT,
+    SUBMITTED,
+    APPROVED,
+    REJECTED,
+    CONVERTED,
+    CANCELLED,
+}
+
+@Entity
+@Table(name = "purchase_request_lines")
+data class PurchaseRequestLine(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "line_number")
+    val lineNumber: Int = 0,
+    @Column(name = "product_id", columnDefinition = "uuid")
+    val productId: String,
+    @Column(name = "product_sku")
+    val productSku: String,
+    @Column(name = "product_name")
+    val productName: String,
+    val quantity: BigDecimal,
+    @Column(name = "estimated_unit_cost")
+    val estimatedUnitCost: BigDecimal? = null,
+    val description: String? = null,
+)
+
+@Entity
+@Table(name = "purchase_requests")
+@EntityListeners(AuditingEntityListener::class)
+data class PurchaseRequest(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "pr_number")
+    val prNumber: String,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Enumerated(EnumType.STRING)
+    val status: PurchaseRequestStatus = PurchaseRequestStatus.DRAFT,
+    @Column(name = "suggested_vendor_id", columnDefinition = "uuid")
+    val suggestedVendorId: String? = null,
+    @Column(name = "warehouse_id", columnDefinition = "uuid")
+    val warehouseId: String? = null,
+    val justification: String? = null,
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "purchase_request_id")
+    @OrderBy("lineNumber ASC")
+    val lines: List<PurchaseRequestLine>,
+    @Column(name = "requested_by", columnDefinition = "uuid")
+    val requestedBy: String,
+    @Column(name = "decided_by", columnDefinition = "uuid")
+    val decidedBy: String? = null,
+    @Column(name = "decided_at")
+    val decidedAt: LocalDateTime? = null,
+    @Column(name = "decision_reason")
+    val decisionReason: String? = null,
+    @Column(name = "converted_purchase_order_id", columnDefinition = "uuid")
+    val convertedPurchaseOrderId: String? = null,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/PurchaseRequestRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/PurchaseRequestRepository.kt
@@ -1,0 +1,23 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.PurchaseRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PurchaseRequestRepository : JpaRepository<PurchaseRequest, String> {
+    fun findByOrganizationId(organizationId: String): List<PurchaseRequest>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: PurchaseRequestStatus,
+    ): List<PurchaseRequest>
+
+    fun findByOrganizationIdAndRequestedBy(
+        organizationId: String,
+        requestedBy: String,
+    ): List<PurchaseRequest>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestService.kt
@@ -1,0 +1,247 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseOrderLineRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseOrderRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.PurchaseOrder
+import com.aquinofroilan.tessera.model.PurchaseRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestLine
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import com.aquinofroilan.tessera.repository.PurchaseRequestRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Service
+class PurchaseRequestService(
+    private val purchaseRequestRepository: PurchaseRequestRepository,
+    private val productService: ProductService,
+    private val vendorService: VendorService,
+    private val warehouseService: WarehouseService,
+    private val purchaseOrderService: PurchaseOrderService,
+) {
+    @Transactional
+    fun createPurchaseRequest(
+        request: CreatePurchaseRequestRequest,
+        organizationId: String,
+        requestedBy: String,
+    ): PurchaseRequest {
+        request.suggestedVendorId?.let { vendorService.getVendor(it, organizationId) }
+        request.warehouseId?.let { warehouseService.getWarehouse(it, organizationId) }
+
+        val lines =
+            request.lines.mapIndexed { index, lineReq ->
+                val quantity = lineReq.quantity ?: throw BusinessRuleException("Quantity is required")
+                if (quantity.signum() <= 0) {
+                    throw BusinessRuleException("Line quantity must be positive")
+                }
+                if (lineReq.estimatedUnitCost != null && lineReq.estimatedUnitCost.signum() < 0) {
+                    throw BusinessRuleException("Estimated unit cost must not be negative")
+                }
+                val product = productService.getProduct(lineReq.productId, organizationId)
+                if (!product.isActive) {
+                    throw BusinessRuleException("Product '${product.sku}' is inactive")
+                }
+                PurchaseRequestLine(
+                    lineNumber = index + 1,
+                    productId = product.id,
+                    productSku = product.sku,
+                    productName = product.name,
+                    quantity = quantity,
+                    estimatedUnitCost = lineReq.estimatedUnitCost,
+                    description = lineReq.description,
+                )
+            }
+
+        return saveWithRetry(organizationId) { number ->
+            PurchaseRequest(
+                prNumber = number,
+                organizationId = organizationId,
+                suggestedVendorId = request.suggestedVendorId,
+                warehouseId = request.warehouseId,
+                justification = request.justification,
+                lines = lines,
+                requestedBy = requestedBy,
+            )
+        }
+    }
+
+    fun getPurchaseRequest(
+        id: String,
+        organizationId: String,
+    ): PurchaseRequest {
+        val pr =
+            purchaseRequestRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Purchase request not found")
+            }
+        if (pr.organizationId != organizationId) {
+            throw ResourceNotFoundException("Purchase request not found")
+        }
+        return pr
+    }
+
+    fun listPurchaseRequests(
+        organizationId: String,
+        status: PurchaseRequestStatus? = null,
+        requestedBy: String? = null,
+    ): List<PurchaseRequest> =
+        when {
+            status != null -> purchaseRequestRepository.findByOrganizationIdAndStatus(organizationId, status)
+            requestedBy != null -> purchaseRequestRepository.findByOrganizationIdAndRequestedBy(organizationId, requestedBy)
+            else -> purchaseRequestRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun submitPurchaseRequest(
+        id: String,
+        organizationId: String,
+    ): PurchaseRequest {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status != PurchaseRequestStatus.DRAFT) {
+            throw BusinessRuleException("Only draft purchase requests can be submitted")
+        }
+        return purchaseRequestRepository.save(pr.copy(status = PurchaseRequestStatus.SUBMITTED))
+    }
+
+    @Transactional
+    fun approvePurchaseRequest(
+        id: String,
+        organizationId: String,
+        decidedBy: String,
+    ): PurchaseRequest {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status != PurchaseRequestStatus.SUBMITTED) {
+            throw BusinessRuleException("Only submitted purchase requests can be approved")
+        }
+        return purchaseRequestRepository.save(
+            pr.copy(
+                status = PurchaseRequestStatus.APPROVED,
+                decidedBy = decidedBy,
+                decidedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+
+    @Transactional
+    fun rejectPurchaseRequest(
+        id: String,
+        reason: String?,
+        organizationId: String,
+        decidedBy: String,
+    ): PurchaseRequest {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status != PurchaseRequestStatus.SUBMITTED) {
+            throw BusinessRuleException("Only submitted purchase requests can be rejected")
+        }
+        return purchaseRequestRepository.save(
+            pr.copy(
+                status = PurchaseRequestStatus.REJECTED,
+                decisionReason = reason,
+                decidedBy = decidedBy,
+                decidedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+
+    @Transactional
+    fun cancelPurchaseRequest(
+        id: String,
+        organizationId: String,
+    ): PurchaseRequest {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status == PurchaseRequestStatus.CONVERTED) {
+            throw BusinessRuleException("A converted purchase request cannot be cancelled")
+        }
+        if (pr.status == PurchaseRequestStatus.CANCELLED || pr.status == PurchaseRequestStatus.REJECTED) {
+            throw BusinessRuleException("Purchase request is already ${pr.status.name.lowercase()}")
+        }
+        return purchaseRequestRepository.save(pr.copy(status = PurchaseRequestStatus.CANCELLED))
+    }
+
+    /**
+     * Converts an approved request into a purchase order. The vendor, warehouse
+     * and order date may be supplied on the request or fall back to the values
+     * captured on the requisition. Each line needs a unit cost — taken from a
+     * per-line override or the line's estimated cost. Marks the request CONVERTED
+     * and links it to the new PO.
+     */
+    @Transactional
+    fun convertToPurchaseOrder(
+        id: String,
+        request: ConvertPurchaseRequestRequest,
+        organizationId: String,
+        createdBy: String,
+    ): PurchaseOrder {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status != PurchaseRequestStatus.APPROVED) {
+            throw BusinessRuleException("Only approved purchase requests can be converted")
+        }
+        val vendorId =
+            request.vendorId ?: pr.suggestedVendorId
+                ?: throw BusinessRuleException("A vendor is required to convert this request")
+        val warehouseId =
+            request.warehouseId ?: pr.warehouseId
+                ?: throw BusinessRuleException("A warehouse is required to convert this request")
+        val costOverrides = request.lineCosts.orEmpty().associate { it.lineId to it.unitCost }
+
+        val poLines =
+            pr.lines.map { line ->
+                val unitCost =
+                    costOverrides[line.id] ?: line.estimatedUnitCost
+                        ?: throw BusinessRuleException("Line '${line.productSku}' has no unit cost; provide one to convert")
+                CreatePurchaseOrderLineRequest(
+                    productId = line.productId,
+                    quantity = line.quantity,
+                    unitCost = unitCost,
+                    description = line.description,
+                )
+            }
+
+        val po =
+            purchaseOrderService.createPurchaseOrder(
+                CreatePurchaseOrderRequest(
+                    vendorId = vendorId,
+                    warehouseId = warehouseId,
+                    orderDate = request.orderDate ?: LocalDate.now(ZoneOffset.UTC),
+                    expectedDate = request.expectedDate,
+                    referenceNumber = pr.prNumber,
+                    lines = poLines,
+                ),
+                organizationId,
+                createdBy,
+            )
+
+        purchaseRequestRepository.save(
+            pr.copy(
+                status = PurchaseRequestStatus.CONVERTED,
+                convertedPurchaseOrderId = po.id,
+            ),
+        )
+        return po
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        build: (String) -> PurchaseRequest,
+    ): PurchaseRequest {
+        repeat(maxRetries) { attempt ->
+            val count = purchaseRequestRepository.countByOrganizationId(organizationId)
+            val number = "PR-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return purchaseRequestRepository.save(build(number))
+            } catch (e: DuplicateKeyException) {
+                if (attempt == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique PR number: $number", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique PR number")
+    }
+}

--- a/src/main/resources/db/migration/V0016__purchase_requests.sql
+++ b/src/main/resources/db/migration/V0016__purchase_requests.sql
@@ -1,0 +1,38 @@
+-- Procurement: purchase requests (requisitions).
+-- A purchase request is the requisition stage that precedes a purchase order:
+-- draft -> submit -> approve/reject, and an approved request can be converted
+-- into a purchase order (linked via converted_purchase_order_id).
+CREATE TABLE purchase_requests (
+    id                          uuid PRIMARY KEY,
+    pr_number                   text NOT NULL,
+    organization_id             uuid NOT NULL REFERENCES organizations(uuid),
+    status                      text NOT NULL DEFAULT 'DRAFT',
+    suggested_vendor_id         uuid REFERENCES vendors(id) ON DELETE SET NULL,
+    warehouse_id                uuid REFERENCES warehouses(id) ON DELETE SET NULL,
+    justification               text,
+    requested_by                uuid NOT NULL REFERENCES users(uuid),
+    decided_by                  uuid REFERENCES users(uuid),
+    decided_at                  timestamp,
+    decision_reason             text,
+    converted_purchase_order_id uuid REFERENCES purchase_orders(id) ON DELETE SET NULL,
+    created_at                  timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at                  timestamp,
+    CONSTRAINT purchase_requests_status_chk
+        CHECK (status IN ('DRAFT','SUBMITTED','APPROVED','REJECTED','CONVERTED','CANCELLED')),
+    CONSTRAINT purchase_requests_unique_number_per_org UNIQUE (organization_id, pr_number)
+);
+CREATE INDEX purchase_requests_org_status_idx ON purchase_requests(organization_id, status);
+
+CREATE TABLE purchase_request_lines (
+    id                   uuid PRIMARY KEY,
+    purchase_request_id  uuid NOT NULL REFERENCES purchase_requests(id) ON DELETE CASCADE,
+    line_number          int NOT NULL,
+    product_id           uuid NOT NULL REFERENCES products(id) ON DELETE RESTRICT,
+    product_sku          text NOT NULL,
+    product_name         text NOT NULL,
+    quantity             numeric(18,4) NOT NULL,
+    estimated_unit_cost  numeric(18,4),
+    description          text,
+    CONSTRAINT purchase_request_lines_unique_line_per_pr UNIQUE (purchase_request_id, line_number)
+);
+CREATE INDEX purchase_request_lines_product_idx ON purchase_request_lines(product_id);

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestServiceTest.kt
@@ -1,0 +1,255 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestLineCost
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseOrderRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestLineRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Product
+import com.aquinofroilan.tessera.model.PurchaseOrder
+import com.aquinofroilan.tessera.model.PurchaseRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestLine
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import com.aquinofroilan.tessera.model.Vendor
+import com.aquinofroilan.tessera.model.Warehouse
+import com.aquinofroilan.tessera.repository.PurchaseRequestRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class PurchaseRequestServiceTest {
+    private lateinit var repository: PurchaseRequestRepository
+    private lateinit var productService: ProductService
+    private lateinit var vendorService: VendorService
+    private lateinit var warehouseService: WarehouseService
+    private lateinit var purchaseOrderService: PurchaseOrderService
+    private lateinit var service: PurchaseRequestService
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(PurchaseRequestRepository::class.java)
+        productService = mock(ProductService::class.java)
+        vendorService = mock(VendorService::class.java)
+        warehouseService = mock(WarehouseService::class.java)
+        purchaseOrderService = mock(PurchaseOrderService::class.java)
+        whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
+        whenever(repository.save(any<PurchaseRequest>())).thenAnswer { it.arguments[0] }
+        whenever(productService.getProduct("p-1", orgId)).thenReturn(
+            Product(id = "p-1", sku = "SKU-1", name = "Widget", listPrice = BigDecimal("9"), priceCurrency = "USD", organizationId = orgId),
+        )
+        whenever(vendorService.getVendor("v-1", orgId)).thenReturn(Vendor(id = "v-1", name = "Acme", organizationId = orgId))
+        whenever(warehouseService.getWarehouse("wh-1", orgId))
+            .thenReturn(Warehouse(id = "wh-1", code = "MAIN", name = "Main", organizationId = orgId))
+        service = PurchaseRequestService(repository, productService, vendorService, warehouseService, purchaseOrderService)
+    }
+
+    private fun lineReq(estimatedUnitCost: BigDecimal? = BigDecimal("5")) =
+        CreatePurchaseRequestLineRequest(productId = "p-1", quantity = BigDecimal("3"), estimatedUnitCost = estimatedUnitCost)
+
+    private fun approvedRequest(
+        lines: List<PurchaseRequestLine> =
+            listOf(
+                PurchaseRequestLine(
+                    id = "prl-1",
+                    lineNumber = 1,
+                    productId = "p-1",
+                    productSku = "SKU-1",
+                    productName = "Widget",
+                    quantity = BigDecimal("3"),
+                    estimatedUnitCost = BigDecimal("5"),
+                ),
+            ),
+        suggestedVendorId: String? = "v-1",
+        warehouseId: String? = "wh-1",
+    ) = PurchaseRequest(
+        id = "pr-1",
+        prNumber = "PR-0001",
+        organizationId = orgId,
+        status = PurchaseRequestStatus.APPROVED,
+        suggestedVendorId = suggestedVendorId,
+        warehouseId = warehouseId,
+        lines = lines,
+        requestedBy = userId,
+    )
+
+    @Test
+    fun `create persists a draft with a generated number`() {
+        val pr =
+            service.createPurchaseRequest(
+                CreatePurchaseRequestRequest(suggestedVendorId = "v-1", warehouseId = "wh-1", lines = listOf(lineReq())),
+                orgId,
+                userId,
+            )
+
+        assertThat(pr.status).isEqualTo(PurchaseRequestStatus.DRAFT)
+        assertThat(pr.prNumber).isEqualTo("PR-0001")
+        assertThat(pr.lines).hasSize(1)
+        assertThat(pr.lines[0].productSku).isEqualTo("SKU-1")
+    }
+
+    @Test
+    fun `create rejects a non-positive quantity`() {
+        assertThatThrownBy {
+            service.createPurchaseRequest(
+                CreatePurchaseRequestRequest(lines = listOf(lineReq().copy(quantity = BigDecimal.ZERO))),
+                orgId,
+                userId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `submit moves a draft to submitted`() {
+        whenever(repository.findById("pr-1"))
+            .thenReturn(Optional.of(approvedRequest().copy(status = PurchaseRequestStatus.DRAFT)))
+
+        assertThat(service.submitPurchaseRequest("pr-1", orgId).status).isEqualTo(PurchaseRequestStatus.SUBMITTED)
+    }
+
+    @Test
+    fun `approve rejects a request that is not submitted`() {
+        whenever(repository.findById("pr-1")).thenReturn(Optional.of(approvedRequest()))
+
+        assertThatThrownBy { service.approvePurchaseRequest("pr-1", orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `cancel rejects a converted request`() {
+        whenever(repository.findById("pr-1"))
+            .thenReturn(Optional.of(approvedRequest().copy(status = PurchaseRequestStatus.CONVERTED)))
+
+        assertThatThrownBy { service.cancelPurchaseRequest("pr-1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `convert requires an approved request`() {
+        whenever(repository.findById("pr-1"))
+            .thenReturn(Optional.of(approvedRequest().copy(status = PurchaseRequestStatus.SUBMITTED)))
+
+        assertThatThrownBy { service.convertToPurchaseOrder("pr-1", ConvertPurchaseRequestRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `convert builds a PO from estimated costs and marks the request converted`() {
+        whenever(repository.findById("pr-1")).thenReturn(Optional.of(approvedRequest()))
+        val createdPo =
+            PurchaseOrder(
+                id = "po-9",
+                poNumber = "PO-0001",
+                vendorId = "v-1",
+                vendorName = "Acme",
+                warehouseId = "wh-1",
+                orderDate = LocalDate.of(2026, 5, 1),
+                organizationId = orgId,
+                lines = emptyList(),
+                totalAmount = BigDecimal("15"),
+                createdBy = userId,
+            )
+        whenever(purchaseOrderService.createPurchaseOrder(any(), eq(orgId), eq(userId))).thenReturn(createdPo)
+
+        val po = service.convertToPurchaseOrder("pr-1", ConvertPurchaseRequestRequest(), orgId, userId)
+
+        assertThat(po.id).isEqualTo("po-9")
+        val captor = argumentCaptor<CreatePurchaseOrderRequest>()
+        org.mockito.kotlin
+            .verify(purchaseOrderService)
+            .createPurchaseOrder(captor.capture(), eq(orgId), eq(userId))
+        assertThat(captor.firstValue.vendorId).isEqualTo("v-1")
+        assertThat(captor.firstValue.warehouseId).isEqualTo("wh-1")
+        assertThat(captor.firstValue.lines[0].unitCost).isEqualByComparingTo("5")
+
+        val saved = argumentCaptor<PurchaseRequest>()
+        org.mockito.kotlin
+            .verify(repository)
+            .save(saved.capture())
+        assertThat(saved.firstValue.status).isEqualTo(PurchaseRequestStatus.CONVERTED)
+        assertThat(saved.firstValue.convertedPurchaseOrderId).isEqualTo("po-9")
+    }
+
+    @Test
+    fun `convert fails when a line has no cost and no override`() {
+        val noCostLine =
+            PurchaseRequestLine(
+                id = "prl-1",
+                lineNumber = 1,
+                productId = "p-1",
+                productSku = "SKU-1",
+                productName = "Widget",
+                quantity = BigDecimal("3"),
+                estimatedUnitCost = null,
+            )
+        whenever(repository.findById("pr-1")).thenReturn(Optional.of(approvedRequest(lines = listOf(noCostLine))))
+
+        assertThatThrownBy { service.convertToPurchaseOrder("pr-1", ConvertPurchaseRequestRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `convert uses a per-line cost override`() {
+        val noCostLine =
+            PurchaseRequestLine(
+                id = "prl-1",
+                lineNumber = 1,
+                productId = "p-1",
+                productSku = "SKU-1",
+                productName = "Widget",
+                quantity = BigDecimal("3"),
+                estimatedUnitCost = null,
+            )
+        whenever(repository.findById("pr-1")).thenReturn(Optional.of(approvedRequest(lines = listOf(noCostLine))))
+        whenever(purchaseOrderService.createPurchaseOrder(any(), eq(orgId), eq(userId))).thenAnswer {
+            val req = it.arguments[0] as CreatePurchaseOrderRequest
+            PurchaseOrder(
+                id = "po-9",
+                poNumber = "PO-0001",
+                vendorId = "v-1",
+                vendorName = "Acme",
+                warehouseId = "wh-1",
+                orderDate = LocalDate.of(2026, 5, 1),
+                organizationId = orgId,
+                lines = emptyList(),
+                totalAmount = req.lines[0].unitCost!!.multiply(req.lines[0].quantity),
+                createdBy = userId,
+            )
+        }
+
+        service.convertToPurchaseOrder(
+            "pr-1",
+            ConvertPurchaseRequestRequest(lineCosts = listOf(ConvertPurchaseRequestLineCost(lineId = "prl-1", unitCost = BigDecimal("7")))),
+            orgId,
+            userId,
+        )
+
+        val captor = argumentCaptor<CreatePurchaseOrderRequest>()
+        org.mockito.kotlin
+            .verify(purchaseOrderService)
+            .createPurchaseOrder(captor.capture(), eq(orgId), eq(userId))
+        assertThat(captor.firstValue.lines[0].unitCost).isEqualByComparingTo("7")
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("pr-1"))
+            .thenReturn(Optional.of(approvedRequest().copy(organizationId = "other")))
+
+        assertThatThrownBy { service.getPurchaseRequest("pr-1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}


### PR DESCRIPTION
Completes #45 — the purchase-request (requisition) stage that precedes a purchase order. (PO approval shipped in v0.10.0.)

## What
A requisition workflow that feeds the existing PO flow.

- **Migration** `V0016__purchase_requests.sql` — `purchase_requests` + `purchase_request_lines`.
- **Lifecycle** — `DRAFT → SUBMITTED → APPROVED/REJECTED`, plus `CANCELLED` and `CONVERTED`.
  - `POST /procurement/purchase-requests` (draft), `GET` list (filter by `status`/`requestedBy`) and `GET /{id}`.
  - `POST /{id}/submit`, `/approve`, `/reject`, `/cancel`.
  - `POST /{id}/convert` → builds a **PurchaseOrder** via `PurchaseOrderService`. Vendor, warehouse and order date come from the request body or fall back to the requisition; each line's unit cost is a per-line override or the line's estimated cost. The request is marked `CONVERTED` and linked to the new PO (`convertedPurchaseOrderId`).
- **Authorization** mirrors the PO endpoints: `procurement:read` / `procurement:write`, with `procurement:approve` on approve/reject.

## Tests
`PurchaseRequestServiceTest` covers create + line validation, the state-transition guards, convert (from estimated costs, with a per-line override, and the missing-cost failure), the converted-cancel guard, and cross-org isolation.

## Notes
Migration is `V0016` (after #158's `V0014` and #159's `V0015`) so the three open cycle PRs don't collide. Closes #45.
