### PR TITLE
feat(hr): employee self-service /hr/me (#37)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/SelfServiceController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/SelfServiceController.kt
@@ -1,0 +1,95 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.EmployeeCompensationResponse
+import com.aquinofroilan.tessera.dto.EmployeeResponse
+import com.aquinofroilan.tessera.dto.LeaveRequestResponse
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.SelfServiceService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Employee self-service surface. Open to any authenticated user; each endpoint
+ * resolves the caller's own employee record, so a user can only access their
+ * own profile, leave, and compensation.
+ */
+@RestController
+@RequestMapping("/hr/me")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class SelfServiceController(
+    private val selfServiceService: SelfServiceService,
+    private val authContext: AuthenticationContext,
+) {
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myProfile(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(selfServiceService.myProfile(userId, orgId)))
+    }
+
+    @GetMapping("/leave-requests")
+    @PreAuthorize("isAuthenticated()")
+    fun myLeaveRequests(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(selfServiceService.myLeaveRequests(userId, orgId).map { LeaveRequestResponse.from(it) })
+    }
+
+    @PostMapping("/leave-requests")
+    @PreAuthorize("isAuthenticated()")
+    fun submitLeave(
+        @Valid @RequestBody request: SubmitSelfLeaveRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        val created = selfServiceService.submitLeave(userId, orgId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(LeaveRequestResponse.from(created))
+    }
+
+    @GetMapping("/leave-balance")
+    @PreAuthorize("isAuthenticated()")
+    fun myLeaveBalance(
+        @RequestParam leaveTypeId: String,
+        @RequestParam(required = false) year: Int?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        val resolvedYear = year ?: LocalDate.now(ZoneOffset.UTC).year
+        return ResponseEntity.ok(selfServiceService.myLeaveBalance(userId, orgId, leaveTypeId, resolvedYear))
+    }
+
+    @GetMapping("/compensation")
+    @PreAuthorize("isAuthenticated()")
+    fun myCompensationHistory(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(
+            selfServiceService.myCompensationHistory(userId, orgId).map { EmployeeCompensationResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/compensation/current")
+    @PreAuthorize("isAuthenticated()")
+    fun myCurrentCompensation(
+        @RequestParam(required = false) asOf: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        val resolved = asOf ?: LocalDate.now(ZoneOffset.UTC)
+        return ResponseEntity.ok(EmployeeCompensationResponse.from(selfServiceService.myCurrentCompensation(userId, orgId, resolved)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/EmployeeDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/EmployeeDtos.kt
@@ -16,6 +16,7 @@ data class CreateEmployeeRequest(
     val email: String? = null,
     val jobTitle: String? = null,
     val departmentId: String? = null,
+    val userId: String? = null,
     @field:NotNull(message = "Hire date is required")
     val hireDate: LocalDate?,
 )
@@ -26,6 +27,7 @@ data class UpdateEmployeeRequest(
     @field:Email(message = "Email must be valid")
     val email: String? = null,
     val jobTitle: String? = null,
+    val userId: String? = null,
 )
 
 data class TerminateEmployeeRequest(
@@ -41,6 +43,7 @@ data class EmployeeResponse(
     val email: String?,
     val jobTitle: String?,
     val departmentId: String?,
+    val userId: String?,
     val hireDate: String,
     val status: EmploymentStatus,
     val terminationDate: String?,
@@ -58,6 +61,7 @@ data class EmployeeResponse(
                 email = employee.email,
                 jobTitle = employee.jobTitle,
                 departmentId = employee.departmentId,
+                userId = employee.userId,
                 hireDate = employee.hireDate.toString(),
                 status = employee.status,
                 terminationDate = employee.terminationDate?.toString(),

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/SubmitSelfLeaveRequest.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/SubmitSelfLeaveRequest.kt
@@ -1,0 +1,19 @@
+package com.aquinofroilan.tessera.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+/**
+ * A leave request submitted by an employee for themselves. The employee is
+ * resolved from the authenticated user, so no employee ID is supplied.
+ */
+data class SubmitSelfLeaveRequest(
+    @field:NotBlank(message = "Leave type ID is required")
+    val leaveTypeId: String,
+    @field:NotNull(message = "Start date is required")
+    val startDate: LocalDate?,
+    @field:NotNull(message = "End date is required")
+    val endDate: LocalDate?,
+    val reason: String? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Employee.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Employee.kt
@@ -38,6 +38,8 @@ data class Employee(
     val jobTitle: String? = null,
     @Column(name = "department_id", columnDefinition = "uuid")
     val departmentId: String? = null,
+    @Column(name = "user_id", columnDefinition = "uuid")
+    val userId: String? = null,
     @Column(name = "hire_date")
     val hireDate: LocalDate,
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/EmployeeRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/EmployeeRepository.kt
@@ -4,10 +4,16 @@ import com.aquinofroilan.tessera.model.Employee
 import com.aquinofroilan.tessera.model.EmploymentStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 
 @Repository
 interface EmployeeRepository : JpaRepository<Employee, String> {
     fun findByOrganizationId(organizationId: String): List<Employee>
+
+    fun findByOrganizationIdAndUserId(
+        organizationId: String,
+        userId: String,
+    ): Optional<Employee>
 
     fun findByOrganizationIdAndStatus(
         organizationId: String,

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/EmployeeService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/EmployeeService.kt
@@ -24,6 +24,7 @@ class EmployeeService(
     ): Employee {
         val hireDate = request.hireDate ?: throw BusinessRuleException("Hire date is required")
         request.departmentId?.let { requireActiveDepartment(it, organizationId) }
+        request.userId?.let { requireUserUnlinked(it, organizationId, excludingEmployeeId = null) }
         return saveWithRetry(organizationId) { number ->
             Employee(
                 employeeNumber = number,
@@ -32,6 +33,7 @@ class EmployeeService(
                 email = request.email?.trim(),
                 jobTitle = request.jobTitle?.trim(),
                 departmentId = request.departmentId,
+                userId = request.userId,
                 hireDate = hireDate,
                 organizationId = organizationId,
             )
@@ -70,15 +72,26 @@ class EmployeeService(
         organizationId: String,
     ): Employee {
         val employee = getEmployee(id, organizationId)
+        request.userId?.let { requireUserUnlinked(it, organizationId, excludingEmployeeId = employee.id) }
         return employeeRepository.save(
             employee.copy(
                 firstName = request.firstName?.trim() ?: employee.firstName,
                 lastName = request.lastName?.trim() ?: employee.lastName,
                 email = request.email?.trim() ?: employee.email,
                 jobTitle = request.jobTitle?.trim() ?: employee.jobTitle,
+                userId = request.userId ?: employee.userId,
             ),
         )
     }
+
+    /** Resolves the employee record linked to the given login user, for self-service. */
+    fun getEmployeeByUser(
+        userId: String,
+        organizationId: String,
+    ): Employee =
+        employeeRepository.findByOrganizationIdAndUserId(organizationId, userId).orElseThrow {
+            ResourceNotFoundException("No employee record is linked to your account")
+        }
 
     @Transactional
     fun assignDepartment(
@@ -134,6 +147,17 @@ class EmployeeService(
         return employeeRepository.save(
             employee.copy(status = EmploymentStatus.TERMINATED, terminationDate = terminationDate),
         )
+    }
+
+    private fun requireUserUnlinked(
+        userId: String,
+        organizationId: String,
+        excludingEmployeeId: String?,
+    ) {
+        val existing = employeeRepository.findByOrganizationIdAndUserId(organizationId, userId)
+        if (existing.isPresent && existing.get().id != excludingEmployeeId) {
+            throw BusinessRuleException("That user is already linked to another employee")
+        }
     }
 
     private fun requireActiveDepartment(

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/SelfServiceService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/SelfServiceService.kt
@@ -1,0 +1,83 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateLeaveRequestRequest
+import com.aquinofroilan.tessera.dto.LeaveBalanceResponse
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import com.aquinofroilan.tessera.model.Employee
+import com.aquinofroilan.tessera.model.EmployeeCompensation
+import com.aquinofroilan.tessera.model.LeaveRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+/**
+ * Employee self-service: a self-scoped facade over the HR services. Every call
+ * resolves the caller's own employee record from their login user, so an
+ * employee can only ever see or act on their own data.
+ */
+@Service
+class SelfServiceService(
+    private val employeeService: EmployeeService,
+    private val leaveRequestService: LeaveRequestService,
+    private val employeeCompensationService: EmployeeCompensationService,
+) {
+    fun myProfile(
+        userId: String,
+        organizationId: String,
+    ): Employee = employeeService.getEmployeeByUser(userId, organizationId)
+
+    fun myLeaveRequests(
+        userId: String,
+        organizationId: String,
+    ): List<LeaveRequest> {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return leaveRequestService.listLeaveRequests(organizationId, employeeId = me.id)
+    }
+
+    @Transactional
+    fun submitLeave(
+        userId: String,
+        organizationId: String,
+        request: SubmitSelfLeaveRequest,
+    ): LeaveRequest {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return leaveRequestService.createLeaveRequest(
+            CreateLeaveRequestRequest(
+                employeeId = me.id,
+                leaveTypeId = request.leaveTypeId,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                reason = request.reason,
+            ),
+            organizationId,
+            requestedBy = userId,
+        )
+    }
+
+    fun myLeaveBalance(
+        userId: String,
+        organizationId: String,
+        leaveTypeId: String,
+        year: Int,
+    ): LeaveBalanceResponse {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return leaveRequestService.balance(me.id, leaveTypeId, year, organizationId)
+    }
+
+    fun myCompensationHistory(
+        userId: String,
+        organizationId: String,
+    ): List<EmployeeCompensation> {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return employeeCompensationService.listCompensation(me.id, organizationId)
+    }
+
+    fun myCurrentCompensation(
+        userId: String,
+        organizationId: String,
+        asOf: LocalDate,
+    ): EmployeeCompensation {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return employeeCompensationService.currentCompensation(me.id, organizationId, asOf)
+    }
+}

--- a/src/main/resources/db/migration/V0017__employee_user_link.sql
+++ b/src/main/resources/db/migration/V0017__employee_user_link.sql
@@ -1,0 +1,9 @@
+-- HR module: link an employee record to a login user, enabling employee
+-- self-service (an authenticated user resolving to their own employee record).
+-- At most one employee per user within an organization.
+ALTER TABLE employees
+    ADD COLUMN user_id uuid REFERENCES users(uuid) ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX employees_unique_user_per_org
+    ON employees(organization_id, user_id)
+    WHERE user_id IS NOT NULL;

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/EmployeeServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/EmployeeServiceTest.kt
@@ -2,6 +2,7 @@ package com.aquinofroilan.tessera.service
 
 import com.aquinofroilan.tessera.dto.CreateEmployeeRequest
 import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
 import com.aquinofroilan.tessera.model.Department
 import com.aquinofroilan.tessera.model.Employee
 import com.aquinofroilan.tessera.model.EmploymentStatus
@@ -100,5 +101,38 @@ class EmployeeServiceTest {
         whenever(repository.findById("e1")).thenReturn(Optional.of(employee(status = EmploymentStatus.TERMINATED)))
         assertThatThrownBy { service.assignDepartment("e1", "d1", orgId) }
             .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `create links a user`() {
+        whenever(repository.findByOrganizationIdAndUserId(orgId, "u1")).thenReturn(Optional.empty())
+        val emp =
+            service.createEmployee(
+                CreateEmployeeRequest(firstName = "Ada", lastName = "Lovelace", hireDate = hireDate, userId = "u1"),
+                orgId,
+            )
+        assertThat(emp.userId).isEqualTo("u1")
+    }
+
+    @Test
+    fun `create rejects linking a user already linked to another employee`() {
+        whenever(repository.findByOrganizationIdAndUserId(orgId, "u1"))
+            .thenReturn(Optional.of(employee(id = "other")))
+        assertThatThrownBy {
+            service.createEmployee(
+                CreateEmployeeRequest(firstName = "Ada", lastName = "Lovelace", hireDate = hireDate, userId = "u1"),
+                orgId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `getEmployeeByUser resolves the linked employee or throws`() {
+        whenever(repository.findByOrganizationIdAndUserId(orgId, "u1")).thenReturn(Optional.of(employee()))
+        assertThat(service.getEmployeeByUser("u1", orgId).id).isEqualTo("e1")
+
+        whenever(repository.findByOrganizationIdAndUserId(orgId, "u2")).thenReturn(Optional.empty())
+        assertThatThrownBy { service.getEmployeeByUser("u2", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
     }
 }

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/SelfServiceServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/SelfServiceServiceTest.kt
@@ -1,0 +1,93 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateLeaveRequestRequest
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Employee
+import com.aquinofroilan.tessera.model.EmploymentStatus
+import com.aquinofroilan.tessera.model.LeaveRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+
+class SelfServiceServiceTest {
+    private lateinit var employeeService: EmployeeService
+    private lateinit var leaveRequestService: LeaveRequestService
+    private lateinit var employeeCompensationService: EmployeeCompensationService
+    private lateinit var service: SelfServiceService
+
+    private val orgId = "org-1"
+    private val userId = "u1"
+
+    @BeforeEach
+    fun setup() {
+        employeeService = mock(EmployeeService::class.java)
+        leaveRequestService = mock(LeaveRequestService::class.java)
+        employeeCompensationService = mock(EmployeeCompensationService::class.java)
+        whenever(employeeService.getEmployeeByUser(userId, orgId)).thenReturn(me())
+        service = SelfServiceService(employeeService, leaveRequestService, employeeCompensationService)
+    }
+
+    private fun me() =
+        Employee(
+            id = "e1",
+            employeeNumber = "EMP-0001",
+            firstName = "Ada",
+            lastName = "Lovelace",
+            hireDate = LocalDate.of(2020, 1, 1),
+            status = EmploymentStatus.ACTIVE,
+            userId = userId,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `my profile resolves the linked employee`() {
+        assertThat(service.myProfile(userId, orgId).id).isEqualTo("e1")
+    }
+
+    @Test
+    fun `my profile surfaces not-found when the user has no employee record`() {
+        whenever(employeeService.getEmployeeByUser("u2", orgId))
+            .thenThrow(ResourceNotFoundException("No employee record is linked to your account"))
+
+        assertThatThrownBy { service.myProfile("u2", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `submit leave forces the caller's own employee id`() {
+        whenever(leaveRequestService.createLeaveRequest(any(), eq(orgId), eq(userId)))
+            .thenReturn(mock(LeaveRequest::class.java))
+
+        service.submitLeave(
+            userId,
+            orgId,
+            SubmitSelfLeaveRequest(leaveTypeId = "lt1", startDate = LocalDate.of(2026, 5, 1), endDate = LocalDate.of(2026, 5, 3)),
+        )
+
+        val captor = argumentCaptor<CreateLeaveRequestRequest>()
+        verify(leaveRequestService).createLeaveRequest(captor.capture(), eq(orgId), eq(userId))
+        assertThat(captor.firstValue.employeeId).isEqualTo("e1")
+        assertThat(captor.firstValue.leaveTypeId).isEqualTo("lt1")
+    }
+
+    @Test
+    fun `leave balance delegates with the caller's own employee id`() {
+        service.myLeaveBalance(userId, orgId, "lt1", 2026)
+        verify(leaveRequestService).balance(eq("e1"), eq("lt1"), eq(2026), eq(orgId))
+    }
+
+    @Test
+    fun `compensation history delegates with the caller's own employee id`() {
+        service.myCompensationHistory(userId, orgId)
+        verify(employeeCompensationService).listCompensation(eq("e1"), eq(orgId))
+    }
+}


### PR DESCRIPTION
Completes #37 — employee self-service. The prerequisite was missing: employee records had **no link to a login user**, so a request couldn't resolve to "my" employee. This adds that link and a self-scoped `/hr/me` surface.

## What
- **Migration** `V0017__employee_user_link.sql` — `employees.user_id` (FK to `users`, unique per org so one employee per user).
- **Link plumbing** — `Employee.userId`; `CreateEmployeeRequest`/`UpdateEmployeeRequest` accept `userId` (guarded so a user can't be linked to two employees); `EmployeeService.getEmployeeByUser` resolves the caller's record.
- **Self-service** — `SelfServiceController` at `/hr/me`, open to any authenticated user; each call resolves the caller's own employee:
  - `GET /hr/me` — own profile
  - `GET /hr/me/leave-requests`, `POST /hr/me/leave-requests` — list and submit own leave (employee id is forced to the caller's, never taken from the body)
  - `GET /hr/me/leave-balance`
  - `GET /hr/me/compensation`, `GET /hr/me/compensation/current` — own compensation history / current
- **`SelfServiceService`** delegates to the existing HR services, always scoping to the caller's own employee id.

## Authorization
`@PreAuthorize("isAuthenticated()")` (the same predicate the GraphQL surface already uses) — self-service shouldn't require HR admin authorities; isolation comes from resolving the caller's own record. A user with no linked employee gets a clear 404.

## Tests
`EmployeeServiceTest` covers user linking + the one-user-per-employee guard + the resolver; `SelfServiceServiceTest` covers profile resolution, the not-linked case, and that leave submission / balance / compensation all force the caller's own employee id.

## Notes
Migration is `V0017` (after #158 `V0014`, #159 `V0015`, #160 `V0016`) so the four open cycle PRs don't collide. Closes #37.
