### PR TITLE
feat(graphql): bridge org-chart, attendance, purchase requests & self-service (#33/#35/#45/#37)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/AttendanceGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/AttendanceGraphqlController.kt
@@ -1,0 +1,54 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.AttendanceController
+import com.aquinofroilan.tessera.dto.ClockRequest
+import com.aquinofroilan.tessera.dto.RecordAttendanceRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+import java.time.LocalDate
+
+/**
+ * GraphQL bridge for the HR attendance routes — clock-in/out, manual entry and
+ * timesheets — delegating to the REST controller via the shared JSON-scalar
+ * pass-through. Authorization mirrors the REST endpoints (`hr:read`/`hr:write`).
+ */
+@Controller
+class AttendanceGraphqlController(
+    private val attendanceController: AttendanceController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun attendance(
+        @Argument employeeId: String?,
+        @Argument from: String?,
+        @Argument to: String?,
+    ): Any = support.unwrap(attendanceController.listTimesheet(employeeId, from?.let(LocalDate::parse), to?.let(LocalDate::parse)))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun attendanceRecord(
+        @Argument id: String,
+    ): Any = support.unwrap(attendanceController.getAttendance(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun clockIn(
+        @Argument input: Any,
+    ): Any = support.unwrap(attendanceController.clockIn(support.toRequest<ClockRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun clockOut(
+        @Argument input: Any,
+    ): Any = support.unwrap(attendanceController.clockOut(support.toRequest<ClockRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun recordAttendance(
+        @Argument input: Any,
+    ): Any = support.unwrap(attendanceController.recordAttendance(support.toRequest<RecordAttendanceRequest>(input)))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlController.kt
@@ -15,6 +15,7 @@ import com.aquinofroilan.tessera.dto.CreateLeaveTypeRequest
 import com.aquinofroilan.tessera.dto.CreatePayrollRunRequest
 import com.aquinofroilan.tessera.dto.CreatePositionRequest
 import com.aquinofroilan.tessera.dto.RejectLeaveRequestRequest
+import com.aquinofroilan.tessera.dto.SetDepartmentParentRequest
 import com.aquinofroilan.tessera.dto.TerminateEmployeeRequest
 import com.aquinofroilan.tessera.dto.UpdateDepartmentRequest
 import com.aquinofroilan.tessera.dto.UpdateEmployeeRequest
@@ -92,6 +93,10 @@ class HrGraphqlController(
         @Argument id: String,
     ): Any = support.unwrap(departmentController.getDepartment(id))
 
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun departmentOrgChart(): Any = support.unwrap(departmentController.getOrgChart())
+
     @MutationMapping
     @PreAuthorize("hasAuthority('hr:write')")
     fun createDepartment(
@@ -104,6 +109,16 @@ class HrGraphqlController(
         @Argument id: String,
         @Argument input: Any,
     ): Any = support.unwrap(departmentController.updateDepartment(id, support.toRequest<UpdateDepartmentRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun setDepartmentParent(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<SetDepartmentParentRequest>(it) } ?: SetDepartmentParentRequest()
+        return support.unwrap(departmentController.setParent(id, request))
+    }
 
     @MutationMapping
     @PreAuthorize("hasAuthority('hr:write')")

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/PurchaseRequestGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/PurchaseRequestGraphqlController.kt
@@ -1,0 +1,79 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.PurchaseRequestController
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.RejectPurchaseRequestRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for the procurement purchase-request (requisition) routes,
+ * delegating to the REST controller via the shared JSON-scalar pass-through.
+ * Authorization mirrors the REST endpoints (`procurement:read`/`:write`/`:approve`).
+ */
+@Controller
+class PurchaseRequestGraphqlController(
+    private val purchaseRequestController: PurchaseRequestController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun purchaseRequests(
+        @Argument status: String?,
+        @Argument requestedBy: String?,
+    ): Any = support.unwrap(purchaseRequestController.listPurchaseRequests(status, requestedBy))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun purchaseRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseRequestController.getPurchaseRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun createPurchaseRequest(
+        @Argument input: Any,
+    ): Any = support.unwrap(purchaseRequestController.createPurchaseRequest(support.toRequest<CreatePurchaseRequestRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun submitPurchaseRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseRequestController.submitPurchaseRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun approvePurchaseRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseRequestController.approvePurchaseRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun rejectPurchaseRequest(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<RejectPurchaseRequestRequest>(it) }
+        return support.unwrap(purchaseRequestController.rejectPurchaseRequest(id, request))
+    }
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun cancelPurchaseRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseRequestController.cancelPurchaseRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun convertPurchaseRequest(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<ConvertPurchaseRequestRequest>(it) }
+        return support.unwrap(purchaseRequestController.convertPurchaseRequest(id, request))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/SelfServiceGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/SelfServiceGraphqlController.kt
@@ -1,0 +1,53 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.SelfServiceController
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+import java.time.LocalDate
+
+/**
+ * GraphQL bridge for the employee self-service routes (`/hr/me`), delegating to
+ * the REST controller via the shared JSON-scalar pass-through. Open to any
+ * authenticated user; the controller resolves the caller's own employee record,
+ * so a user can only ever see or act on their own data.
+ */
+@Controller
+class SelfServiceGraphqlController(
+    private val selfServiceController: SelfServiceController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun me(): Any = support.unwrap(selfServiceController.myProfile())
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myLeaveRequests(): Any = support.unwrap(selfServiceController.myLeaveRequests())
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myLeaveBalance(
+        @Argument leaveTypeId: String,
+        @Argument year: Int?,
+    ): Any = support.unwrap(selfServiceController.myLeaveBalance(leaveTypeId, year))
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myCompensation(): Any = support.unwrap(selfServiceController.myCompensationHistory())
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myCurrentCompensation(
+        @Argument asOf: String?,
+    ): Any = support.unwrap(selfServiceController.myCurrentCompensation(asOf?.let(LocalDate::parse)))
+
+    @MutationMapping
+    @PreAuthorize("isAuthenticated()")
+    fun submitMyLeave(
+        @Argument input: Any,
+    ): Any = support.unwrap(selfServiceController.submitLeave(support.toRequest<SubmitSelfLeaveRequest>(input)))
+}

--- a/src/main/resources/graphql/attendance.graphqls
+++ b/src/main/resources/graphql/attendance.graphqls
@@ -1,0 +1,10 @@
+extend type Query {
+  attendance(employeeId: String, from: String, to: String): JSON!
+  attendanceRecord(id: ID!): JSON!
+}
+
+extend type Mutation {
+  clockIn(input: JSON!): JSON!
+  clockOut(input: JSON!): JSON!
+  recordAttendance(input: JSON!): JSON!
+}

--- a/src/main/resources/graphql/hr.graphqls
+++ b/src/main/resources/graphql/hr.graphqls
@@ -4,6 +4,7 @@ extend type Query {
 
   departments(activeOnly: Boolean = false): JSON!
   department(id: ID!): JSON!
+  departmentOrgChart: JSON!
 
   employees(status: String, departmentId: String): JSON!
   employee(id: ID!): JSON!
@@ -30,6 +31,7 @@ extend type Mutation {
 
   createDepartment(input: JSON!): JSON!
   updateDepartment(id: ID!, input: JSON!): JSON!
+  setDepartmentParent(id: ID!, input: JSON): JSON!
   deactivateDepartment(id: ID!): JSON!
 
   createEmployee(input: JSON!): JSON!

--- a/src/main/resources/graphql/me.graphqls
+++ b/src/main/resources/graphql/me.graphqls
@@ -1,0 +1,11 @@
+extend type Query {
+  me: JSON!
+  myLeaveRequests: JSON!
+  myLeaveBalance(leaveTypeId: ID!, year: Int): JSON!
+  myCompensation: JSON!
+  myCurrentCompensation(asOf: String): JSON!
+}
+
+extend type Mutation {
+  submitMyLeave(input: JSON!): JSON!
+}

--- a/src/main/resources/graphql/purchase-requests.graphqls
+++ b/src/main/resources/graphql/purchase-requests.graphqls
@@ -1,0 +1,13 @@
+extend type Query {
+  purchaseRequests(status: String, requestedBy: String): JSON!
+  purchaseRequest(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createPurchaseRequest(input: JSON!): JSON!
+  submitPurchaseRequest(id: ID!): JSON!
+  approvePurchaseRequest(id: ID!): JSON!
+  rejectPurchaseRequest(id: ID!, input: JSON): JSON!
+  cancelPurchaseRequest(id: ID!): JSON!
+  convertPurchaseRequest(id: ID!, input: JSON): JSON!
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/AttendanceGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/AttendanceGraphqlControllerTest.kt
@@ -1,0 +1,91 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.AttendanceController
+import com.aquinofroilan.tessera.dto.ClockRequest
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [AttendanceGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class AttendanceGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var attendanceController: AttendanceController
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `attendance query should return json payload`() {
+        `when`(attendanceController.listTimesheet(null, null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "a1", "status" to "PRESENT"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  attendance
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("attendance[0].id")
+            .entity(String::class.java)
+            .isEqualTo("a1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["hr:write"])
+    fun `clockIn mutation should bridge to controller`() {
+        `when`(attendanceController.clockIn(any<ClockRequest>()))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "a1", "status" to "PRESENT")))
+
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  clockIn(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("employeeId" to "e1"))
+            .execute()
+            .path("clockIn.status")
+            .entity(String::class.java)
+            .isEqualTo("PRESENT")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `clockIn mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  clockIn(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("employeeId" to "e1"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlControllerTest.kt
@@ -72,6 +72,29 @@ class HrGraphqlControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `departmentOrgChart query should return the nested tree`() {
+        `when`(departmentController.getOrgChart())
+            .thenReturn(
+                ResponseEntity.ok(
+                    listOf(mapOf("id" to "d1", "children" to listOf(mapOf("id" to "d2", "children" to emptyList<Any>())))),
+                ),
+            )
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  departmentOrgChart
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("departmentOrgChart[0].children[0].id")
+            .entity(String::class.java)
+            .isEqualTo("d2")
+    }
+
+    @Test
     @WithMockUser(authorities = ["hr:approve"])
     fun `approvePayrollRun mutation should bridge to controller`() {
         `when`(payrollRunController.approvePayrollRun("pr1"))

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/PurchaseRequestGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/PurchaseRequestGraphqlControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.PurchaseRequestController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [PurchaseRequestGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class PurchaseRequestGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var purchaseRequestController: PurchaseRequestController
+
+    @Test
+    @WithMockUser(authorities = ["procurement:read"])
+    fun `purchaseRequests query should return json payload`() {
+        `when`(purchaseRequestController.listPurchaseRequests(null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "pr1", "status" to "DRAFT"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  purchaseRequests
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("purchaseRequests[0].id")
+            .entity(String::class.java)
+            .isEqualTo("pr1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["procurement:approve"])
+    fun `approvePurchaseRequest mutation should bridge to controller`() {
+        `when`(purchaseRequestController.approvePurchaseRequest("pr1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "pr1", "status" to "APPROVED")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  approvePurchaseRequest(id: "pr1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("approvePurchaseRequest.status")
+            .entity(String::class.java)
+            .isEqualTo("APPROVED")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["procurement:read"])
+    fun `createPurchaseRequest mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createPurchaseRequest(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("lines" to emptyList<Any>()))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/SelfServiceGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/SelfServiceGraphqlControllerTest.kt
@@ -1,0 +1,89 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.SelfServiceController
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [SelfServiceGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class SelfServiceGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var selfServiceController: SelfServiceController
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `me query returns the caller profile`() {
+        `when`(selfServiceController.myProfile())
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "e1", "firstName" to "Ada")))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  me
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("me.id")
+            .entity(String::class.java)
+            .isEqualTo("e1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `submitMyLeave mutation bridges to controller`() {
+        `when`(selfServiceController.submitLeave(any<SubmitSelfLeaveRequest>()))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "lr1", "status" to "PENDING")))
+
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  submitMyLeave(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("leaveTypeId" to "lt1", "startDate" to "2026-05-01", "endDate" to "2026-05-03"))
+            .execute()
+            .path("submitMyLeave.status")
+            .entity(String::class.java)
+            .isEqualTo("PENDING")
+    }
+
+    @Test
+    fun `me query is denied for an unauthenticated caller`() {
+        graphQlTester
+            .document(
+                """
+                query {
+                  me
+                }
+                """.trimIndent(),
+            ).execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}


### PR DESCRIPTION
Dedicated branch for the GraphQL bridge of the 0.11.0 cycle's four new features — restoring GraphQL parity with the REST surface (same JSON-scalar pass-through pattern as #133/#156). The feature PRs (#158/#159/#160/#161) merged REST-only; this brings their GraphQL.

## Bridges added
- **Org chart (#33)** — `departmentOrgChart` query + `setDepartmentParent` mutation (`hr.graphqls` / `HrGraphqlController`).
- **Attendance (#35)** — `attendance.graphqls` + `AttendanceGraphqlController`: `attendance`/`attendanceRecord` queries; `clockIn`/`clockOut`/`recordAttendance` mutations.
- **Purchase requests (#45)** — `purchase-requests.graphqls` + `PurchaseRequestGraphqlController`: `purchaseRequests`/`purchaseRequest` queries; create/submit/approve/reject/cancel/convert mutations.
- **Self-service (#37)** — `me.graphqls` + `SelfServiceGraphqlController`: `me`, `myLeaveRequests`, `myLeaveBalance`, `myCompensation`, `myCurrentCompensation` queries; `submitMyLeave` mutation.

## Conventions
Each resolver delegates to the existing REST controller via `GraphqlBridgeSupport` (JSON-scalar in/out). Authorities mirror REST exactly: HR uses `hr:read`/`hr:write`, procurement uses `procurement:read`/`:write`/`:approve`, and self-service uses `isAuthenticated()` (isolation comes from resolving the caller's own record). Every bridge has a `@GraphQlTest` covering a query, a mutation, and an authorization-denied path.
