### PR TITLE
feat(sales): quotation workflow + GraphQL (#51)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/QuotationController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/QuotationController.kt
@@ -1,0 +1,123 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.ConvertQuotationRequest
+import com.aquinofroilan.tessera.dto.CreateQuotationRequest
+import com.aquinofroilan.tessera.dto.QuotationResponse
+import com.aquinofroilan.tessera.dto.RejectQuotationRequest
+import com.aquinofroilan.tessera.dto.SalesOrderResponse
+import com.aquinofroilan.tessera.model.QuotationStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.QuotationService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/sales/quotations")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class QuotationController(
+    private val quotationService: QuotationService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun createQuotation(
+        @Valid @RequestBody request: CreateQuotationRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
+        val created = quotationService.createQuotation(request, orgId, createdBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(QuotationResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('sales:read')")
+    fun listQuotations(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) customerId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val quoteStatus =
+            if (status != null) {
+                try {
+                    QuotationStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(
+            quotationService.listQuotations(orgId, quoteStatus, customerId).map { QuotationResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('sales:read')")
+    fun getQuotation(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(QuotationResponse.from(quotationService.getQuotation(id, orgId)))
+    }
+
+    @PostMapping("/{id}/send")
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun sendQuotation(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(QuotationResponse.from(quotationService.sendQuotation(id, orgId)))
+    }
+
+    @PostMapping("/{id}/accept")
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun acceptQuotation(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(QuotationResponse.from(quotationService.acceptQuotation(id, orgId)))
+    }
+
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun rejectQuotation(
+        @PathVariable id: String,
+        @RequestBody(required = false) request: RejectQuotationRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(QuotationResponse.from(quotationService.rejectQuotation(id, request?.reason, orgId)))
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun cancelQuotation(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(QuotationResponse.from(quotationService.cancelQuotation(id, orgId)))
+    }
+
+    @PostMapping("/{id}/convert")
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun convertQuotation(
+        @PathVariable id: String,
+        @Valid @RequestBody(required = false) request: ConvertQuotationRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
+        val salesOrder = quotationService.convertToSalesOrder(id, request ?: ConvertQuotationRequest(), orgId, createdBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(SalesOrderResponse.from(salesOrder))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/QuotationDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/QuotationDtos.kt
@@ -1,0 +1,122 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.Quotation
+import com.aquinofroilan.tessera.model.QuotationStatus
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreateQuotationLineRequest(
+    @field:NotBlank(message = "Product ID is required")
+    val productId: String,
+    @field:NotNull(message = "Quantity is required")
+    @field:Positive(message = "Quantity must be positive")
+    val quantity: BigDecimal?,
+    @field:NotNull(message = "Unit price is required")
+    val unitPrice: BigDecimal?,
+    val description: String? = null,
+)
+
+data class CreateQuotationRequest(
+    @field:NotBlank(message = "Customer ID is required")
+    val customerId: String,
+    val warehouseId: String? = null,
+    @field:NotNull(message = "Quote date is required")
+    val quoteDate: LocalDate?,
+    val validUntil: LocalDate? = null,
+    val referenceNumber: String? = null,
+    @field:NotEmpty(message = "At least one line item is required")
+    @field:Valid
+    val lines: List<CreateQuotationLineRequest>,
+)
+
+data class RejectQuotationRequest(
+    val reason: String? = null,
+)
+
+/**
+ * Options applied when converting an accepted quote into a sales order. The
+ * warehouse and order date may be supplied here or fall back to the quote's
+ * warehouse / today.
+ */
+data class ConvertQuotationRequest(
+    val warehouseId: String? = null,
+    val orderDate: LocalDate? = null,
+    val expectedDate: LocalDate? = null,
+)
+
+data class QuotationLineResponse(
+    val id: String,
+    val lineNumber: Int,
+    val productId: String,
+    val productSku: String,
+    val productName: String,
+    val quantity: BigDecimal,
+    val unitPrice: BigDecimal,
+    val lineTotal: BigDecimal,
+    val description: String?,
+)
+
+data class QuotationResponse(
+    val id: String,
+    val quoteNumber: String,
+    val customerId: String,
+    val customerName: String,
+    val warehouseId: String?,
+    val quoteDate: String,
+    val validUntil: String?,
+    val referenceNumber: String?,
+    val organizationId: String,
+    val status: QuotationStatus,
+    val lines: List<QuotationLineResponse>,
+    val totalAmount: BigDecimal,
+    val createdBy: String,
+    val sentAt: String?,
+    val decidedAt: String?,
+    val decisionReason: String?,
+    val convertedSalesOrderId: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(quote: Quotation) =
+            QuotationResponse(
+                id = quote.id,
+                quoteNumber = quote.quoteNumber,
+                customerId = quote.customerId,
+                customerName = quote.customerName,
+                warehouseId = quote.warehouseId,
+                quoteDate = quote.quoteDate.toString(),
+                validUntil = quote.validUntil?.toString(),
+                referenceNumber = quote.referenceNumber,
+                organizationId = quote.organizationId,
+                status = quote.status,
+                lines =
+                    quote.lines.map { line ->
+                        QuotationLineResponse(
+                            id = line.id,
+                            lineNumber = line.lineNumber,
+                            productId = line.productId,
+                            productSku = line.productSku,
+                            productName = line.productName,
+                            quantity = line.quantity,
+                            unitPrice = line.unitPrice,
+                            lineTotal = line.lineTotal,
+                            description = line.description,
+                        )
+                    },
+                totalAmount = quote.totalAmount,
+                createdBy = quote.createdBy,
+                sentAt = quote.sentAt?.toString(),
+                decidedAt = quote.decidedAt?.toString(),
+                decisionReason = quote.decisionReason,
+                convertedSalesOrderId = quote.convertedSalesOrderId,
+                createdAt = quote.createdAt?.toString(),
+                updatedAt = quote.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/QuotationGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/QuotationGraphqlController.kt
@@ -1,0 +1,79 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.QuotationController
+import com.aquinofroilan.tessera.dto.ConvertQuotationRequest
+import com.aquinofroilan.tessera.dto.CreateQuotationRequest
+import com.aquinofroilan.tessera.dto.RejectQuotationRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for the sales quotation routes, delegating to the REST
+ * controller via the shared JSON-scalar pass-through. Authorization mirrors the
+ * REST endpoints (`sales:read`/`sales:write`).
+ */
+@Controller
+class QuotationGraphqlController(
+    private val quotationController: QuotationController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('sales:read')")
+    fun quotations(
+        @Argument status: String?,
+        @Argument customerId: String?,
+    ): Any = support.unwrap(quotationController.listQuotations(status, customerId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('sales:read')")
+    fun quotation(
+        @Argument id: String,
+    ): Any = support.unwrap(quotationController.getQuotation(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun createQuotation(
+        @Argument input: Any,
+    ): Any = support.unwrap(quotationController.createQuotation(support.toRequest<CreateQuotationRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun sendQuotation(
+        @Argument id: String,
+    ): Any = support.unwrap(quotationController.sendQuotation(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun acceptQuotation(
+        @Argument id: String,
+    ): Any = support.unwrap(quotationController.acceptQuotation(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun rejectQuotation(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<RejectQuotationRequest>(it) }
+        return support.unwrap(quotationController.rejectQuotation(id, request))
+    }
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun cancelQuotation(
+        @Argument id: String,
+    ): Any = support.unwrap(quotationController.cancelQuotation(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun convertQuotation(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<ConvertQuotationRequest>(it) }
+        return support.unwrap(quotationController.convertQuotation(id, request))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Quotation.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Quotation.kt
@@ -1,0 +1,101 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class QuotationStatus {
+    DRAFT,
+    SENT,
+    ACCEPTED,
+    REJECTED,
+    CONVERTED,
+    CANCELLED,
+}
+
+@Entity
+@Table(name = "quotation_lines")
+data class QuotationLine(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "line_number")
+    val lineNumber: Int = 0,
+    @Column(name = "product_id", columnDefinition = "uuid")
+    val productId: String,
+    @Column(name = "product_sku")
+    val productSku: String,
+    @Column(name = "product_name")
+    val productName: String,
+    val quantity: BigDecimal,
+    @Column(name = "unit_price")
+    val unitPrice: BigDecimal,
+    @Column(name = "line_total")
+    val lineTotal: BigDecimal,
+    val description: String? = null,
+)
+
+@Entity
+@Table(name = "quotations")
+@EntityListeners(AuditingEntityListener::class)
+data class Quotation(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "quote_number")
+    val quoteNumber: String,
+    @Column(name = "customer_id", columnDefinition = "uuid")
+    val customerId: String,
+    @Column(name = "customer_name")
+    val customerName: String,
+    @Column(name = "warehouse_id", columnDefinition = "uuid")
+    val warehouseId: String? = null,
+    @Column(name = "quote_date")
+    val quoteDate: LocalDate,
+    @Column(name = "valid_until")
+    val validUntil: LocalDate? = null,
+    @Column(name = "reference_number")
+    val referenceNumber: String? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Enumerated(EnumType.STRING)
+    val status: QuotationStatus = QuotationStatus.DRAFT,
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "quotation_id")
+    @OrderBy("lineNumber ASC")
+    val lines: List<QuotationLine>,
+    @Column(name = "total_amount")
+    val totalAmount: BigDecimal,
+    @Column(name = "created_by", columnDefinition = "uuid")
+    val createdBy: String,
+    @Column(name = "sent_at")
+    val sentAt: LocalDateTime? = null,
+    @Column(name = "decided_at")
+    val decidedAt: LocalDateTime? = null,
+    @Column(name = "decision_reason")
+    val decisionReason: String? = null,
+    @Column(name = "converted_sales_order_id", columnDefinition = "uuid")
+    val convertedSalesOrderId: String? = null,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/QuotationRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/QuotationRepository.kt
@@ -1,0 +1,29 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.Quotation
+import com.aquinofroilan.tessera.model.QuotationStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface QuotationRepository : JpaRepository<Quotation, String> {
+    fun findByOrganizationId(organizationId: String): List<Quotation>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: QuotationStatus,
+    ): List<Quotation>
+
+    fun findByOrganizationIdAndCustomerId(
+        organizationId: String,
+        customerId: String,
+    ): List<Quotation>
+
+    fun findByOrganizationIdAndStatusAndCustomerId(
+        organizationId: String,
+        status: QuotationStatus,
+        customerId: String,
+    ): List<Quotation>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/QuotationService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/QuotationService.kt
@@ -1,0 +1,260 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.ConvertQuotationRequest
+import com.aquinofroilan.tessera.dto.CreateQuotationRequest
+import com.aquinofroilan.tessera.dto.CreateSalesOrderLineRequest
+import com.aquinofroilan.tessera.dto.CreateSalesOrderRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Quotation
+import com.aquinofroilan.tessera.model.QuotationLine
+import com.aquinofroilan.tessera.model.QuotationStatus
+import com.aquinofroilan.tessera.model.SalesOrder
+import com.aquinofroilan.tessera.repository.QuotationRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Service
+class QuotationService(
+    private val quotationRepository: QuotationRepository,
+    private val customerService: CustomerService,
+    private val warehouseService: WarehouseService,
+    private val productService: ProductService,
+    private val salesOrderService: SalesOrderService,
+) {
+    @Transactional
+    fun createQuotation(
+        request: CreateQuotationRequest,
+        organizationId: String,
+        createdBy: String,
+    ): Quotation {
+        val customer = customerService.getCustomer(request.customerId, organizationId)
+        if (!customer.isActive) {
+            throw BusinessRuleException("Cannot create a quotation for an inactive customer")
+        }
+        request.warehouseId?.let {
+            val warehouse = warehouseService.getWarehouse(it, organizationId)
+            if (!warehouse.isActive) {
+                throw BusinessRuleException("Cannot create a quotation for an inactive warehouse")
+            }
+        }
+
+        val lines =
+            request.lines.mapIndexed { index, lineReq ->
+                val quantity = lineReq.quantity ?: throw BusinessRuleException("Quantity is required")
+                val unitPrice = lineReq.unitPrice ?: throw BusinessRuleException("Unit price is required")
+                if (quantity.signum() <= 0) {
+                    throw BusinessRuleException("Line quantity must be positive")
+                }
+                if (unitPrice.signum() < 0) {
+                    throw BusinessRuleException("Line unit price must not be negative")
+                }
+                val product = productService.getProduct(lineReq.productId, organizationId)
+                if (!product.isActive) {
+                    throw BusinessRuleException("Product '${product.sku}' is inactive")
+                }
+                QuotationLine(
+                    lineNumber = index + 1,
+                    productId = product.id,
+                    productSku = product.sku,
+                    productName = product.name,
+                    quantity = quantity,
+                    unitPrice = unitPrice,
+                    lineTotal = quantity.multiply(unitPrice),
+                    description = lineReq.description,
+                )
+            }
+
+        val total = lines.fold(BigDecimal.ZERO) { sum, line -> sum.add(line.lineTotal) }
+
+        return saveWithRetry(organizationId) { number ->
+            Quotation(
+                quoteNumber = number,
+                customerId = customer.id,
+                customerName = customer.name,
+                warehouseId = request.warehouseId,
+                quoteDate = request.quoteDate ?: throw BusinessRuleException("Quote date is required"),
+                validUntil = request.validUntil,
+                referenceNumber = request.referenceNumber,
+                organizationId = organizationId,
+                lines = lines,
+                totalAmount = total,
+                createdBy = createdBy,
+            )
+        }
+    }
+
+    fun getQuotation(
+        id: String,
+        organizationId: String,
+    ): Quotation {
+        val quote =
+            quotationRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Quotation not found")
+            }
+        if (quote.organizationId != organizationId) {
+            throw ResourceNotFoundException("Quotation not found")
+        }
+        return quote
+    }
+
+    fun listQuotations(
+        organizationId: String,
+        status: QuotationStatus? = null,
+        customerId: String? = null,
+    ): List<Quotation> =
+        when {
+            status != null && customerId != null ->
+                quotationRepository.findByOrganizationIdAndStatusAndCustomerId(organizationId, status, customerId)
+            status != null -> quotationRepository.findByOrganizationIdAndStatus(organizationId, status)
+            customerId != null -> quotationRepository.findByOrganizationIdAndCustomerId(organizationId, customerId)
+            else -> quotationRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun sendQuotation(
+        id: String,
+        organizationId: String,
+    ): Quotation {
+        val quote = getQuotation(id, organizationId)
+        if (quote.status != QuotationStatus.DRAFT) {
+            throw BusinessRuleException("Only draft quotations can be sent")
+        }
+        return quotationRepository.save(
+            quote.copy(status = QuotationStatus.SENT, sentAt = LocalDateTime.now(ZoneOffset.UTC)),
+        )
+    }
+
+    @Transactional
+    fun acceptQuotation(
+        id: String,
+        organizationId: String,
+    ): Quotation {
+        val quote = getQuotation(id, organizationId)
+        if (quote.status != QuotationStatus.SENT) {
+            throw BusinessRuleException("Only sent quotations can be accepted")
+        }
+        requireNotExpired(quote)
+        return quotationRepository.save(
+            quote.copy(status = QuotationStatus.ACCEPTED, decidedAt = LocalDateTime.now(ZoneOffset.UTC)),
+        )
+    }
+
+    @Transactional
+    fun rejectQuotation(
+        id: String,
+        reason: String?,
+        organizationId: String,
+    ): Quotation {
+        val quote = getQuotation(id, organizationId)
+        if (quote.status != QuotationStatus.SENT) {
+            throw BusinessRuleException("Only sent quotations can be rejected")
+        }
+        return quotationRepository.save(
+            quote.copy(
+                status = QuotationStatus.REJECTED,
+                decisionReason = reason,
+                decidedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+
+    @Transactional
+    fun cancelQuotation(
+        id: String,
+        organizationId: String,
+    ): Quotation {
+        val quote = getQuotation(id, organizationId)
+        if (quote.status == QuotationStatus.CONVERTED) {
+            throw BusinessRuleException("A converted quotation cannot be cancelled")
+        }
+        if (quote.status == QuotationStatus.CANCELLED || quote.status == QuotationStatus.REJECTED) {
+            throw BusinessRuleException("Quotation is already ${quote.status.name.lowercase()}")
+        }
+        return quotationRepository.save(quote.copy(status = QuotationStatus.CANCELLED))
+    }
+
+    /**
+     * Converts an accepted quote into a sales order. The warehouse and order
+     * date may be supplied on the request or fall back to the quote's warehouse
+     * / today. Marks the quote CONVERTED and links it to the new sales order.
+     */
+    @Transactional
+    fun convertToSalesOrder(
+        id: String,
+        request: ConvertQuotationRequest,
+        organizationId: String,
+        createdBy: String,
+    ): SalesOrder {
+        val quote = getQuotation(id, organizationId)
+        if (quote.status != QuotationStatus.ACCEPTED) {
+            throw BusinessRuleException("Only accepted quotations can be converted")
+        }
+        val warehouseId =
+            request.warehouseId ?: quote.warehouseId
+                ?: throw BusinessRuleException("A warehouse is required to convert this quotation")
+
+        val soLines =
+            quote.lines.map { line ->
+                CreateSalesOrderLineRequest(
+                    productId = line.productId,
+                    quantity = line.quantity,
+                    unitPrice = line.unitPrice,
+                    description = line.description,
+                )
+            }
+
+        val salesOrder =
+            salesOrderService.createSalesOrder(
+                CreateSalesOrderRequest(
+                    customerId = quote.customerId,
+                    warehouseId = warehouseId,
+                    orderDate = request.orderDate ?: LocalDate.now(ZoneOffset.UTC),
+                    expectedDate = request.expectedDate,
+                    referenceNumber = quote.quoteNumber,
+                    lines = soLines,
+                ),
+                organizationId,
+                createdBy,
+            )
+
+        quotationRepository.save(
+            quote.copy(
+                status = QuotationStatus.CONVERTED,
+                convertedSalesOrderId = salesOrder.id,
+            ),
+        )
+        return salesOrder
+    }
+
+    private fun requireNotExpired(quote: Quotation) {
+        val validUntil = quote.validUntil ?: return
+        if (validUntil.isBefore(LocalDate.now(ZoneOffset.UTC))) {
+            throw BusinessRuleException("Quotation expired on $validUntil")
+        }
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        build: (String) -> Quotation,
+    ): Quotation {
+        repeat(maxRetries) { attempt ->
+            val count = quotationRepository.countByOrganizationId(organizationId)
+            val number = "QT-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return quotationRepository.save(build(number))
+            } catch (e: DuplicateKeyException) {
+                if (attempt == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique quotation number: $number", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique quotation number")
+    }
+}

--- a/src/main/resources/db/migration/V0018__quotations.sql
+++ b/src/main/resources/db/migration/V0018__quotations.sql
@@ -1,0 +1,44 @@
+-- Sales: quotations.
+-- A quotation is the quote stage that precedes a sales order: draft -> send ->
+-- accept/reject, and an accepted quote can be converted into a sales order
+-- (linked via converted_sales_order_id).
+CREATE TABLE quotations (
+    id                       uuid PRIMARY KEY,
+    quote_number             text NOT NULL,
+    customer_id              uuid NOT NULL REFERENCES customers(id) ON DELETE RESTRICT,
+    customer_name            text NOT NULL,
+    warehouse_id             uuid REFERENCES warehouses(id) ON DELETE SET NULL,
+    quote_date               date NOT NULL,
+    valid_until              date,
+    reference_number         text,
+    organization_id          uuid NOT NULL REFERENCES organizations(uuid),
+    status                   text NOT NULL DEFAULT 'DRAFT',
+    total_amount             numeric(18,4) NOT NULL,
+    created_by               uuid NOT NULL REFERENCES users(uuid),
+    sent_at                  timestamp,
+    decided_at               timestamp,
+    decision_reason          text,
+    converted_sales_order_id uuid REFERENCES sales_orders(id) ON DELETE SET NULL,
+    created_at               timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at               timestamp,
+    CONSTRAINT quotations_status_chk
+        CHECK (status IN ('DRAFT','SENT','ACCEPTED','REJECTED','CONVERTED','CANCELLED')),
+    CONSTRAINT quotations_unique_number_per_org UNIQUE (organization_id, quote_number)
+);
+CREATE INDEX quotations_org_status_idx ON quotations(organization_id, status);
+CREATE INDEX quotations_org_customer_idx ON quotations(organization_id, customer_id);
+
+CREATE TABLE quotation_lines (
+    id              uuid PRIMARY KEY,
+    quotation_id    uuid NOT NULL REFERENCES quotations(id) ON DELETE CASCADE,
+    line_number     int NOT NULL,
+    product_id      uuid NOT NULL REFERENCES products(id) ON DELETE RESTRICT,
+    product_sku     text NOT NULL,
+    product_name    text NOT NULL,
+    quantity        numeric(18,4) NOT NULL,
+    unit_price      numeric(18,4) NOT NULL,
+    line_total      numeric(18,4) NOT NULL,
+    description     text,
+    CONSTRAINT quotation_lines_unique_line_per_quote UNIQUE (quotation_id, line_number)
+);
+CREATE INDEX quotation_lines_product_idx ON quotation_lines(product_id);

--- a/src/main/resources/graphql/quotations.graphqls
+++ b/src/main/resources/graphql/quotations.graphqls
@@ -1,0 +1,13 @@
+extend type Query {
+  quotations(status: String, customerId: String): JSON!
+  quotation(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createQuotation(input: JSON!): JSON!
+  sendQuotation(id: ID!): JSON!
+  acceptQuotation(id: ID!): JSON!
+  rejectQuotation(id: ID!, input: JSON): JSON!
+  cancelQuotation(id: ID!): JSON!
+  convertQuotation(id: ID!, input: JSON): JSON!
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/QuotationGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/QuotationGraphqlControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.QuotationController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [QuotationGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class QuotationGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var quotationController: QuotationController
+
+    @Test
+    @WithMockUser(authorities = ["sales:read"])
+    fun `quotations query should return json payload`() {
+        `when`(quotationController.listQuotations(null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "q1", "status" to "DRAFT"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  quotations
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("quotations[0].id")
+            .entity(String::class.java)
+            .isEqualTo("q1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["sales:write"])
+    fun `acceptQuotation mutation should bridge to controller`() {
+        `when`(quotationController.acceptQuotation("q1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "q1", "status" to "ACCEPTED")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  acceptQuotation(id: "q1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("acceptQuotation.status")
+            .entity(String::class.java)
+            .isEqualTo("ACCEPTED")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["sales:read"])
+    fun `createQuotation mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createQuotation(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("customerId" to "c1", "lines" to emptyList<Any>()))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/QuotationServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/QuotationServiceTest.kt
@@ -1,0 +1,193 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.ConvertQuotationRequest
+import com.aquinofroilan.tessera.dto.CreateQuotationLineRequest
+import com.aquinofroilan.tessera.dto.CreateQuotationRequest
+import com.aquinofroilan.tessera.dto.CreateSalesOrderRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Customer
+import com.aquinofroilan.tessera.model.Product
+import com.aquinofroilan.tessera.model.Quotation
+import com.aquinofroilan.tessera.model.QuotationLine
+import com.aquinofroilan.tessera.model.QuotationStatus
+import com.aquinofroilan.tessera.model.SalesOrder
+import com.aquinofroilan.tessera.model.Warehouse
+import com.aquinofroilan.tessera.repository.QuotationRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class QuotationServiceTest {
+    private lateinit var repository: QuotationRepository
+    private lateinit var customerService: CustomerService
+    private lateinit var warehouseService: WarehouseService
+    private lateinit var productService: ProductService
+    private lateinit var salesOrderService: SalesOrderService
+    private lateinit var service: QuotationService
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(QuotationRepository::class.java)
+        customerService = mock(CustomerService::class.java)
+        warehouseService = mock(WarehouseService::class.java)
+        productService = mock(ProductService::class.java)
+        salesOrderService = mock(SalesOrderService::class.java)
+        whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
+        whenever(repository.save(any<Quotation>())).thenAnswer { it.arguments[0] }
+        whenever(customerService.getCustomer("c-1", orgId)).thenReturn(Customer(id = "c-1", name = "Globex", organizationId = orgId))
+        whenever(warehouseService.getWarehouse("wh-1", orgId))
+            .thenReturn(Warehouse(id = "wh-1", code = "MAIN", name = "Main", organizationId = orgId))
+        whenever(productService.getProduct("p-1", orgId)).thenReturn(
+            Product(id = "p-1", sku = "SKU-1", name = "Widget", listPrice = BigDecimal("9"), priceCurrency = "USD", organizationId = orgId),
+        )
+        service = QuotationService(repository, customerService, warehouseService, productService, salesOrderService)
+    }
+
+    private fun lineReq() = CreateQuotationLineRequest(productId = "p-1", quantity = BigDecimal("2"), unitPrice = BigDecimal("10"))
+
+    private fun acceptedQuote(
+        warehouseId: String? = "wh-1",
+        validUntil: LocalDate? = null,
+        status: QuotationStatus = QuotationStatus.ACCEPTED,
+    ) = Quotation(
+        id = "q-1",
+        quoteNumber = "QT-0001",
+        customerId = "c-1",
+        customerName = "Globex",
+        warehouseId = warehouseId,
+        quoteDate = LocalDate.of(2026, 5, 1),
+        validUntil = validUntil,
+        organizationId = orgId,
+        status = status,
+        lines =
+            listOf(
+                QuotationLine(
+                    id = "ql-1",
+                    lineNumber = 1,
+                    productId = "p-1",
+                    productSku = "SKU-1",
+                    productName = "Widget",
+                    quantity = BigDecimal("2"),
+                    unitPrice = BigDecimal("10"),
+                    lineTotal = BigDecimal("20"),
+                ),
+            ),
+        totalAmount = BigDecimal("20"),
+        createdBy = userId,
+    )
+
+    @Test
+    fun `create persists a draft with a generated number and computed total`() {
+        val quote =
+            service.createQuotation(
+                CreateQuotationRequest(
+                    customerId = "c-1",
+                    warehouseId = "wh-1",
+                    quoteDate = LocalDate.of(2026, 5, 1),
+                    lines = listOf(lineReq()),
+                ),
+                orgId,
+                userId,
+            )
+
+        assertThat(quote.status).isEqualTo(QuotationStatus.DRAFT)
+        assertThat(quote.quoteNumber).isEqualTo("QT-0001")
+        assertThat(quote.totalAmount).isEqualByComparingTo("20")
+    }
+
+    @Test
+    fun `send moves a draft to sent`() {
+        whenever(repository.findById("q-1")).thenReturn(Optional.of(acceptedQuote(status = QuotationStatus.DRAFT)))
+        assertThat(service.sendQuotation("q-1", orgId).status).isEqualTo(QuotationStatus.SENT)
+    }
+
+    @Test
+    fun `accept rejects a quote that is not sent`() {
+        whenever(repository.findById("q-1")).thenReturn(Optional.of(acceptedQuote()))
+        assertThatThrownBy { service.acceptQuotation("q-1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `accept rejects an expired quote`() {
+        whenever(repository.findById("q-1"))
+            .thenReturn(Optional.of(acceptedQuote(status = QuotationStatus.SENT, validUntil = LocalDate.of(2000, 1, 1))))
+        assertThatThrownBy { service.acceptQuotation("q-1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `cancel rejects a converted quote`() {
+        whenever(repository.findById("q-1")).thenReturn(Optional.of(acceptedQuote(status = QuotationStatus.CONVERTED)))
+        assertThatThrownBy { service.cancelQuotation("q-1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `convert requires an accepted quote`() {
+        whenever(repository.findById("q-1")).thenReturn(Optional.of(acceptedQuote(status = QuotationStatus.SENT)))
+        assertThatThrownBy { service.convertToSalesOrder("q-1", ConvertQuotationRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `convert builds a sales order from quote lines and marks it converted`() {
+        whenever(repository.findById("q-1")).thenReturn(Optional.of(acceptedQuote()))
+        val createdSo =
+            SalesOrder(
+                id = "so-9",
+                soNumber = "SO-0001",
+                customerId = "c-1",
+                customerName = "Globex",
+                warehouseId = "wh-1",
+                orderDate = LocalDate.of(2026, 5, 1),
+                organizationId = orgId,
+                lines = emptyList(),
+                totalAmount = BigDecimal("20"),
+                createdBy = userId,
+            )
+        whenever(salesOrderService.createSalesOrder(any(), eq(orgId), eq(userId))).thenReturn(createdSo)
+
+        val so = service.convertToSalesOrder("q-1", ConvertQuotationRequest(), orgId, userId)
+
+        assertThat(so.id).isEqualTo("so-9")
+        val soReq = argumentCaptor<CreateSalesOrderRequest>()
+        verify(salesOrderService).createSalesOrder(soReq.capture(), eq(orgId), eq(userId))
+        assertThat(soReq.firstValue.customerId).isEqualTo("c-1")
+        assertThat(soReq.firstValue.warehouseId).isEqualTo("wh-1")
+        assertThat(soReq.firstValue.lines[0].unitPrice).isEqualByComparingTo("10")
+
+        val saved = argumentCaptor<Quotation>()
+        verify(repository).save(saved.capture())
+        assertThat(saved.firstValue.status).isEqualTo(QuotationStatus.CONVERTED)
+        assertThat(saved.firstValue.convertedSalesOrderId).isEqualTo("so-9")
+    }
+
+    @Test
+    fun `convert without a warehouse anywhere is rejected`() {
+        whenever(repository.findById("q-1")).thenReturn(Optional.of(acceptedQuote(warehouseId = null)))
+        assertThatThrownBy { service.convertToSalesOrder("q-1", ConvertQuotationRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("q-1")).thenReturn(Optional.of(acceptedQuote().copy(organizationId = "other")))
+        assertThatThrownBy { service.getQuotation("q-1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}


### PR DESCRIPTION
First of the **Sales module completion** (#10). Adds the **quotation workflow (#51)** — the quote stage that precedes a sales order — mirroring the purchase-request → PO flow shipped last cycle.

## What
- **Migration** `V0018__quotations.sql` — `quotations` + `quotation_lines`.
- **Lifecycle** — `DRAFT → SENT → ACCEPTED/REJECTED`, plus `CANCELLED` and `CONVERTED`.
  - `POST /sales/quotations` (draft), `GET` list (filter `status`/`customerId`), `GET /{id}`.
  - `POST /{id}/send`, `/accept`, `/reject`, `/cancel`.
  - `POST /{id}/convert` → builds a **SalesOrder** via `SalesOrderService`; warehouse and order date come from the body or fall back to the quote; the quote is marked `CONVERTED` and linked (`convertedSalesOrderId`).
- **Expiry** — `accept` rejects a quote past its `validUntil`.
- **GraphQL** — bundled in this PR: `quotations.graphqls` + `QuotationGraphqlController` (queries + send/accept/reject/cancel/convert), so REST and GraphQL ship together (no parity gap this time).
- **Authorization** — `sales:read` / `sales:write`.

## Tests
`QuotationServiceTest` covers create + line validation, state-transition guards, expiry, convert (line mapping + warehouse fallback + missing-warehouse failure), the converted-cancel guard, and cross-org isolation. `QuotationGraphqlControllerTest` covers a query, a mutation, and an auth-denied path.

## Next in this module
Price lists & discounts (#50) and returns & credit notes (#54) — separate PRs to follow. Migration is `V0018` (next after the 0.11.0 HR/procurement set V0014–V0017).
