### PR TITLE
feat(projects): project entity + lifecycle — stack 1/5 (#180)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/config/RoleSeeder.kt
@@ -85,6 +85,9 @@ class RoleSeeder(
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
                             Permissions.HR_APPROVE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
+                            Permissions.PROJECT_APPROVE,
                         ),
                 ),
                 Role(
@@ -137,6 +140,9 @@ class RoleSeeder(
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
                             Permissions.HR_APPROVE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
+                            Permissions.PROJECT_APPROVE,
                         ),
                 ),
                 Role(
@@ -168,6 +174,8 @@ class RoleSeeder(
                             Permissions.SALES_WRITE,
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
                         ),
                 ),
                 Role(
@@ -189,6 +197,7 @@ class RoleSeeder(
                             Permissions.PROCUREMENT_READ,
                             Permissions.SALES_READ,
                             Permissions.HR_READ,
+                            Permissions.PROJECT_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectController.kt
@@ -1,0 +1,116 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.ProjectResponse
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.ProjectService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/projects")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProjectController(
+    private val projectService: ProjectService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createProject(
+        @Valid @RequestBody request: CreateProjectRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val created = projectService.createProject(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ProjectResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listProjects(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) customerId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val projectStatus =
+            if (status != null) {
+                try {
+                    ProjectStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(projectService.listProjects(orgId, projectStatus, customerId).map { ProjectResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun getProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.getProject(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateProject(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateProjectRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.updateProject(id, request, orgId)))
+    }
+
+    @PostMapping("/{id}/activate")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun activateProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.activateProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/hold")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun holdProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.holdProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/close")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun closeProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.closeProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun cancelProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.cancelProject(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectDtos.kt
@@ -1,0 +1,64 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectBillingType
+import com.aquinofroilan.tessera.model.ProjectStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class CreateProjectRequest(
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    val description: String? = null,
+    val customerId: String? = null,
+    val managerEmployeeId: String? = null,
+    @field:NotNull(message = "Start date is required")
+    val startDate: LocalDate?,
+    val endDate: LocalDate? = null,
+    val billingType: ProjectBillingType? = null,
+)
+
+data class UpdateProjectRequest(
+    val name: String? = null,
+    val description: String? = null,
+    val customerId: String? = null,
+    val managerEmployeeId: String? = null,
+    val endDate: LocalDate? = null,
+    val billingType: ProjectBillingType? = null,
+)
+
+data class ProjectResponse(
+    val id: String,
+    val projectNumber: String,
+    val name: String,
+    val description: String?,
+    val customerId: String?,
+    val managerEmployeeId: String?,
+    val startDate: String,
+    val endDate: String?,
+    val status: ProjectStatus,
+    val billingType: ProjectBillingType,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(project: Project) =
+            ProjectResponse(
+                id = project.id,
+                projectNumber = project.projectNumber,
+                name = project.name,
+                description = project.description,
+                customerId = project.customerId,
+                managerEmployeeId = project.managerEmployeeId,
+                startDate = project.startDate.toString(),
+                endDate = project.endDate?.toString(),
+                status = project.status,
+                billingType = project.billingType,
+                organizationId = project.organizationId,
+                createdAt = project.createdAt?.toString(),
+                updatedAt = project.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlController.kt
@@ -1,0 +1,71 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.ProjectController
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for the project routes, delegating to the REST controller via
+ * the shared JSON-scalar pass-through. Authorization mirrors the REST endpoints
+ * (`projects:read`/`projects:write`).
+ */
+@Controller
+class ProjectGraphqlController(
+    private val projectController: ProjectController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projects(
+        @Argument status: String?,
+        @Argument customerId: String?,
+    ): Any = support.unwrap(projectController.listProjects(status, customerId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun project(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.getProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createProject(
+        @Argument input: Any,
+    ): Any = support.unwrap(projectController.createProject(support.toRequest<CreateProjectRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateProject(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectController.updateProject(id, support.toRequest<UpdateProjectRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun activateProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.activateProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun holdProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.holdProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun closeProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.closeProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun cancelProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.cancelProject(id))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Project.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Project.kt
@@ -1,0 +1,63 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class ProjectStatus {
+    PLANNED,
+    ACTIVE,
+    ON_HOLD,
+    CLOSED,
+    CANCELLED,
+}
+
+enum class ProjectBillingType {
+    TIME_AND_MATERIALS,
+    FIXED_PRICE,
+    MILESTONE,
+}
+
+@Entity
+@Table(name = "projects")
+@EntityListeners(AuditingEntityListener::class)
+data class Project(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "project_number")
+    val projectNumber: String,
+    val name: String,
+    val description: String? = null,
+    @Column(name = "customer_id", columnDefinition = "uuid")
+    val customerId: String? = null,
+    @Column(name = "manager_employee_id", columnDefinition = "uuid")
+    val managerEmployeeId: String? = null,
+    @Column(name = "start_date")
+    val startDate: LocalDate,
+    @Column(name = "end_date")
+    val endDate: LocalDate? = null,
+    @Enumerated(EnumType.STRING)
+    val status: ProjectStatus = ProjectStatus.PLANNED,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "billing_type")
+    val billingType: ProjectBillingType = ProjectBillingType.TIME_AND_MATERIALS,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectRepository.kt
@@ -1,0 +1,23 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProjectRepository : JpaRepository<Project, String> {
+    fun findByOrganizationId(organizationId: String): List<Project>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: ProjectStatus,
+    ): List<Project>
+
+    fun findByOrganizationIdAndCustomerId(
+        organizationId: String,
+        customerId: String,
+    ): List<Project>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/security/Permissions.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/security/Permissions.kt
@@ -69,6 +69,10 @@ object Permissions {
     const val HR_WRITE = "hr:write"
     const val HR_APPROVE = "hr:approve"
 
+    const val PROJECT_READ = "projects:read"
+    const val PROJECT_WRITE = "projects:write"
+    const val PROJECT_APPROVE = "projects:approve"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -122,5 +126,8 @@ object Permissions {
             HR_READ,
             HR_WRITE,
             HR_APPROVE,
+            PROJECT_READ,
+            PROJECT_WRITE,
+            PROJECT_APPROVE,
         )
 }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectService.kt
@@ -1,0 +1,164 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectBillingType
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.repository.ProjectRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ProjectService(
+    private val projectRepository: ProjectRepository,
+    private val customerService: CustomerService,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun createProject(
+        request: CreateProjectRequest,
+        organizationId: String,
+    ): Project {
+        val startDate = request.startDate ?: throw BusinessRuleException("Start date is required")
+        if (request.endDate != null && request.endDate.isBefore(startDate)) {
+            throw BusinessRuleException("End date cannot be before the start date")
+        }
+        request.customerId?.let { customerService.getCustomer(it, organizationId) }
+        request.managerEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+
+        return saveWithRetry(organizationId) { number ->
+            Project(
+                projectNumber = number,
+                name = request.name.trim(),
+                description = request.description,
+                customerId = request.customerId,
+                managerEmployeeId = request.managerEmployeeId,
+                startDate = startDate,
+                endDate = request.endDate,
+                billingType = request.billingType ?: ProjectBillingType.TIME_AND_MATERIALS,
+                organizationId = organizationId,
+            )
+        }
+    }
+
+    fun getProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project =
+            projectRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Project not found")
+            }
+        if (project.organizationId != organizationId) {
+            throw ResourceNotFoundException("Project not found")
+        }
+        return project
+    }
+
+    fun listProjects(
+        organizationId: String,
+        status: ProjectStatus? = null,
+        customerId: String? = null,
+    ): List<Project> =
+        when {
+            status != null -> projectRepository.findByOrganizationIdAndStatus(organizationId, status)
+            customerId != null -> projectRepository.findByOrganizationIdAndCustomerId(organizationId, customerId)
+            else -> projectRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateProject(
+        id: String,
+        request: UpdateProjectRequest,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        request.customerId?.let { customerService.getCustomer(it, organizationId) }
+        request.managerEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+        val endDate = request.endDate ?: project.endDate
+        if (endDate != null && endDate.isBefore(project.startDate)) {
+            throw BusinessRuleException("End date cannot be before the start date")
+        }
+        return projectRepository.save(
+            project.copy(
+                name = request.name?.trim() ?: project.name,
+                description = request.description ?: project.description,
+                customerId = request.customerId ?: project.customerId,
+                managerEmployeeId = request.managerEmployeeId ?: project.managerEmployeeId,
+                endDate = endDate,
+                billingType = request.billingType ?: project.billingType,
+            ),
+        )
+    }
+
+    @Transactional
+    fun activateProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.PLANNED && project.status != ProjectStatus.ON_HOLD) {
+            throw BusinessRuleException("Only planned or on-hold projects can be activated")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.ACTIVE))
+    }
+
+    @Transactional
+    fun holdProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.ACTIVE) {
+            throw BusinessRuleException("Only active projects can be put on hold")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.ON_HOLD))
+    }
+
+    @Transactional
+    fun closeProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.ACTIVE && project.status != ProjectStatus.ON_HOLD) {
+            throw BusinessRuleException("Only active or on-hold projects can be closed")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.CLOSED))
+    }
+
+    @Transactional
+    fun cancelProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status == ProjectStatus.CLOSED || project.status == ProjectStatus.CANCELLED) {
+            throw BusinessRuleException("Project is already ${project.status.name.lowercase()}")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.CANCELLED))
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        build: (String) -> Project,
+    ): Project {
+        repeat(maxRetries) { attempt ->
+            val count = projectRepository.countByOrganizationId(organizationId)
+            val number = "PRJ-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return projectRepository.save(build(number))
+            } catch (e: DuplicateKeyException) {
+                if (attempt == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique project number: $number", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique project number")
+    }
+}

--- a/src/main/resources/db/migration/V0019__projects.sql
+++ b/src/main/resources/db/migration/V0019__projects.sql
@@ -1,0 +1,24 @@
+-- Project module: projects (root entity of the project-management epic).
+-- Projects own tasks, timesheets, budgets and billing in later migrations.
+CREATE TABLE projects (
+    id                   uuid PRIMARY KEY,
+    project_number       text NOT NULL,
+    name                 text NOT NULL,
+    description          text,
+    customer_id          uuid REFERENCES customers(id) ON DELETE SET NULL,
+    manager_employee_id  uuid REFERENCES employees(id) ON DELETE SET NULL,
+    start_date           date NOT NULL,
+    end_date             date,
+    status               text NOT NULL DEFAULT 'PLANNED',
+    billing_type         text NOT NULL DEFAULT 'TIME_AND_MATERIALS',
+    organization_id      uuid NOT NULL REFERENCES organizations(uuid),
+    created_at           timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at           timestamp,
+    CONSTRAINT projects_status_chk
+        CHECK (status IN ('PLANNED','ACTIVE','ON_HOLD','CLOSED','CANCELLED')),
+    CONSTRAINT projects_billing_type_chk
+        CHECK (billing_type IN ('TIME_AND_MATERIALS','FIXED_PRICE','MILESTONE')),
+    CONSTRAINT projects_unique_number_per_org UNIQUE (organization_id, project_number)
+);
+CREATE INDEX projects_org_status_idx ON projects(organization_id, status);
+CREATE INDEX projects_org_customer_idx ON projects(organization_id, customer_id);

--- a/src/main/resources/graphql/projects.graphqls
+++ b/src/main/resources/graphql/projects.graphqls
@@ -1,0 +1,13 @@
+extend type Query {
+  projects(status: String, customerId: String): JSON!
+  project(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createProject(input: JSON!): JSON!
+  updateProject(id: ID!, input: JSON!): JSON!
+  activateProject(id: ID!): JSON!
+  holdProject(id: ID!): JSON!
+  closeProject(id: ID!): JSON!
+  cancelProject(id: ID!): JSON!
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/config/RoleSeederTest.kt
@@ -104,6 +104,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -308,6 +311,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         val admin =
@@ -361,6 +367,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         val member =
@@ -393,6 +402,8 @@ class RoleSeederTest {
                         Permissions.SALES_WRITE,
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
                     ),
             )
         val viewer =
@@ -415,6 +426,7 @@ class RoleSeederTest {
                         Permissions.PROCUREMENT_READ,
                         Permissions.SALES_READ,
                         Permissions.HR_READ,
+                        Permissions.PROJECT_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.ProjectController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [ProjectGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class ProjectGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var projectController: ProjectController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `projects query should return json payload`() {
+        `when`(projectController.listProjects(null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "p1", "status" to "PLANNED"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  projects
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("projects[0].id")
+            .entity(String::class.java)
+            .isEqualTo("p1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:write"])
+    fun `activateProject mutation should bridge to controller`() {
+        `when`(projectController.activateProject("p1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "p1", "status" to "ACTIVE")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  activateProject(id: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("activateProject.status")
+            .entity(String::class.java)
+            .isEqualTo("ACTIVE")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `createProject mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createProject(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("name" to "Apollo"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectServiceTest.kt
@@ -1,0 +1,113 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Customer
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.repository.ProjectRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.util.Optional
+
+class ProjectServiceTest {
+    private lateinit var repository: ProjectRepository
+    private lateinit var customerService: CustomerService
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: ProjectService
+
+    private val orgId = "org-1"
+    private val start = LocalDate.of(2026, 1, 1)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(ProjectRepository::class.java)
+        customerService = mock(CustomerService::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
+        whenever(repository.save(any<Project>())).thenAnswer { it.arguments[0] }
+        whenever(customerService.getCustomer("c-1", orgId)).thenReturn(Customer(id = "c-1", name = "Globex", organizationId = orgId))
+        service = ProjectService(repository, customerService, employeeService)
+    }
+
+    private fun project(status: ProjectStatus = ProjectStatus.PLANNED) =
+        Project(
+            id = "p-1",
+            projectNumber = "PRJ-0001",
+            name = "Apollo",
+            startDate = start,
+            status = status,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `create persists a planned project with a generated number`() {
+        val p = service.createProject(CreateProjectRequest(name = " Apollo ", startDate = start), orgId)
+
+        assertThat(p.status).isEqualTo(ProjectStatus.PLANNED)
+        assertThat(p.projectNumber).isEqualTo("PRJ-0001")
+        assertThat(p.name).isEqualTo("Apollo")
+    }
+
+    @Test
+    fun `create rejects an end date before the start date`() {
+        assertThatThrownBy {
+            service.createProject(CreateProjectRequest(name = "Apollo", startDate = start, endDate = start.minusDays(1)), orgId)
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `create validates the customer belongs to the org`() {
+        whenever(customerService.getCustomer("missing", orgId)).thenThrow(ResourceNotFoundException("Customer not found"))
+        assertThatThrownBy {
+            service.createProject(CreateProjectRequest(name = "Apollo", startDate = start, customerId = "missing"), orgId)
+        }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `activate moves planned to active and rejects from other states`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.PLANNED)))
+        assertThat(service.activateProject("p-1", orgId).status).isEqualTo(ProjectStatus.ACTIVE)
+
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.CLOSED)))
+        assertThatThrownBy { service.activateProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `hold requires an active project`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.PLANNED)))
+        assertThatThrownBy { service.holdProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `cancel rejects an already-closed project`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.CLOSED)))
+        assertThatThrownBy { service.cancelProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `update changes fields and validates end date`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project()))
+        val updated = service.updateProject("p-1", UpdateProjectRequest(name = "Apollo II"), orgId)
+        assertThat(updated.name).isEqualTo("Apollo II")
+
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project()))
+        assertThatThrownBy {
+            service.updateProject("p-1", UpdateProjectRequest(endDate = start.minusDays(5)), orgId)
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project().copy(organizationId = "other")))
+        assertThatThrownBy { service.getProject("p-1", orgId) }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}


### PR DESCRIPTION
**Stack 1/5** of Epic #165 (Project Management & Accounting). Base: `staging`. Closes #180.

The foundation every other project feature builds on, plus the one-time `projects:*` authority registration.

## What
- **Authorities** — `projects:read/write/approve` added to `Permissions`, granted in `RoleSeeder` (OWNER/ADMIN: all three; MEMBER: read+write; VIEWER: read), with `RoleSeederTest` mirrored.
- **Migration** `V0019__projects.sql` — `projects` (number `PRJ-0001`, optional customer/manager refs, start/end dates, status, billing type).
- **Lifecycle** — `PLANNED → ACTIVE → ON_HOLD`, `CLOSED`, `CANCELLED` with guards.
- **REST** `/projects` — CRUD + `activate`/`hold`/`close`/`cancel` (`projects:read`/`projects:write`).
- **GraphQL** — `projects.graphqls` + `ProjectGraphqlController` (bundled, no parity gap).
- **Tests** — `ProjectServiceTest` (create/validation/lifecycle/cross-org) + `ProjectGraphqlControllerTest`.

## Stack
1/5 **#180 projects (this)** → 2/5 #181 tasks → 3/5 #182 timesheets → 4/5 #183 budgeting ∥ 5/5 #184 billing. Reviews read cleanly top-to-bottom; I rebase children as each merges.

Migration `V0019` (after quotations #163 `V0018`).
