### PR TITLE
feat(projects): budgeting & cost capture — stack 4/5 (#183)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/config/RoleSeeder.kt
@@ -85,6 +85,9 @@ class RoleSeeder(
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
                             Permissions.HR_APPROVE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
+                            Permissions.PROJECT_APPROVE,
                         ),
                 ),
                 Role(
@@ -137,6 +140,9 @@ class RoleSeeder(
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
                             Permissions.HR_APPROVE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
+                            Permissions.PROJECT_APPROVE,
                         ),
                 ),
                 Role(
@@ -168,6 +174,8 @@ class RoleSeeder(
                             Permissions.SALES_WRITE,
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
                         ),
                 ),
                 Role(
@@ -189,6 +197,7 @@ class RoleSeeder(
                             Permissions.PROCUREMENT_READ,
                             Permissions.SALES_READ,
                             Permissions.HR_READ,
+                            Permissions.PROJECT_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectBudgetController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectBudgetController.kt
@@ -1,0 +1,55 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.ProjectBudgetResponse
+import com.aquinofroilan.tessera.dto.SetProjectBudgetRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.ProjectBudgetService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/projects/{projectId}/budget")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProjectBudgetController(
+    private val projectBudgetService: ProjectBudgetService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun setBudget(
+        @PathVariable projectId: String,
+        @Valid @RequestBody request: SetProjectBudgetRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val budget = projectBudgetService.setBudget(projectId, request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ProjectBudgetResponse.from(budget))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listBudgets(
+        @PathVariable projectId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(projectBudgetService.listBudgets(projectId, orgId).map { ProjectBudgetResponse.from(it) })
+    }
+
+    @GetMapping("/vs-actual")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun budgetVsActual(
+        @PathVariable projectId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(projectBudgetService.budgetVsActual(projectId, orgId))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectController.kt
@@ -1,0 +1,116 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.ProjectResponse
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.ProjectService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/projects")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProjectController(
+    private val projectService: ProjectService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createProject(
+        @Valid @RequestBody request: CreateProjectRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val created = projectService.createProject(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ProjectResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listProjects(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) customerId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val projectStatus =
+            if (status != null) {
+                try {
+                    ProjectStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(projectService.listProjects(orgId, projectStatus, customerId).map { ProjectResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun getProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.getProject(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateProject(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateProjectRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.updateProject(id, request, orgId)))
+    }
+
+    @PostMapping("/{id}/activate")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun activateProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.activateProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/hold")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun holdProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.holdProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/close")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun closeProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.closeProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun cancelProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.cancelProject(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectTaskController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectTaskController.kt
@@ -1,0 +1,93 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CreateProjectTaskRequest
+import com.aquinofroilan.tessera.dto.ProjectTaskResponse
+import com.aquinofroilan.tessera.dto.SetTaskParentRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectTaskRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.ProjectTaskService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/projects/{projectId}/tasks")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProjectTaskController(
+    private val projectTaskService: ProjectTaskService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createTask(
+        @PathVariable projectId: String,
+        @Valid @RequestBody request: CreateProjectTaskRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val created = projectTaskService.createTask(projectId, request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ProjectTaskResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listTasks(
+        @PathVariable projectId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(projectTaskService.listTasks(projectId, orgId).map { ProjectTaskResponse.from(it) })
+    }
+
+    @GetMapping("/tree")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun taskTree(
+        @PathVariable projectId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(projectTaskService.getTaskTree(projectId, orgId))
+    }
+
+    @GetMapping("/{taskId}")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun getTask(
+        @PathVariable projectId: String,
+        @PathVariable taskId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectTaskResponse.from(projectTaskService.getTask(projectId, taskId, orgId)))
+    }
+
+    @PatchMapping("/{taskId}")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateTask(
+        @PathVariable projectId: String,
+        @PathVariable taskId: String,
+        @Valid @RequestBody request: UpdateProjectTaskRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectTaskResponse.from(projectTaskService.updateTask(projectId, taskId, request, orgId)))
+    }
+
+    @PutMapping("/{taskId}/parent")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun setParent(
+        @PathVariable projectId: String,
+        @PathVariable taskId: String,
+        @Valid @RequestBody request: SetTaskParentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(
+            ProjectTaskResponse.from(projectTaskService.setParent(projectId, taskId, request.parentTaskId, orgId)),
+        )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/TimeEntryController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/TimeEntryController.kt
@@ -1,0 +1,112 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CreateTimeEntryRequest
+import com.aquinofroilan.tessera.dto.TimeEntryResponse
+import com.aquinofroilan.tessera.dto.UpdateTimeEntryRequest
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.TimeEntryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/projects/time-entries")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class TimeEntryController(
+    private val timeEntryService: TimeEntryService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createTimeEntry(
+        @Valid @RequestBody request: CreateTimeEntryRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val created = timeEntryService.createTimeEntry(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(TimeEntryResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listTimeEntries(
+        @RequestParam(required = false) employeeId: String?,
+        @RequestParam(required = false) projectId: String?,
+        @RequestParam(required = false) status: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val entryStatus =
+            if (status != null) {
+                try {
+                    TimeEntryStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(
+            timeEntryService.listTimeEntries(orgId, employeeId, projectId, entryStatus).map { TimeEntryResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun getTimeEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.getTimeEntry(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateTimeEntry(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateTimeEntryRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.updateTimeEntry(id, request, orgId)))
+    }
+
+    @PostMapping("/{id}/submit")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun submitTimeEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.submitTimeEntry(id, orgId)))
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('projects:approve')")
+    fun approveTimeEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val approvedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.approveTimeEntry(id, orgId, approvedBy)))
+    }
+
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasAuthority('projects:approve')")
+    fun rejectTimeEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val decidedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.rejectTimeEntry(id, orgId, decidedBy)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectBudgetDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectBudgetDtos.kt
@@ -1,0 +1,54 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.ProjectBudget
+import com.aquinofroilan.tessera.model.ProjectCostCategory
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+
+data class SetProjectBudgetRequest(
+    @field:NotNull(message = "Category is required")
+    val category: ProjectCostCategory?,
+    @field:NotNull(message = "Budget amount is required")
+    val budgetAmount: BigDecimal?,
+    val currency: String? = null,
+)
+
+data class ProjectBudgetResponse(
+    val id: String,
+    val projectId: String,
+    val category: ProjectCostCategory,
+    val budgetAmount: BigDecimal,
+    val currency: String?,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(budget: ProjectBudget) =
+            ProjectBudgetResponse(
+                id = budget.id,
+                projectId = budget.projectId,
+                category = budget.category,
+                budgetAmount = budget.budgetAmount,
+                currency = budget.currency,
+                organizationId = budget.organizationId,
+                createdAt = budget.createdAt?.toString(),
+                updatedAt = budget.updatedAt?.toString(),
+            )
+    }
+}
+
+data class BudgetVarianceLine(
+    val category: ProjectCostCategory,
+    val budgeted: BigDecimal,
+    val actual: BigDecimal,
+    val remaining: BigDecimal,
+)
+
+data class ProjectBudgetVsActualResponse(
+    val projectId: String,
+    val lines: List<BudgetVarianceLine>,
+    val totalBudgeted: BigDecimal,
+    val totalActual: BigDecimal,
+    val totalRemaining: BigDecimal,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectDtos.kt
@@ -1,0 +1,64 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectBillingType
+import com.aquinofroilan.tessera.model.ProjectStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class CreateProjectRequest(
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    val description: String? = null,
+    val customerId: String? = null,
+    val managerEmployeeId: String? = null,
+    @field:NotNull(message = "Start date is required")
+    val startDate: LocalDate?,
+    val endDate: LocalDate? = null,
+    val billingType: ProjectBillingType? = null,
+)
+
+data class UpdateProjectRequest(
+    val name: String? = null,
+    val description: String? = null,
+    val customerId: String? = null,
+    val managerEmployeeId: String? = null,
+    val endDate: LocalDate? = null,
+    val billingType: ProjectBillingType? = null,
+)
+
+data class ProjectResponse(
+    val id: String,
+    val projectNumber: String,
+    val name: String,
+    val description: String?,
+    val customerId: String?,
+    val managerEmployeeId: String?,
+    val startDate: String,
+    val endDate: String?,
+    val status: ProjectStatus,
+    val billingType: ProjectBillingType,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(project: Project) =
+            ProjectResponse(
+                id = project.id,
+                projectNumber = project.projectNumber,
+                name = project.name,
+                description = project.description,
+                customerId = project.customerId,
+                managerEmployeeId = project.managerEmployeeId,
+                startDate = project.startDate.toString(),
+                endDate = project.endDate?.toString(),
+                status = project.status,
+                billingType = project.billingType,
+                organizationId = project.organizationId,
+                createdAt = project.createdAt?.toString(),
+                updatedAt = project.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectTaskDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectTaskDtos.kt
@@ -1,0 +1,81 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.ProjectTask
+import com.aquinofroilan.tessera.model.TaskStatus
+import jakarta.validation.constraints.NotBlank
+import java.math.BigDecimal
+
+data class CreateProjectTaskRequest(
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    val description: String? = null,
+    val parentTaskId: String? = null,
+    val assigneeEmployeeId: String? = null,
+    val estimatedHours: BigDecimal? = null,
+)
+
+data class UpdateProjectTaskRequest(
+    val name: String? = null,
+    val description: String? = null,
+    val assigneeEmployeeId: String? = null,
+    val estimatedHours: BigDecimal? = null,
+    val status: TaskStatus? = null,
+)
+
+/** Sets or clears a task's parent within the same project. */
+data class SetTaskParentRequest(
+    val parentTaskId: String? = null,
+)
+
+data class ProjectTaskResponse(
+    val id: String,
+    val projectId: String,
+    val parentTaskId: String?,
+    val name: String,
+    val description: String?,
+    val assigneeEmployeeId: String?,
+    val estimatedHours: BigDecimal?,
+    val status: TaskStatus,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(task: ProjectTask) =
+            ProjectTaskResponse(
+                id = task.id,
+                projectId = task.projectId,
+                parentTaskId = task.parentTaskId,
+                name = task.name,
+                description = task.description,
+                assigneeEmployeeId = task.assigneeEmployeeId,
+                estimatedHours = task.estimatedHours,
+                status = task.status,
+                organizationId = task.organizationId,
+                createdAt = task.createdAt?.toString(),
+                updatedAt = task.updatedAt?.toString(),
+            )
+    }
+}
+
+/** A node in the project work-breakdown tree: the task plus its nested children. */
+data class ProjectTaskTreeNode(
+    val id: String,
+    val name: String,
+    val status: TaskStatus,
+    val assigneeEmployeeId: String?,
+    val children: List<ProjectTaskTreeNode>,
+) {
+    companion object {
+        fun from(
+            task: ProjectTask,
+            children: List<ProjectTaskTreeNode>,
+        ) = ProjectTaskTreeNode(
+            id = task.id,
+            name = task.name,
+            status = task.status,
+            assigneeEmployeeId = task.assigneeEmployeeId,
+            children = children,
+        )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/TimeEntryDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/TimeEntryDtos.kt
@@ -1,0 +1,74 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreateTimeEntryRequest(
+    @field:NotBlank(message = "Employee ID is required")
+    val employeeId: String,
+    @field:NotBlank(message = "Project ID is required")
+    val projectId: String,
+    val taskId: String? = null,
+    @field:NotNull(message = "Entry date is required")
+    val entryDate: LocalDate?,
+    @field:NotNull(message = "Hours are required")
+    @field:Positive(message = "Hours must be positive")
+    val hours: BigDecimal?,
+    val billable: Boolean = true,
+    val rate: BigDecimal? = null,
+    val notes: String? = null,
+)
+
+data class UpdateTimeEntryRequest(
+    val taskId: String? = null,
+    val entryDate: LocalDate? = null,
+    @field:Positive(message = "Hours must be positive")
+    val hours: BigDecimal? = null,
+    val billable: Boolean? = null,
+    val rate: BigDecimal? = null,
+    val notes: String? = null,
+)
+
+data class TimeEntryResponse(
+    val id: String,
+    val employeeId: String,
+    val projectId: String,
+    val taskId: String?,
+    val entryDate: String,
+    val hours: BigDecimal,
+    val billable: Boolean,
+    val rate: BigDecimal?,
+    val status: TimeEntryStatus,
+    val notes: String?,
+    val approvedBy: String?,
+    val approvedAt: String?,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(entry: TimeEntry) =
+            TimeEntryResponse(
+                id = entry.id,
+                employeeId = entry.employeeId,
+                projectId = entry.projectId,
+                taskId = entry.taskId,
+                entryDate = entry.entryDate.toString(),
+                hours = entry.hours,
+                billable = entry.billable,
+                rate = entry.rate,
+                status = entry.status,
+                notes = entry.notes,
+                approvedBy = entry.approvedBy,
+                approvedAt = entry.approvedAt?.toString(),
+                organizationId = entry.organizationId,
+                createdAt = entry.createdAt?.toString(),
+                updatedAt = entry.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectBudgetGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectBudgetGraphqlController.kt
@@ -1,0 +1,39 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.ProjectBudgetController
+import com.aquinofroilan.tessera.dto.SetProjectBudgetRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for project budgets, delegating to the REST controller via the
+ * shared JSON-scalar pass-through. Authorization mirrors the REST endpoints
+ * (`projects:read`/`projects:write`).
+ */
+@Controller
+class ProjectBudgetGraphqlController(
+    private val projectBudgetController: ProjectBudgetController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectBudgets(
+        @Argument projectId: String,
+    ): Any = support.unwrap(projectBudgetController.listBudgets(projectId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectBudgetVsActual(
+        @Argument projectId: String,
+    ): Any = support.unwrap(projectBudgetController.budgetVsActual(projectId))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun setProjectBudget(
+        @Argument projectId: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectBudgetController.setBudget(projectId, support.toRequest<SetProjectBudgetRequest>(input)))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlController.kt
@@ -1,0 +1,71 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.ProjectController
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for the project routes, delegating to the REST controller via
+ * the shared JSON-scalar pass-through. Authorization mirrors the REST endpoints
+ * (`projects:read`/`projects:write`).
+ */
+@Controller
+class ProjectGraphqlController(
+    private val projectController: ProjectController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projects(
+        @Argument status: String?,
+        @Argument customerId: String?,
+    ): Any = support.unwrap(projectController.listProjects(status, customerId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun project(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.getProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createProject(
+        @Argument input: Any,
+    ): Any = support.unwrap(projectController.createProject(support.toRequest<CreateProjectRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateProject(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectController.updateProject(id, support.toRequest<UpdateProjectRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun activateProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.activateProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun holdProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.holdProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun closeProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.closeProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun cancelProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.cancelProject(id))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectTaskGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectTaskGraphqlController.kt
@@ -1,0 +1,67 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.ProjectTaskController
+import com.aquinofroilan.tessera.dto.CreateProjectTaskRequest
+import com.aquinofroilan.tessera.dto.SetTaskParentRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectTaskRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for project tasks (work breakdown structure), delegating to the
+ * REST controller via the shared JSON-scalar pass-through. Authorization mirrors
+ * the REST endpoints (`projects:read`/`projects:write`).
+ */
+@Controller
+class ProjectTaskGraphqlController(
+    private val projectTaskController: ProjectTaskController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectTasks(
+        @Argument projectId: String,
+    ): Any = support.unwrap(projectTaskController.listTasks(projectId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectTaskTree(
+        @Argument projectId: String,
+    ): Any = support.unwrap(projectTaskController.taskTree(projectId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectTask(
+        @Argument projectId: String,
+        @Argument taskId: String,
+    ): Any = support.unwrap(projectTaskController.getTask(projectId, taskId))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createProjectTask(
+        @Argument projectId: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectTaskController.createTask(projectId, support.toRequest<CreateProjectTaskRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateProjectTask(
+        @Argument projectId: String,
+        @Argument taskId: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectTaskController.updateTask(projectId, taskId, support.toRequest<UpdateProjectTaskRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun setProjectTaskParent(
+        @Argument projectId: String,
+        @Argument taskId: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<SetTaskParentRequest>(it) } ?: SetTaskParentRequest()
+        return support.unwrap(projectTaskController.setParent(projectId, taskId, request))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/TimeEntryGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/TimeEntryGraphqlController.kt
@@ -1,0 +1,66 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.TimeEntryController
+import com.aquinofroilan.tessera.dto.CreateTimeEntryRequest
+import com.aquinofroilan.tessera.dto.UpdateTimeEntryRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for project time entries (timesheets), delegating to the REST
+ * controller via the shared JSON-scalar pass-through. Authorization mirrors the
+ * REST endpoints (`projects:read`/`projects:write`/`projects:approve`).
+ */
+@Controller
+class TimeEntryGraphqlController(
+    private val timeEntryController: TimeEntryController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun timeEntries(
+        @Argument employeeId: String?,
+        @Argument projectId: String?,
+        @Argument status: String?,
+    ): Any = support.unwrap(timeEntryController.listTimeEntries(employeeId, projectId, status))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun timeEntry(
+        @Argument id: String,
+    ): Any = support.unwrap(timeEntryController.getTimeEntry(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createTimeEntry(
+        @Argument input: Any,
+    ): Any = support.unwrap(timeEntryController.createTimeEntry(support.toRequest<CreateTimeEntryRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateTimeEntry(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(timeEntryController.updateTimeEntry(id, support.toRequest<UpdateTimeEntryRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun submitTimeEntry(
+        @Argument id: String,
+    ): Any = support.unwrap(timeEntryController.submitTimeEntry(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:approve')")
+    fun approveTimeEntry(
+        @Argument id: String,
+    ): Any = support.unwrap(timeEntryController.approveTimeEntry(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:approve')")
+    fun rejectTimeEntry(
+        @Argument id: String,
+    ): Any = support.unwrap(timeEntryController.rejectTimeEntry(id))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Project.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Project.kt
@@ -1,0 +1,63 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class ProjectStatus {
+    PLANNED,
+    ACTIVE,
+    ON_HOLD,
+    CLOSED,
+    CANCELLED,
+}
+
+enum class ProjectBillingType {
+    TIME_AND_MATERIALS,
+    FIXED_PRICE,
+    MILESTONE,
+}
+
+@Entity
+@Table(name = "projects")
+@EntityListeners(AuditingEntityListener::class)
+data class Project(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "project_number")
+    val projectNumber: String,
+    val name: String,
+    val description: String? = null,
+    @Column(name = "customer_id", columnDefinition = "uuid")
+    val customerId: String? = null,
+    @Column(name = "manager_employee_id", columnDefinition = "uuid")
+    val managerEmployeeId: String? = null,
+    @Column(name = "start_date")
+    val startDate: LocalDate,
+    @Column(name = "end_date")
+    val endDate: LocalDate? = null,
+    @Enumerated(EnumType.STRING)
+    val status: ProjectStatus = ProjectStatus.PLANNED,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "billing_type")
+    val billingType: ProjectBillingType = ProjectBillingType.TIME_AND_MATERIALS,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectBudget.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectBudget.kt
@@ -1,0 +1,46 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class ProjectCostCategory {
+    LABOR,
+    MATERIAL,
+    EXPENSE,
+    OTHER,
+}
+
+@Entity
+@Table(name = "project_budgets")
+@EntityListeners(AuditingEntityListener::class)
+data class ProjectBudget(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "project_id", columnDefinition = "uuid")
+    val projectId: String,
+    @Enumerated(EnumType.STRING)
+    val category: ProjectCostCategory,
+    @Column(name = "budget_amount")
+    val budgetAmount: BigDecimal,
+    val currency: String? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectTask.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectTask.kt
@@ -1,0 +1,51 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class TaskStatus {
+    TODO,
+    IN_PROGRESS,
+    DONE,
+    CANCELLED,
+}
+
+@Entity
+@Table(name = "project_tasks")
+@EntityListeners(AuditingEntityListener::class)
+data class ProjectTask(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "project_id", columnDefinition = "uuid")
+    val projectId: String,
+    @Column(name = "parent_task_id", columnDefinition = "uuid")
+    val parentTaskId: String? = null,
+    val name: String,
+    val description: String? = null,
+    @Column(name = "assignee_employee_id", columnDefinition = "uuid")
+    val assigneeEmployeeId: String? = null,
+    @Column(name = "estimated_hours")
+    val estimatedHours: BigDecimal? = null,
+    @Enumerated(EnumType.STRING)
+    val status: TaskStatus = TaskStatus.TODO,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/TimeEntry.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/TimeEntry.kt
@@ -1,0 +1,58 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class TimeEntryStatus {
+    DRAFT,
+    SUBMITTED,
+    APPROVED,
+    REJECTED,
+}
+
+@Entity
+@Table(name = "time_entries")
+@EntityListeners(AuditingEntityListener::class)
+data class TimeEntry(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "employee_id", columnDefinition = "uuid")
+    val employeeId: String,
+    @Column(name = "project_id", columnDefinition = "uuid")
+    val projectId: String,
+    @Column(name = "task_id", columnDefinition = "uuid")
+    val taskId: String? = null,
+    @Column(name = "entry_date")
+    val entryDate: LocalDate,
+    val hours: BigDecimal,
+    val billable: Boolean = true,
+    val rate: BigDecimal? = null,
+    @Enumerated(EnumType.STRING)
+    val status: TimeEntryStatus = TimeEntryStatus.DRAFT,
+    val notes: String? = null,
+    @Column(name = "approved_by", columnDefinition = "uuid")
+    val approvedBy: String? = null,
+    @Column(name = "approved_at")
+    val approvedAt: LocalDateTime? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectBudgetRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectBudgetRepository.kt
@@ -1,0 +1,21 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.ProjectBudget
+import com.aquinofroilan.tessera.model.ProjectCostCategory
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface ProjectBudgetRepository : JpaRepository<ProjectBudget, String> {
+    fun findByOrganizationIdAndProjectId(
+        organizationId: String,
+        projectId: String,
+    ): List<ProjectBudget>
+
+    fun findByOrganizationIdAndProjectIdAndCategory(
+        organizationId: String,
+        projectId: String,
+        category: ProjectCostCategory,
+    ): Optional<ProjectBudget>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectRepository.kt
@@ -1,0 +1,23 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProjectRepository : JpaRepository<Project, String> {
+    fun findByOrganizationId(organizationId: String): List<Project>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: ProjectStatus,
+    ): List<Project>
+
+    fun findByOrganizationIdAndCustomerId(
+        organizationId: String,
+        customerId: String,
+    ): List<Project>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectTaskRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectTaskRepository.kt
@@ -1,0 +1,13 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.ProjectTask
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProjectTaskRepository : JpaRepository<ProjectTask, String> {
+    fun findByOrganizationIdAndProjectId(
+        organizationId: String,
+        projectId: String,
+    ): List<ProjectTask>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/TimeEntryRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/TimeEntryRepository.kt
@@ -1,0 +1,32 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TimeEntryRepository : JpaRepository<TimeEntry, String> {
+    fun findByOrganizationId(organizationId: String): List<TimeEntry>
+
+    fun findByOrganizationIdAndEmployeeId(
+        organizationId: String,
+        employeeId: String,
+    ): List<TimeEntry>
+
+    fun findByOrganizationIdAndProjectId(
+        organizationId: String,
+        projectId: String,
+    ): List<TimeEntry>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: TimeEntryStatus,
+    ): List<TimeEntry>
+
+    fun findByOrganizationIdAndProjectIdAndStatus(
+        organizationId: String,
+        projectId: String,
+        status: TimeEntryStatus,
+    ): List<TimeEntry>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/security/Permissions.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/security/Permissions.kt
@@ -69,6 +69,10 @@ object Permissions {
     const val HR_WRITE = "hr:write"
     const val HR_APPROVE = "hr:approve"
 
+    const val PROJECT_READ = "projects:read"
+    const val PROJECT_WRITE = "projects:write"
+    const val PROJECT_APPROVE = "projects:approve"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -122,5 +126,8 @@ object Permissions {
             HR_READ,
             HR_WRITE,
             HR_APPROVE,
+            PROJECT_READ,
+            PROJECT_WRITE,
+            PROJECT_APPROVE,
         )
 }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectBudgetService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectBudgetService.kt
@@ -1,0 +1,105 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.BudgetVarianceLine
+import com.aquinofroilan.tessera.dto.ProjectBudgetVsActualResponse
+import com.aquinofroilan.tessera.dto.SetProjectBudgetRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.ProjectBudget
+import com.aquinofroilan.tessera.model.ProjectCostCategory
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.ProjectBudgetRepository
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+class ProjectBudgetService(
+    private val projectBudgetRepository: ProjectBudgetRepository,
+    private val projectService: ProjectService,
+    private val timeEntryRepository: TimeEntryRepository,
+) {
+    /** Upserts the budget for a single cost category on a project. */
+    @Transactional
+    fun setBudget(
+        projectId: String,
+        request: SetProjectBudgetRequest,
+        organizationId: String,
+    ): ProjectBudget {
+        projectService.getProject(projectId, organizationId)
+        val category = request.category ?: throw BusinessRuleException("Category is required")
+        val amount = request.budgetAmount ?: throw BusinessRuleException("Budget amount is required")
+        if (amount.signum() < 0) {
+            throw BusinessRuleException("Budget amount must not be negative")
+        }
+        val existing =
+            projectBudgetRepository.findByOrganizationIdAndProjectIdAndCategory(organizationId, projectId, category)
+        val budget =
+            existing
+                .map { it.copy(budgetAmount = amount, currency = request.currency ?: it.currency) }
+                .orElseGet {
+                    ProjectBudget(
+                        projectId = projectId,
+                        category = category,
+                        budgetAmount = amount,
+                        currency = request.currency,
+                        organizationId = organizationId,
+                    )
+                }
+        return projectBudgetRepository.save(budget)
+    }
+
+    fun listBudgets(
+        projectId: String,
+        organizationId: String,
+    ): List<ProjectBudget> {
+        projectService.getProject(projectId, organizationId)
+        return projectBudgetRepository.findByOrganizationIdAndProjectId(organizationId, projectId)
+    }
+
+    /**
+     * Budget vs actual for a project. Labor actuals are the sum of (hours x rate)
+     * over approved time entries. Material/expense actuals are 0 until bills and
+     * expense claims carry a project reference (Epic #166).
+     */
+    fun budgetVsActual(
+        projectId: String,
+        organizationId: String,
+    ): ProjectBudgetVsActualResponse {
+        projectService.getProject(projectId, organizationId)
+        val budgets = projectBudgetRepository.findByOrganizationIdAndProjectId(organizationId, projectId)
+
+        val laborActual =
+            timeEntryRepository
+                .findByOrganizationIdAndProjectIdAndStatus(organizationId, projectId, TimeEntryStatus.APPROVED)
+                .filter { it.rate != null }
+                .fold(BigDecimal.ZERO) { sum, entry -> sum.add(entry.hours.multiply(entry.rate)) }
+
+        val actualByCategory = mapOf(ProjectCostCategory.LABOR to laborActual)
+        val budgetByCategory = budgets.associateBy { it.category }
+        val categories =
+            (budgetByCategory.keys + actualByCategory.filterValues { it.signum() != 0 }.keys)
+                .distinct()
+                .sortedBy { it.name }
+
+        val lines =
+            categories.map { category ->
+                val budgeted = budgetByCategory[category]?.budgetAmount ?: BigDecimal.ZERO
+                val actual = actualByCategory[category] ?: BigDecimal.ZERO
+                BudgetVarianceLine(
+                    category = category,
+                    budgeted = budgeted,
+                    actual = actual,
+                    remaining = budgeted.subtract(actual),
+                )
+            }
+
+        return ProjectBudgetVsActualResponse(
+            projectId = projectId,
+            lines = lines,
+            totalBudgeted = lines.fold(BigDecimal.ZERO) { s, l -> s.add(l.budgeted) },
+            totalActual = lines.fold(BigDecimal.ZERO) { s, l -> s.add(l.actual) },
+            totalRemaining = lines.fold(BigDecimal.ZERO) { s, l -> s.add(l.remaining) },
+        )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectService.kt
@@ -1,0 +1,164 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectBillingType
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.repository.ProjectRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ProjectService(
+    private val projectRepository: ProjectRepository,
+    private val customerService: CustomerService,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun createProject(
+        request: CreateProjectRequest,
+        organizationId: String,
+    ): Project {
+        val startDate = request.startDate ?: throw BusinessRuleException("Start date is required")
+        if (request.endDate != null && request.endDate.isBefore(startDate)) {
+            throw BusinessRuleException("End date cannot be before the start date")
+        }
+        request.customerId?.let { customerService.getCustomer(it, organizationId) }
+        request.managerEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+
+        return saveWithRetry(organizationId) { number ->
+            Project(
+                projectNumber = number,
+                name = request.name.trim(),
+                description = request.description,
+                customerId = request.customerId,
+                managerEmployeeId = request.managerEmployeeId,
+                startDate = startDate,
+                endDate = request.endDate,
+                billingType = request.billingType ?: ProjectBillingType.TIME_AND_MATERIALS,
+                organizationId = organizationId,
+            )
+        }
+    }
+
+    fun getProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project =
+            projectRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Project not found")
+            }
+        if (project.organizationId != organizationId) {
+            throw ResourceNotFoundException("Project not found")
+        }
+        return project
+    }
+
+    fun listProjects(
+        organizationId: String,
+        status: ProjectStatus? = null,
+        customerId: String? = null,
+    ): List<Project> =
+        when {
+            status != null -> projectRepository.findByOrganizationIdAndStatus(organizationId, status)
+            customerId != null -> projectRepository.findByOrganizationIdAndCustomerId(organizationId, customerId)
+            else -> projectRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateProject(
+        id: String,
+        request: UpdateProjectRequest,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        request.customerId?.let { customerService.getCustomer(it, organizationId) }
+        request.managerEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+        val endDate = request.endDate ?: project.endDate
+        if (endDate != null && endDate.isBefore(project.startDate)) {
+            throw BusinessRuleException("End date cannot be before the start date")
+        }
+        return projectRepository.save(
+            project.copy(
+                name = request.name?.trim() ?: project.name,
+                description = request.description ?: project.description,
+                customerId = request.customerId ?: project.customerId,
+                managerEmployeeId = request.managerEmployeeId ?: project.managerEmployeeId,
+                endDate = endDate,
+                billingType = request.billingType ?: project.billingType,
+            ),
+        )
+    }
+
+    @Transactional
+    fun activateProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.PLANNED && project.status != ProjectStatus.ON_HOLD) {
+            throw BusinessRuleException("Only planned or on-hold projects can be activated")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.ACTIVE))
+    }
+
+    @Transactional
+    fun holdProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.ACTIVE) {
+            throw BusinessRuleException("Only active projects can be put on hold")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.ON_HOLD))
+    }
+
+    @Transactional
+    fun closeProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.ACTIVE && project.status != ProjectStatus.ON_HOLD) {
+            throw BusinessRuleException("Only active or on-hold projects can be closed")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.CLOSED))
+    }
+
+    @Transactional
+    fun cancelProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status == ProjectStatus.CLOSED || project.status == ProjectStatus.CANCELLED) {
+            throw BusinessRuleException("Project is already ${project.status.name.lowercase()}")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.CANCELLED))
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        build: (String) -> Project,
+    ): Project {
+        repeat(maxRetries) { attempt ->
+            val count = projectRepository.countByOrganizationId(organizationId)
+            val number = "PRJ-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return projectRepository.save(build(number))
+            } catch (e: DuplicateKeyException) {
+                if (attempt == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique project number: $number", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique project number")
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectTaskService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectTaskService.kt
@@ -1,0 +1,150 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectTaskRequest
+import com.aquinofroilan.tessera.dto.ProjectTaskTreeNode
+import com.aquinofroilan.tessera.dto.UpdateProjectTaskRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.ProjectTask
+import com.aquinofroilan.tessera.repository.ProjectTaskRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ProjectTaskService(
+    private val projectTaskRepository: ProjectTaskRepository,
+    private val projectService: ProjectService,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun createTask(
+        projectId: String,
+        request: CreateProjectTaskRequest,
+        organizationId: String,
+    ): ProjectTask {
+        projectService.getProject(projectId, organizationId)
+        request.assigneeEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+        request.parentTaskId?.let { requireTaskInProject(it, projectId, organizationId) }
+        return projectTaskRepository.save(
+            ProjectTask(
+                projectId = projectId,
+                parentTaskId = request.parentTaskId,
+                name = request.name.trim(),
+                description = request.description,
+                assigneeEmployeeId = request.assigneeEmployeeId,
+                estimatedHours = request.estimatedHours,
+                organizationId = organizationId,
+            ),
+        )
+    }
+
+    fun getTask(
+        projectId: String,
+        taskId: String,
+        organizationId: String,
+    ): ProjectTask {
+        val task =
+            projectTaskRepository.findById(taskId).orElseThrow {
+                ResourceNotFoundException("Task not found")
+            }
+        if (task.organizationId != organizationId || task.projectId != projectId) {
+            throw ResourceNotFoundException("Task not found")
+        }
+        return task
+    }
+
+    fun listTasks(
+        projectId: String,
+        organizationId: String,
+    ): List<ProjectTask> {
+        projectService.getProject(projectId, organizationId)
+        return projectTaskRepository.findByOrganizationIdAndProjectId(organizationId, projectId)
+    }
+
+    /** Builds the work-breakdown tree for a project: root tasks with nested children. */
+    fun getTaskTree(
+        projectId: String,
+        organizationId: String,
+    ): List<ProjectTaskTreeNode> {
+        val all = listTasks(projectId, organizationId)
+        val childrenByParent = all.groupBy { it.parentTaskId }
+
+        fun build(task: ProjectTask): ProjectTaskTreeNode =
+            ProjectTaskTreeNode.from(
+                task,
+                childrenByParent[task.id].orEmpty().sortedBy { it.name }.map(::build),
+            )
+        return childrenByParent[null].orEmpty().sortedBy { it.name }.map(::build)
+    }
+
+    @Transactional
+    fun updateTask(
+        projectId: String,
+        taskId: String,
+        request: UpdateProjectTaskRequest,
+        organizationId: String,
+    ): ProjectTask {
+        val task = getTask(projectId, taskId, organizationId)
+        request.assigneeEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+        return projectTaskRepository.save(
+            task.copy(
+                name = request.name?.trim() ?: task.name,
+                description = request.description ?: task.description,
+                assigneeEmployeeId = request.assigneeEmployeeId ?: task.assigneeEmployeeId,
+                estimatedHours = request.estimatedHours ?: task.estimatedHours,
+                status = request.status ?: task.status,
+            ),
+        )
+    }
+
+    /**
+     * Sets or clears a task's parent. A null parent promotes it to a root.
+     * Rejects self-parenting, cross-project parents, and descendant cycles.
+     */
+    @Transactional
+    fun setParent(
+        projectId: String,
+        taskId: String,
+        parentTaskId: String?,
+        organizationId: String,
+    ): ProjectTask {
+        val task = getTask(projectId, taskId, organizationId)
+        if (parentTaskId == null) {
+            return projectTaskRepository.save(task.copy(parentTaskId = null))
+        }
+        if (parentTaskId == taskId) {
+            throw BusinessRuleException("A task cannot be its own parent")
+        }
+        requireTaskInProject(parentTaskId, projectId, organizationId)
+        if (descendantIds(taskId, projectId, organizationId).contains(parentTaskId)) {
+            throw BusinessRuleException("Cannot move a task under one of its own descendants")
+        }
+        return projectTaskRepository.save(task.copy(parentTaskId = parentTaskId))
+    }
+
+    private fun requireTaskInProject(
+        taskId: String,
+        projectId: String,
+        organizationId: String,
+    ) {
+        getTask(projectId, taskId, organizationId)
+    }
+
+    private fun descendantIds(
+        taskId: String,
+        projectId: String,
+        organizationId: String,
+    ): Set<String> {
+        val childrenByParent =
+            projectTaskRepository.findByOrganizationIdAndProjectId(organizationId, projectId).groupBy { it.parentTaskId }
+        val descendants = mutableSetOf<String>()
+        val queue = ArrayDeque(childrenByParent[taskId].orEmpty().map { it.id })
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (descendants.add(current)) {
+                childrenByParent[current].orEmpty().forEach { queue.addLast(it.id) }
+            }
+        }
+        return descendants
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/TimeEntryService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/TimeEntryService.kt
@@ -1,0 +1,156 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateTimeEntryRequest
+import com.aquinofroilan.tessera.dto.UpdateTimeEntryRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Service
+class TimeEntryService(
+    private val timeEntryRepository: TimeEntryRepository,
+    private val projectService: ProjectService,
+    private val projectTaskService: ProjectTaskService,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun createTimeEntry(
+        request: CreateTimeEntryRequest,
+        organizationId: String,
+    ): TimeEntry {
+        val hours = request.hours ?: throw BusinessRuleException("Hours are required")
+        if (hours.signum() <= 0) {
+            throw BusinessRuleException("Hours must be positive")
+        }
+        val entryDate = request.entryDate ?: throw BusinessRuleException("Entry date is required")
+        if (request.rate != null && request.rate.signum() < 0) {
+            throw BusinessRuleException("Rate must not be negative")
+        }
+        projectService.getProject(request.projectId, organizationId)
+        request.taskId?.let { projectTaskService.getTask(request.projectId, it, organizationId) }
+        employeeService.getEmployee(request.employeeId, organizationId)
+
+        return timeEntryRepository.save(
+            TimeEntry(
+                employeeId = request.employeeId,
+                projectId = request.projectId,
+                taskId = request.taskId,
+                entryDate = entryDate,
+                hours = hours,
+                billable = request.billable,
+                rate = request.rate,
+                notes = request.notes,
+                organizationId = organizationId,
+            ),
+        )
+    }
+
+    fun getTimeEntry(
+        id: String,
+        organizationId: String,
+    ): TimeEntry {
+        val entry =
+            timeEntryRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Time entry not found")
+            }
+        if (entry.organizationId != organizationId) {
+            throw ResourceNotFoundException("Time entry not found")
+        }
+        return entry
+    }
+
+    fun listTimeEntries(
+        organizationId: String,
+        employeeId: String? = null,
+        projectId: String? = null,
+        status: TimeEntryStatus? = null,
+    ): List<TimeEntry> =
+        when {
+            projectId != null && status != null ->
+                timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(organizationId, projectId, status)
+            employeeId != null -> timeEntryRepository.findByOrganizationIdAndEmployeeId(organizationId, employeeId)
+            projectId != null -> timeEntryRepository.findByOrganizationIdAndProjectId(organizationId, projectId)
+            status != null -> timeEntryRepository.findByOrganizationIdAndStatus(organizationId, status)
+            else -> timeEntryRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateTimeEntry(
+        id: String,
+        request: UpdateTimeEntryRequest,
+        organizationId: String,
+    ): TimeEntry {
+        val entry = getTimeEntry(id, organizationId)
+        if (entry.status != TimeEntryStatus.DRAFT) {
+            throw BusinessRuleException("Only draft time entries can be edited")
+        }
+        request.hours?.let { if (it.signum() <= 0) throw BusinessRuleException("Hours must be positive") }
+        request.taskId?.let { projectTaskService.getTask(entry.projectId, it, organizationId) }
+        return timeEntryRepository.save(
+            entry.copy(
+                taskId = request.taskId ?: entry.taskId,
+                entryDate = request.entryDate ?: entry.entryDate,
+                hours = request.hours ?: entry.hours,
+                billable = request.billable ?: entry.billable,
+                rate = request.rate ?: entry.rate,
+                notes = request.notes ?: entry.notes,
+            ),
+        )
+    }
+
+    @Transactional
+    fun submitTimeEntry(
+        id: String,
+        organizationId: String,
+    ): TimeEntry {
+        val entry = getTimeEntry(id, organizationId)
+        if (entry.status != TimeEntryStatus.DRAFT) {
+            throw BusinessRuleException("Only draft time entries can be submitted")
+        }
+        return timeEntryRepository.save(entry.copy(status = TimeEntryStatus.SUBMITTED))
+    }
+
+    @Transactional
+    fun approveTimeEntry(
+        id: String,
+        organizationId: String,
+        approvedBy: String,
+    ): TimeEntry {
+        val entry = getTimeEntry(id, organizationId)
+        if (entry.status != TimeEntryStatus.SUBMITTED) {
+            throw BusinessRuleException("Only submitted time entries can be approved")
+        }
+        return timeEntryRepository.save(
+            entry.copy(
+                status = TimeEntryStatus.APPROVED,
+                approvedBy = approvedBy,
+                approvedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+
+    @Transactional
+    fun rejectTimeEntry(
+        id: String,
+        organizationId: String,
+        decidedBy: String,
+    ): TimeEntry {
+        val entry = getTimeEntry(id, organizationId)
+        if (entry.status != TimeEntryStatus.SUBMITTED) {
+            throw BusinessRuleException("Only submitted time entries can be rejected")
+        }
+        return timeEntryRepository.save(
+            entry.copy(
+                status = TimeEntryStatus.REJECTED,
+                approvedBy = decidedBy,
+                approvedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+}

--- a/src/main/resources/db/migration/V0019__projects.sql
+++ b/src/main/resources/db/migration/V0019__projects.sql
@@ -1,0 +1,24 @@
+-- Project module: projects (root entity of the project-management epic).
+-- Projects own tasks, timesheets, budgets and billing in later migrations.
+CREATE TABLE projects (
+    id                   uuid PRIMARY KEY,
+    project_number       text NOT NULL,
+    name                 text NOT NULL,
+    description          text,
+    customer_id          uuid REFERENCES customers(id) ON DELETE SET NULL,
+    manager_employee_id  uuid REFERENCES employees(id) ON DELETE SET NULL,
+    start_date           date NOT NULL,
+    end_date             date,
+    status               text NOT NULL DEFAULT 'PLANNED',
+    billing_type         text NOT NULL DEFAULT 'TIME_AND_MATERIALS',
+    organization_id      uuid NOT NULL REFERENCES organizations(uuid),
+    created_at           timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at           timestamp,
+    CONSTRAINT projects_status_chk
+        CHECK (status IN ('PLANNED','ACTIVE','ON_HOLD','CLOSED','CANCELLED')),
+    CONSTRAINT projects_billing_type_chk
+        CHECK (billing_type IN ('TIME_AND_MATERIALS','FIXED_PRICE','MILESTONE')),
+    CONSTRAINT projects_unique_number_per_org UNIQUE (organization_id, project_number)
+);
+CREATE INDEX projects_org_status_idx ON projects(organization_id, status);
+CREATE INDEX projects_org_customer_idx ON projects(organization_id, customer_id);

--- a/src/main/resources/db/migration/V0020__project_tasks.sql
+++ b/src/main/resources/db/migration/V0020__project_tasks.sql
@@ -1,0 +1,19 @@
+-- Project module: tasks / work breakdown structure.
+-- Tasks nest within a project via an optional self-referencing parent.
+CREATE TABLE project_tasks (
+    id                   uuid PRIMARY KEY,
+    project_id           uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    parent_task_id       uuid REFERENCES project_tasks(id) ON DELETE CASCADE,
+    name                 text NOT NULL,
+    description          text,
+    assignee_employee_id uuid REFERENCES employees(id) ON DELETE SET NULL,
+    estimated_hours      numeric(10,2),
+    status               text NOT NULL DEFAULT 'TODO',
+    organization_id      uuid NOT NULL REFERENCES organizations(uuid),
+    created_at           timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at           timestamp,
+    CONSTRAINT project_tasks_status_chk
+        CHECK (status IN ('TODO','IN_PROGRESS','DONE','CANCELLED'))
+);
+CREATE INDEX project_tasks_org_project_idx ON project_tasks(organization_id, project_id);
+CREATE INDEX project_tasks_parent_idx ON project_tasks(parent_task_id);

--- a/src/main/resources/db/migration/V0021__time_entries.sql
+++ b/src/main/resources/db/migration/V0021__time_entries.sql
@@ -1,0 +1,25 @@
+-- Project module: timesheets / time entries.
+-- Employees log time against a project (and optionally a task). Distinct from
+-- HR attendance. Approved billable entries feed project budgeting and billing.
+CREATE TABLE time_entries (
+    id               uuid PRIMARY KEY,
+    employee_id      uuid NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+    project_id       uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    task_id          uuid REFERENCES project_tasks(id) ON DELETE SET NULL,
+    entry_date       date NOT NULL,
+    hours            numeric(8,2) NOT NULL,
+    billable         boolean NOT NULL DEFAULT true,
+    rate             numeric(18,4),
+    status           text NOT NULL DEFAULT 'DRAFT',
+    notes            text,
+    approved_by      uuid REFERENCES users(uuid),
+    approved_at      timestamp,
+    organization_id  uuid NOT NULL REFERENCES organizations(uuid),
+    created_at       timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at       timestamp,
+    CONSTRAINT time_entries_status_chk
+        CHECK (status IN ('DRAFT','SUBMITTED','APPROVED','REJECTED'))
+);
+CREATE INDEX time_entries_org_project_idx ON time_entries(organization_id, project_id);
+CREATE INDEX time_entries_org_employee_idx ON time_entries(organization_id, employee_id);
+CREATE INDEX time_entries_org_status_idx ON time_entries(organization_id, status);

--- a/src/main/resources/db/migration/V0022__project_budgets.sql
+++ b/src/main/resources/db/migration/V0022__project_budgets.sql
@@ -1,0 +1,18 @@
+-- Project module: budgets per project, by cost category.
+-- Actuals are computed (not stored): labor actuals come from approved time
+-- entries; material/expense actuals arrive once bills/expense claims carry a
+-- project reference (Epic #166).
+CREATE TABLE project_budgets (
+    id               uuid PRIMARY KEY,
+    project_id       uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    category         text NOT NULL,
+    budget_amount    numeric(18,4) NOT NULL,
+    currency         char(3),
+    organization_id  uuid NOT NULL REFERENCES organizations(uuid),
+    created_at       timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at       timestamp,
+    CONSTRAINT project_budgets_category_chk
+        CHECK (category IN ('LABOR','MATERIAL','EXPENSE','OTHER')),
+    CONSTRAINT project_budgets_unique_category_per_project UNIQUE (project_id, category)
+);
+CREATE INDEX project_budgets_org_project_idx ON project_budgets(organization_id, project_id);

--- a/src/main/resources/graphql/project-budgets.graphqls
+++ b/src/main/resources/graphql/project-budgets.graphqls
@@ -1,0 +1,8 @@
+extend type Query {
+  projectBudgets(projectId: ID!): JSON!
+  projectBudgetVsActual(projectId: ID!): JSON!
+}
+
+extend type Mutation {
+  setProjectBudget(projectId: ID!, input: JSON!): JSON!
+}

--- a/src/main/resources/graphql/project-tasks.graphqls
+++ b/src/main/resources/graphql/project-tasks.graphqls
@@ -1,0 +1,11 @@
+extend type Query {
+  projectTasks(projectId: ID!): JSON!
+  projectTaskTree(projectId: ID!): JSON!
+  projectTask(projectId: ID!, taskId: ID!): JSON!
+}
+
+extend type Mutation {
+  createProjectTask(projectId: ID!, input: JSON!): JSON!
+  updateProjectTask(projectId: ID!, taskId: ID!, input: JSON!): JSON!
+  setProjectTaskParent(projectId: ID!, taskId: ID!, input: JSON): JSON!
+}

--- a/src/main/resources/graphql/projects.graphqls
+++ b/src/main/resources/graphql/projects.graphqls
@@ -1,0 +1,13 @@
+extend type Query {
+  projects(status: String, customerId: String): JSON!
+  project(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createProject(input: JSON!): JSON!
+  updateProject(id: ID!, input: JSON!): JSON!
+  activateProject(id: ID!): JSON!
+  holdProject(id: ID!): JSON!
+  closeProject(id: ID!): JSON!
+  cancelProject(id: ID!): JSON!
+}

--- a/src/main/resources/graphql/time-entries.graphqls
+++ b/src/main/resources/graphql/time-entries.graphqls
@@ -1,0 +1,12 @@
+extend type Query {
+  timeEntries(employeeId: String, projectId: String, status: String): JSON!
+  timeEntry(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createTimeEntry(input: JSON!): JSON!
+  updateTimeEntry(id: ID!, input: JSON!): JSON!
+  submitTimeEntry(id: ID!): JSON!
+  approveTimeEntry(id: ID!): JSON!
+  rejectTimeEntry(id: ID!): JSON!
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/config/RoleSeederTest.kt
@@ -104,6 +104,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -308,6 +311,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         val admin =
@@ -361,6 +367,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         val member =
@@ -393,6 +402,8 @@ class RoleSeederTest {
                         Permissions.SALES_WRITE,
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
                     ),
             )
         val viewer =
@@ -415,6 +426,7 @@ class RoleSeederTest {
                         Permissions.PROCUREMENT_READ,
                         Permissions.SALES_READ,
                         Permissions.HR_READ,
+                        Permissions.PROJECT_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectBudgetGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectBudgetGraphqlControllerTest.kt
@@ -1,0 +1,69 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.ProjectBudgetController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [ProjectBudgetGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class ProjectBudgetGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var projectBudgetController: ProjectBudgetController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `projectBudgets query should return json payload`() {
+        `when`(projectBudgetController.listBudgets("p1"))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("category" to "LABOR", "budgetAmount" to "1000"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  projectBudgets(projectId: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("projectBudgets[0].category")
+            .entity(String::class.java)
+            .isEqualTo("LABOR")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `setProjectBudget mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  setProjectBudget(projectId: "p1", input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("category" to "LABOR", "budgetAmount" to "1000"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.ProjectController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [ProjectGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class ProjectGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var projectController: ProjectController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `projects query should return json payload`() {
+        `when`(projectController.listProjects(null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "p1", "status" to "PLANNED"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  projects
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("projects[0].id")
+            .entity(String::class.java)
+            .isEqualTo("p1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:write"])
+    fun `activateProject mutation should bridge to controller`() {
+        `when`(projectController.activateProject("p1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "p1", "status" to "ACTIVE")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  activateProject(id: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("activateProject.status")
+            .entity(String::class.java)
+            .isEqualTo("ACTIVE")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `createProject mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createProject(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("name" to "Apollo"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectTaskGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectTaskGraphqlControllerTest.kt
@@ -1,0 +1,69 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.ProjectTaskController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [ProjectTaskGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class ProjectTaskGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var projectTaskController: ProjectTaskController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `projectTasks query should return json payload`() {
+        `when`(projectTaskController.listTasks("p1"))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "t1", "status" to "TODO"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  projectTasks(projectId: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("projectTasks[0].id")
+            .entity(String::class.java)
+            .isEqualTo("t1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `createProjectTask mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createProjectTask(projectId: "p1", input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("name" to "Design"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/TimeEntryGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/TimeEntryGraphqlControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.TimeEntryController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [TimeEntryGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class TimeEntryGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var timeEntryController: TimeEntryController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `timeEntries query should return json payload`() {
+        `when`(timeEntryController.listTimeEntries(null, null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "te1", "status" to "DRAFT"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  timeEntries
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("timeEntries[0].id")
+            .entity(String::class.java)
+            .isEqualTo("te1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:approve"])
+    fun `approveTimeEntry mutation should bridge to controller`() {
+        `when`(timeEntryController.approveTimeEntry("te1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "te1", "status" to "APPROVED")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  approveTimeEntry(id: "te1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("approveTimeEntry.status")
+            .entity(String::class.java)
+            .isEqualTo("APPROVED")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `createTimeEntry mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createTimeEntry(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("employeeId" to "e1", "projectId" to "p1"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectBudgetServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectBudgetServiceTest.kt
@@ -1,0 +1,107 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.SetProjectBudgetRequest
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectBudget
+import com.aquinofroilan.tessera.model.ProjectCostCategory
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.ProjectBudgetRepository
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class ProjectBudgetServiceTest {
+    private lateinit var repository: ProjectBudgetRepository
+    private lateinit var projectService: ProjectService
+    private lateinit var timeEntryRepository: TimeEntryRepository
+    private lateinit var service: ProjectBudgetService
+
+    private val orgId = "org-1"
+    private val projectId = "p-1"
+    private val day = LocalDate.of(2026, 5, 1)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(ProjectBudgetRepository::class.java)
+        projectService = mock(ProjectService::class.java)
+        timeEntryRepository = mock(TimeEntryRepository::class.java)
+        whenever(repository.save(any<ProjectBudget>())).thenAnswer { it.arguments[0] }
+        whenever(projectService.getProject(projectId, orgId)).thenReturn(
+            Project(id = projectId, projectNumber = "PRJ-0001", name = "Apollo", startDate = day, organizationId = orgId),
+        )
+        whenever(repository.findByOrganizationIdAndProjectIdAndCategory(any(), any(), any())).thenReturn(Optional.empty())
+        whenever(timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(any(), any(), any())).thenReturn(emptyList())
+        service = ProjectBudgetService(repository, projectService, timeEntryRepository)
+    }
+
+    private fun entry(
+        hours: String,
+        rate: String?,
+    ) = TimeEntry(
+        employeeId = "e-1",
+        projectId = projectId,
+        entryDate = day,
+        hours = BigDecimal(hours),
+        rate = rate?.let { BigDecimal(it) },
+        status = TimeEntryStatus.APPROVED,
+        organizationId = orgId,
+    )
+
+    @Test
+    fun `set budget creates a new category budget`() {
+        val b = service.setBudget(projectId, SetProjectBudgetRequest(ProjectCostCategory.LABOR, BigDecimal("1000")), orgId)
+        assertThat(b.category).isEqualTo(ProjectCostCategory.LABOR)
+        assertThat(b.budgetAmount).isEqualByComparingTo("1000")
+    }
+
+    @Test
+    fun `set budget updates an existing category budget`() {
+        whenever(repository.findByOrganizationIdAndProjectIdAndCategory(orgId, projectId, ProjectCostCategory.LABOR))
+            .thenReturn(
+                Optional.of(
+                    ProjectBudget(
+                        id = "b-1",
+                        projectId = projectId,
+                        category = ProjectCostCategory.LABOR,
+                        budgetAmount = BigDecimal("500"),
+                        organizationId = orgId,
+                    ),
+                ),
+            )
+        val b = service.setBudget(projectId, SetProjectBudgetRequest(ProjectCostCategory.LABOR, BigDecimal("1500")), orgId)
+        assertThat(b.id).isEqualTo("b-1")
+        assertThat(b.budgetAmount).isEqualByComparingTo("1500")
+    }
+
+    @Test
+    fun `budget vs actual computes labor actual from approved time entries`() {
+        whenever(repository.findByOrganizationIdAndProjectId(orgId, projectId)).thenReturn(
+            listOf(
+                ProjectBudget(
+                    projectId = projectId,
+                    category = ProjectCostCategory.LABOR,
+                    budgetAmount = BigDecimal("1000"),
+                    organizationId = orgId,
+                ),
+            ),
+        )
+        whenever(timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(orgId, projectId, TimeEntryStatus.APPROVED))
+            .thenReturn(listOf(entry("4", "50"), entry("4", "50"), entry("2", null)))
+
+        val report = service.budgetVsActual(projectId, orgId)
+
+        val labor = report.lines.first { it.category == ProjectCostCategory.LABOR }
+        assertThat(labor.budgeted).isEqualByComparingTo("1000")
+        assertThat(labor.actual).isEqualByComparingTo("400") // 4*50 + 4*50; the null-rate entry is excluded
+        assertThat(labor.remaining).isEqualByComparingTo("600")
+        assertThat(report.totalActual).isEqualByComparingTo("400")
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectServiceTest.kt
@@ -1,0 +1,113 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Customer
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.repository.ProjectRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.util.Optional
+
+class ProjectServiceTest {
+    private lateinit var repository: ProjectRepository
+    private lateinit var customerService: CustomerService
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: ProjectService
+
+    private val orgId = "org-1"
+    private val start = LocalDate.of(2026, 1, 1)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(ProjectRepository::class.java)
+        customerService = mock(CustomerService::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
+        whenever(repository.save(any<Project>())).thenAnswer { it.arguments[0] }
+        whenever(customerService.getCustomer("c-1", orgId)).thenReturn(Customer(id = "c-1", name = "Globex", organizationId = orgId))
+        service = ProjectService(repository, customerService, employeeService)
+    }
+
+    private fun project(status: ProjectStatus = ProjectStatus.PLANNED) =
+        Project(
+            id = "p-1",
+            projectNumber = "PRJ-0001",
+            name = "Apollo",
+            startDate = start,
+            status = status,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `create persists a planned project with a generated number`() {
+        val p = service.createProject(CreateProjectRequest(name = " Apollo ", startDate = start), orgId)
+
+        assertThat(p.status).isEqualTo(ProjectStatus.PLANNED)
+        assertThat(p.projectNumber).isEqualTo("PRJ-0001")
+        assertThat(p.name).isEqualTo("Apollo")
+    }
+
+    @Test
+    fun `create rejects an end date before the start date`() {
+        assertThatThrownBy {
+            service.createProject(CreateProjectRequest(name = "Apollo", startDate = start, endDate = start.minusDays(1)), orgId)
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `create validates the customer belongs to the org`() {
+        whenever(customerService.getCustomer("missing", orgId)).thenThrow(ResourceNotFoundException("Customer not found"))
+        assertThatThrownBy {
+            service.createProject(CreateProjectRequest(name = "Apollo", startDate = start, customerId = "missing"), orgId)
+        }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `activate moves planned to active and rejects from other states`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.PLANNED)))
+        assertThat(service.activateProject("p-1", orgId).status).isEqualTo(ProjectStatus.ACTIVE)
+
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.CLOSED)))
+        assertThatThrownBy { service.activateProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `hold requires an active project`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.PLANNED)))
+        assertThatThrownBy { service.holdProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `cancel rejects an already-closed project`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.CLOSED)))
+        assertThatThrownBy { service.cancelProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `update changes fields and validates end date`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project()))
+        val updated = service.updateProject("p-1", UpdateProjectRequest(name = "Apollo II"), orgId)
+        assertThat(updated.name).isEqualTo("Apollo II")
+
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project()))
+        assertThatThrownBy {
+            service.updateProject("p-1", UpdateProjectRequest(endDate = start.minusDays(5)), orgId)
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project().copy(organizationId = "other")))
+        assertThatThrownBy { service.getProject("p-1", orgId) }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectTaskServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectTaskServiceTest.kt
@@ -1,0 +1,124 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectTaskRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectTaskRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectTask
+import com.aquinofroilan.tessera.model.TaskStatus
+import com.aquinofroilan.tessera.repository.ProjectTaskRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.util.Optional
+
+class ProjectTaskServiceTest {
+    private lateinit var repository: ProjectTaskRepository
+    private lateinit var projectService: ProjectService
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: ProjectTaskService
+
+    private val orgId = "org-1"
+    private val projectId = "p-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(ProjectTaskRepository::class.java)
+        projectService = mock(ProjectService::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.save(any<ProjectTask>())).thenAnswer { it.arguments[0] }
+        whenever(projectService.getProject(projectId, orgId)).thenReturn(
+            Project(
+                id = projectId,
+                projectNumber = "PRJ-0001",
+                name = "Apollo",
+                startDate = LocalDate.of(2026, 1, 1),
+                organizationId = orgId,
+            ),
+        )
+        service = ProjectTaskService(repository, projectService, employeeService)
+    }
+
+    private fun task(
+        id: String,
+        parent: String? = null,
+        org: String = orgId,
+        project: String = projectId,
+    ) = ProjectTask(id = id, projectId = project, parentTaskId = parent, name = id, organizationId = org)
+
+    @Test
+    fun `create persists a task under a validated project`() {
+        val t = service.createTask(projectId, CreateProjectTaskRequest(name = " Design "), orgId)
+        assertThat(t.name).isEqualTo("Design")
+        assertThat(t.projectId).isEqualTo(projectId)
+        assertThat(t.status).isEqualTo(TaskStatus.TODO)
+    }
+
+    @Test
+    fun `create with a parent validates the parent is in the same project`() {
+        whenever(repository.findById("missing")).thenReturn(Optional.empty())
+        assertThatThrownBy {
+            service.createTask(projectId, CreateProjectTaskRequest(name = "Sub", parentTaskId = "missing"), orgId)
+        }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `setParent rejects self-parenting`() {
+        whenever(repository.findById("t1")).thenReturn(Optional.of(task("t1")))
+        assertThatThrownBy { service.setParent(projectId, "t1", "t1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `setParent rejects a descendant cycle`() {
+        val t1 = task("t1")
+        val t2 = task("t2", parent = "t1")
+        whenever(repository.findById("t1")).thenReturn(Optional.of(t1))
+        whenever(repository.findById("t2")).thenReturn(Optional.of(t2))
+        whenever(repository.findByOrganizationIdAndProjectId(orgId, projectId)).thenReturn(listOf(t1, t2))
+
+        assertThatThrownBy { service.setParent(projectId, "t1", "t2", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `setParent clears the parent when null`() {
+        whenever(repository.findById("t2")).thenReturn(Optional.of(task("t2", parent = "t1")))
+        assertThat(service.setParent(projectId, "t2", null, orgId).parentTaskId).isNull()
+    }
+
+    @Test
+    fun `task tree nests children under roots`() {
+        val root = task("t1")
+        val child = task("t2", parent = "t1")
+        val grandchild = task("t3", parent = "t2")
+        whenever(repository.findByOrganizationIdAndProjectId(orgId, projectId)).thenReturn(listOf(child, root, grandchild))
+
+        val tree = service.getTaskTree(projectId, orgId)
+
+        assertThat(tree).hasSize(1)
+        assertThat(tree[0].id).isEqualTo("t1")
+        assertThat(tree[0].children[0].id).isEqualTo("t2")
+        assertThat(tree[0].children[0].children[0].id).isEqualTo("t3")
+    }
+
+    @Test
+    fun `get rejects a task from another project`() {
+        whenever(repository.findById("t1")).thenReturn(Optional.of(task("t1", project = "other")))
+        assertThatThrownBy { service.getTask(projectId, "t1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `update changes status`() {
+        whenever(repository.findById("t1")).thenReturn(Optional.of(task("t1")))
+        val updated = service.updateTask(projectId, "t1", UpdateProjectTaskRequest(status = TaskStatus.DONE), orgId)
+        assertThat(updated.status).isEqualTo(TaskStatus.DONE)
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/TimeEntryServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/TimeEntryServiceTest.kt
@@ -1,0 +1,116 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateTimeEntryRequest
+import com.aquinofroilan.tessera.dto.UpdateTimeEntryRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Employee
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class TimeEntryServiceTest {
+    private lateinit var repository: TimeEntryRepository
+    private lateinit var projectService: ProjectService
+    private lateinit var projectTaskService: ProjectTaskService
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: TimeEntryService
+
+    private val orgId = "org-1"
+    private val projectId = "p-1"
+    private val empId = "e-1"
+    private val day = LocalDate.of(2026, 5, 1)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(TimeEntryRepository::class.java)
+        projectService = mock(ProjectService::class.java)
+        projectTaskService = mock(ProjectTaskService::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.save(any<TimeEntry>())).thenAnswer { it.arguments[0] }
+        whenever(projectService.getProject(projectId, orgId)).thenReturn(
+            Project(id = projectId, projectNumber = "PRJ-0001", name = "Apollo", startDate = day, organizationId = orgId),
+        )
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(
+            Employee(
+                id = empId,
+                employeeNumber = "EMP-0001",
+                firstName = "Ada",
+                lastName = "Lovelace",
+                hireDate = day,
+                organizationId = orgId,
+            ),
+        )
+        service = TimeEntryService(repository, projectService, projectTaskService, employeeService)
+    }
+
+    private fun req(hours: BigDecimal = BigDecimal("4")) =
+        CreateTimeEntryRequest(employeeId = empId, projectId = projectId, entryDate = day, hours = hours)
+
+    private fun entry(status: TimeEntryStatus = TimeEntryStatus.DRAFT) =
+        TimeEntry(
+            id = "te-1",
+            employeeId = empId,
+            projectId = projectId,
+            entryDate = day,
+            hours = BigDecimal("4"),
+            status = status,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `create persists a draft entry`() {
+        val e = service.createTimeEntry(req(), orgId)
+        assertThat(e.status).isEqualTo(TimeEntryStatus.DRAFT)
+        assertThat(e.hours).isEqualByComparingTo("4")
+    }
+
+    @Test
+    fun `create rejects non-positive hours`() {
+        assertThatThrownBy { service.createTimeEntry(req(hours = BigDecimal.ZERO), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `submit moves draft to submitted then approval is gated`() {
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry(TimeEntryStatus.DRAFT)))
+        assertThat(service.submitTimeEntry("te-1", orgId).status).isEqualTo(TimeEntryStatus.SUBMITTED)
+
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry(TimeEntryStatus.DRAFT)))
+        assertThatThrownBy { service.approveTimeEntry("te-1", orgId, "u1") }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `approve sets approver on a submitted entry`() {
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry(TimeEntryStatus.SUBMITTED)))
+        val approved = service.approveTimeEntry("te-1", orgId, "u1")
+        assertThat(approved.status).isEqualTo(TimeEntryStatus.APPROVED)
+        assertThat(approved.approvedBy).isEqualTo("u1")
+    }
+
+    @Test
+    fun `update is rejected once not draft`() {
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry(TimeEntryStatus.APPROVED)))
+        assertThatThrownBy { service.updateTimeEntry("te-1", UpdateTimeEntryRequest(hours = BigDecimal("2")), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry().copy(organizationId = "other")))
+        assertThatThrownBy { service.getTimeEntry("te-1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}


### PR DESCRIPTION
**Stack 4/5** of Epic #165. Base: `project-timesheets` (#182). Closes #183. *(Sibling of #184 — both branch off #182, neither depends on the other.)*

Project budgets + budget-vs-actual.

## What
- **Migration** `V0022__project_budgets.sql` — one budget row per `(project, category)`.
- **Categories** — `LABOR / MATERIAL / EXPENSE / OTHER`.
- **Service** — `setBudget` (upsert per category); **budget-vs-actual** where **labor actual = Σ(hours × rate)** over APPROVED time entries.
- **REST** `/projects/{projectId}/budget` — POST (set) / GET (list) / `GET /vs-actual`. `projects:read`/`projects:write`.
- **GraphQL** — `project-budgets.graphqls` + `ProjectBudgetGraphqlController`.
- **Tests** — `ProjectBudgetServiceTest` (upsert new/existing, labor-actual computation incl. null-rate exclusion) + `ProjectBudgetGraphqlControllerTest`.

## Scope note
MVP captures **labor** actuals only. Material/expense actuals require bills and expense claims to carry a `projectId` — that hook arrives with **Epic #166** (expense management). Flagged in code + migration comments.

Review on top of #180→#181→#182.
