### PR TITLE
feat(inventory): physical inventory count & reconciliation (#120)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/InventoryCountController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/InventoryCountController.kt
@@ -1,0 +1,99 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CountSessionResponse
+import com.aquinofroilan.tessera.dto.CreateCountSessionRequest
+import com.aquinofroilan.tessera.dto.RecordCountRequest
+import com.aquinofroilan.tessera.model.InventoryCountStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.InventoryCountSessionService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/inventory/counts")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class InventoryCountController(
+    private val countService: InventoryCountSessionService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun create(
+        @Valid @RequestBody request: CreateCountSessionRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        val s = countService.createSession(request, orgId, userId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(CountSessionResponse.from(s))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun list(
+        @RequestParam(required = false) status: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val parsed =
+            if (status != null) {
+                try {
+                    InventoryCountStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(countService.listSessions(orgId, parsed).map { CountSessionResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun get(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(CountSessionResponse.from(countService.getSession(id, orgId)))
+    }
+
+    @PostMapping("/{id}/lines/{lineId}/record-count")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun recordCount(
+        @PathVariable id: String,
+        @PathVariable lineId: String,
+        @Valid @RequestBody request: RecordCountRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(CountSessionResponse.from(countService.recordCount(id, lineId, request, orgId)))
+    }
+
+    @PostMapping("/{id}/post")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun post(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(CountSessionResponse.from(countService.postSession(id, orgId, userId)))
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun cancel(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(CountSessionResponse.from(countService.cancelSession(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/InventoryCountDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/InventoryCountDtos.kt
@@ -1,0 +1,82 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.InventoryCountLine
+import com.aquinofroilan.tessera.model.InventoryCountSession
+import com.aquinofroilan.tessera.model.InventoryCountStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.PositiveOrZero
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreateCountSessionRequest(
+    @field:NotBlank(message = "Code is required")
+    val code: String,
+    @field:NotBlank(message = "Warehouse ID is required")
+    val warehouseId: String,
+    val scheduledFor: LocalDate? = null,
+    val notes: String? = null,
+)
+
+data class RecordCountRequest(
+    @field:NotNull(message = "Counted quantity is required")
+    @field:PositiveOrZero(message = "Counted quantity cannot be negative")
+    val countedQuantity: BigDecimal?,
+    val notes: String? = null,
+)
+
+data class CountLineResponse(
+    val id: String,
+    val lineNumber: Int,
+    val productId: String,
+    val productSku: String,
+    val productName: String,
+    val expectedQuantity: BigDecimal,
+    val countedQuantity: BigDecimal?,
+    val varianceQuantity: BigDecimal?,
+    val adjustmentMovementId: String?,
+    val notes: String?,
+) {
+    companion object {
+        fun from(l: InventoryCountLine) =
+            CountLineResponse(
+                id = l.id,
+                lineNumber = l.lineNumber,
+                productId = l.productId,
+                productSku = l.productSku,
+                productName = l.productName,
+                expectedQuantity = l.expectedQuantity,
+                countedQuantity = l.countedQuantity,
+                varianceQuantity = l.varianceQuantity,
+                adjustmentMovementId = l.adjustmentMovementId,
+                notes = l.notes,
+            )
+    }
+}
+
+data class CountSessionResponse(
+    val id: String,
+    val code: String,
+    val warehouseId: String,
+    val status: InventoryCountStatus,
+    val scheduledFor: LocalDate?,
+    val startedAt: String?,
+    val postedAt: String?,
+    val notes: String?,
+    val lines: List<CountLineResponse>,
+) {
+    companion object {
+        fun from(s: InventoryCountSession) =
+            CountSessionResponse(
+                id = s.id,
+                code = s.code,
+                warehouseId = s.warehouseId,
+                status = s.status,
+                scheduledFor = s.scheduledFor,
+                startedAt = s.startedAt?.toString(),
+                postedAt = s.postedAt?.toString(),
+                notes = s.notes,
+                lines = s.lines.map { CountLineResponse.from(it) },
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/InventoryCountSession.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/InventoryCountSession.kt
@@ -1,0 +1,90 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class InventoryCountStatus {
+    DRAFT,
+    COUNTING,
+    POSTED,
+    CANCELLED,
+}
+
+@Entity
+@Table(name = "inventory_count_lines")
+data class InventoryCountLine(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "line_number")
+    val lineNumber: Int,
+    @Column(name = "product_id", columnDefinition = "uuid")
+    val productId: String,
+    @Column(name = "product_sku")
+    val productSku: String,
+    @Column(name = "product_name")
+    val productName: String,
+    @Column(name = "expected_quantity")
+    val expectedQuantity: BigDecimal,
+    @Column(name = "counted_quantity")
+    val countedQuantity: BigDecimal? = null,
+    @Column(name = "variance_quantity")
+    val varianceQuantity: BigDecimal? = null,
+    val notes: String? = null,
+    @Column(name = "adjustment_movement_id", columnDefinition = "uuid")
+    val adjustmentMovementId: String? = null,
+)
+
+@Entity
+@Table(name = "inventory_count_sessions")
+@EntityListeners(AuditingEntityListener::class)
+data class InventoryCountSession(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    val code: String,
+    @Column(name = "warehouse_id", columnDefinition = "uuid")
+    val warehouseId: String,
+    @Enumerated(EnumType.STRING)
+    val status: InventoryCountStatus = InventoryCountStatus.DRAFT,
+    @Column(name = "scheduled_for")
+    val scheduledFor: LocalDate? = null,
+    @Column(name = "started_at")
+    val startedAt: LocalDateTime? = null,
+    @Column(name = "posted_at")
+    val postedAt: LocalDateTime? = null,
+    @Column(name = "posted_by", columnDefinition = "uuid")
+    val postedBy: String? = null,
+    val notes: String? = null,
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "session_id")
+    @OrderBy("lineNumber ASC")
+    val lines: List<InventoryCountLine>,
+    @Column(name = "created_by", columnDefinition = "uuid")
+    val createdBy: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/InventoryCountSessionRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/InventoryCountSessionRepository.kt
@@ -1,0 +1,22 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.InventoryCountSession
+import com.aquinofroilan.tessera.model.InventoryCountStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface InventoryCountSessionRepository : JpaRepository<InventoryCountSession, String> {
+    fun findByOrganizationId(organizationId: String): List<InventoryCountSession>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: InventoryCountStatus,
+    ): List<InventoryCountSession>
+
+    fun findByOrganizationIdAndCode(
+        organizationId: String,
+        code: String,
+    ): Optional<InventoryCountSession>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/InventoryCountSessionService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/InventoryCountSessionService.kt
@@ -1,0 +1,198 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateCountSessionRequest
+import com.aquinofroilan.tessera.dto.CreateStockMovementRequest
+import com.aquinofroilan.tessera.dto.RecordCountRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.InventoryCountLine
+import com.aquinofroilan.tessera.model.InventoryCountSession
+import com.aquinofroilan.tessera.model.InventoryCountStatus
+import com.aquinofroilan.tessera.model.StockMovementType
+import com.aquinofroilan.tessera.repository.InventoryCountSessionRepository
+import com.aquinofroilan.tessera.repository.StockOnHandRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@Service
+class InventoryCountSessionService(
+    private val sessionRepository: InventoryCountSessionRepository,
+    private val stockOnHandRepository: StockOnHandRepository,
+    private val warehouseService: WarehouseService,
+    private val productService: ProductService,
+    private val stockMovementService: StockMovementService,
+) {
+    @Transactional
+    fun createSession(
+        request: CreateCountSessionRequest,
+        organizationId: String,
+        userId: String,
+    ): InventoryCountSession {
+        val warehouse = warehouseService.getWarehouse(request.warehouseId, organizationId)
+        if (!warehouse.isActive) {
+            throw BusinessRuleException("Warehouse '${warehouse.code}' is inactive")
+        }
+        sessionRepository.findByOrganizationIdAndCode(organizationId, request.code).ifPresent {
+            throw BusinessRuleException("Count session with code '${request.code}' already exists")
+        }
+        // Snapshot stock-on-hand for this warehouse into count lines.
+        val sohRows =
+            stockOnHandRepository
+                .findByOrganizationId(organizationId)
+                .filter { it.warehouseId == warehouse.id && it.quantity.signum() != 0 }
+        val lines =
+            sohRows.mapIndexed { idx, soh ->
+                val product = productService.getProduct(soh.productId, organizationId)
+                InventoryCountLine(
+                    lineNumber = idx + 1,
+                    productId = product.id,
+                    productSku = product.sku,
+                    productName = product.name,
+                    expectedQuantity = soh.quantity,
+                )
+            }
+        val session =
+            InventoryCountSession(
+                organizationId = organizationId,
+                code = request.code.trim(),
+                warehouseId = warehouse.id,
+                status = InventoryCountStatus.DRAFT,
+                scheduledFor = request.scheduledFor,
+                notes = request.notes,
+                lines = lines,
+                createdBy = userId,
+            )
+        return try {
+            sessionRepository.save(session)
+        } catch (e: DataIntegrityViolationException) {
+            throw BusinessRuleException("Count session with code '${request.code}' already exists")
+        }
+    }
+
+    fun getSession(
+        id: String,
+        organizationId: String,
+    ): InventoryCountSession {
+        val s =
+            sessionRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Count session not found: $id")
+            }
+        if (s.organizationId != organizationId) {
+            throw ResourceNotFoundException("Count session not found: $id")
+        }
+        return s
+    }
+
+    fun listSessions(
+        organizationId: String,
+        status: InventoryCountStatus?,
+    ): List<InventoryCountSession> =
+        if (status != null) {
+            sessionRepository.findByOrganizationIdAndStatus(organizationId, status)
+        } else {
+            sessionRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun recordCount(
+        sessionId: String,
+        lineId: String,
+        request: RecordCountRequest,
+        organizationId: String,
+    ): InventoryCountSession {
+        val session = getSession(sessionId, organizationId)
+        if (session.status == InventoryCountStatus.POSTED || session.status == InventoryCountStatus.CANCELLED) {
+            throw BusinessRuleException("Cannot record counts on a ${session.status} session")
+        }
+        val counted = request.countedQuantity ?: throw BusinessRuleException("countedQuantity is required")
+        val updatedLines =
+            session.lines.map { line ->
+                if (line.id == lineId) {
+                    line.copy(countedQuantity = counted, notes = request.notes ?: line.notes)
+                } else {
+                    line
+                }
+            }
+        if (updatedLines == session.lines) {
+            throw ResourceNotFoundException("Count line not found in this session: $lineId")
+        }
+        val nextStatus =
+            if (session.status == InventoryCountStatus.DRAFT) InventoryCountStatus.COUNTING else session.status
+        return sessionRepository.save(
+            session.copy(
+                status = nextStatus,
+                startedAt = session.startedAt ?: LocalDateTime.now(),
+                lines = updatedLines,
+            ),
+        )
+    }
+
+    @Transactional
+    fun postSession(
+        sessionId: String,
+        organizationId: String,
+        userId: String,
+    ): InventoryCountSession {
+        val session = getSession(sessionId, organizationId)
+        if (session.status == InventoryCountStatus.POSTED) {
+            throw BusinessRuleException("Session is already POSTED")
+        }
+        if (session.status == InventoryCountStatus.CANCELLED) {
+            throw BusinessRuleException("Cannot post a CANCELLED session")
+        }
+        val missing = session.lines.filter { it.countedQuantity == null }
+        if (missing.isNotEmpty()) {
+            throw BusinessRuleException("Cannot post: ${missing.size} line(s) have not been counted")
+        }
+        val postedLines =
+            session.lines.map { line ->
+                val counted = line.countedQuantity!!
+                val variance = counted.subtract(line.expectedQuantity)
+                if (variance.signum() == 0) {
+                    line.copy(varianceQuantity = BigDecimal.ZERO)
+                } else {
+                    val movement =
+                        stockMovementService.createMovement(
+                            CreateStockMovementRequest(
+                                type = StockMovementType.ADJUSTMENT,
+                                productId = line.productId,
+                                warehouseId = session.warehouseId,
+                                quantity = variance,
+                                reference = "COUNT-${session.code}",
+                                notes = "Physical count adjustment (session ${session.code})",
+                            ),
+                            organizationId,
+                            userId,
+                        )
+                    line.copy(
+                        varianceQuantity = variance,
+                        adjustmentMovementId = movement.id,
+                    )
+                }
+            }
+        return sessionRepository.save(
+            session.copy(
+                status = InventoryCountStatus.POSTED,
+                postedAt = LocalDateTime.now(),
+                postedBy = userId,
+                lines = postedLines,
+            ),
+        )
+    }
+
+    @Transactional
+    fun cancelSession(
+        sessionId: String,
+        organizationId: String,
+    ): InventoryCountSession {
+        val session = getSession(sessionId, organizationId)
+        if (session.status == InventoryCountStatus.POSTED) {
+            throw BusinessRuleException("Cannot cancel a POSTED session")
+        }
+        if (session.status == InventoryCountStatus.CANCELLED) return session
+        return sessionRepository.save(session.copy(status = InventoryCountStatus.CANCELLED))
+    }
+}

--- a/src/main/resources/db/migration/V0031__inventory_count_sessions.sql
+++ b/src/main/resources/db/migration/V0031__inventory_count_sessions.sql
@@ -1,0 +1,41 @@
+-- Inventory: physical count & reconciliation.
+-- A count session snapshots the on-hand quantity for every product at a
+-- chosen warehouse at creation time. Counters then record the actual
+-- physical count per line; at post time the variance for each line is
+-- reconciled into an ADJUSTMENT stock movement so the GL stays in sync.
+
+CREATE TABLE inventory_count_sessions (
+    id                uuid PRIMARY KEY,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    code              text NOT NULL,
+    warehouse_id      uuid NOT NULL REFERENCES warehouses(id) ON DELETE RESTRICT,
+    status            text NOT NULL DEFAULT 'DRAFT',
+    scheduled_for     date,
+    started_at        timestamp,
+    posted_at         timestamp,
+    posted_by         uuid REFERENCES users(uuid),
+    notes             text,
+    created_by        uuid NOT NULL REFERENCES users(uuid),
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT inv_count_status_chk CHECK (status IN ('DRAFT','COUNTING','POSTED','CANCELLED')),
+    CONSTRAINT inv_count_unique_code_per_org UNIQUE (organization_id, code)
+);
+CREATE INDEX inv_count_org_warehouse_idx ON inventory_count_sessions(organization_id, warehouse_id);
+CREATE INDEX inv_count_org_status_idx    ON inventory_count_sessions(organization_id, status);
+
+CREATE TABLE inventory_count_lines (
+    id                       uuid PRIMARY KEY,
+    session_id               uuid NOT NULL REFERENCES inventory_count_sessions(id) ON DELETE CASCADE,
+    line_number              int NOT NULL,
+    product_id               uuid NOT NULL REFERENCES products(id) ON DELETE RESTRICT,
+    product_sku              text NOT NULL,
+    product_name             text NOT NULL,
+    expected_quantity        numeric(18,4) NOT NULL,
+    counted_quantity         numeric(18,4),
+    variance_quantity        numeric(18,4),
+    notes                    text,
+    adjustment_movement_id   uuid,
+    CONSTRAINT inv_count_lines_unique_per_session UNIQUE (session_id, line_number)
+);
+CREATE INDEX inv_count_lines_product_idx ON inventory_count_lines(product_id);

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/InventoryCountSessionServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/InventoryCountSessionServiceTest.kt
@@ -1,0 +1,196 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateCountSessionRequest
+import com.aquinofroilan.tessera.dto.CreateStockMovementRequest
+import com.aquinofroilan.tessera.dto.RecordCountRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.InventoryCountLine
+import com.aquinofroilan.tessera.model.InventoryCountSession
+import com.aquinofroilan.tessera.model.InventoryCountStatus
+import com.aquinofroilan.tessera.model.Product
+import com.aquinofroilan.tessera.model.StockMovement
+import com.aquinofroilan.tessera.model.StockMovementType
+import com.aquinofroilan.tessera.model.StockOnHand
+import com.aquinofroilan.tessera.model.Warehouse
+import com.aquinofroilan.tessera.repository.InventoryCountSessionRepository
+import com.aquinofroilan.tessera.repository.StockOnHandRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+
+class InventoryCountSessionServiceTest {
+    private lateinit var repository: InventoryCountSessionRepository
+    private lateinit var sohRepository: StockOnHandRepository
+    private lateinit var warehouseService: WarehouseService
+    private lateinit var productService: ProductService
+    private lateinit var movementService: StockMovementService
+    private lateinit var service: InventoryCountSessionService
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+    private val whId = "wh-1"
+    private val productAId = "prod-A"
+    private val productBId = "prod-B"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(InventoryCountSessionRepository::class.java)
+        sohRepository = mock(StockOnHandRepository::class.java)
+        warehouseService = mock(WarehouseService::class.java)
+        productService = mock(ProductService::class.java)
+        movementService = mock(StockMovementService::class.java)
+        whenever(repository.save(any<InventoryCountSession>())).thenAnswer { it.arguments[0] }
+        whenever(repository.findByOrganizationIdAndCode(any(), any())).thenReturn(Optional.empty())
+        whenever(warehouseService.getWarehouse(whId, orgId)).thenReturn(
+            Warehouse(id = whId, code = "MAIN", name = "Main", organizationId = orgId, isActive = true),
+        )
+        whenever(productService.getProduct(productAId, orgId)).thenReturn(product(productAId, "A"))
+        whenever(productService.getProduct(productBId, orgId)).thenReturn(product(productBId, "B"))
+        whenever(sohRepository.findByOrganizationId(orgId)).thenReturn(
+            listOf(
+                StockOnHand(organizationId = orgId, productId = productAId, warehouseId = whId, quantity = BigDecimal("100")),
+                StockOnHand(organizationId = orgId, productId = productBId, warehouseId = whId, quantity = BigDecimal("50")),
+                StockOnHand(organizationId = orgId, productId = "prod-other", warehouseId = "wh-other", quantity = BigDecimal("999")),
+            ),
+        )
+        service = InventoryCountSessionService(repository, sohRepository, warehouseService, productService, movementService)
+    }
+
+    @Test
+    fun `create snapshots on-hand for the chosen warehouse only`() {
+        val s =
+            service.createSession(
+                CreateCountSessionRequest(code = "Q3-MAIN", warehouseId = whId),
+                orgId,
+                userId,
+            )
+        assertThat(s.status).isEqualTo(InventoryCountStatus.DRAFT)
+        assertThat(s.lines).hasSize(2)
+        assertThat(s.lines.map { it.productSku }).containsExactlyInAnyOrder("A", "B")
+        assertThat(s.lines[0].expectedQuantity).isEqualByComparingTo(BigDecimal("100"))
+    }
+
+    @Test
+    fun `recordCount transitions DRAFT to COUNTING and updates line`() {
+        val draft =
+            session(InventoryCountStatus.DRAFT)
+                .copy(lines = listOf(line("l1", productAId, BigDecimal("100"))))
+        whenever(repository.findById("s1")).thenReturn(Optional.of(draft))
+
+        val updated = service.recordCount("s1", "l1", RecordCountRequest(countedQuantity = BigDecimal("95")), orgId)
+
+        assertThat(updated.status).isEqualTo(InventoryCountStatus.COUNTING)
+        assertThat(updated.lines[0].countedQuantity).isEqualByComparingTo(BigDecimal("95"))
+        assertThat(updated.startedAt).isNotNull
+    }
+
+    @Test
+    fun `recordCount rejects POSTED sessions`() {
+        whenever(repository.findById("s1")).thenReturn(Optional.of(session(InventoryCountStatus.POSTED)))
+        assertThatThrownBy {
+            service.recordCount("s1", "l1", RecordCountRequest(countedQuantity = BigDecimal.ZERO), orgId)
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `postSession rejects when any line is unrecorded`() {
+        val s =
+            session(InventoryCountStatus.COUNTING).copy(
+                lines =
+                    listOf(
+                        line("l1", productAId, BigDecimal("100")).copy(countedQuantity = BigDecimal("100")),
+                        line("l2", productBId, BigDecimal("50")),
+                    ),
+            )
+        whenever(repository.findById("s1")).thenReturn(Optional.of(s))
+        assertThatThrownBy { service.postSession("s1", orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+            .hasMessageContaining("have not been counted")
+    }
+
+    @Test
+    fun `postSession creates ADJUSTMENT movement only for variances`() {
+        val s =
+            session(InventoryCountStatus.COUNTING).copy(
+                lines =
+                    listOf(
+                        line("l1", productAId, BigDecimal("100")).copy(countedQuantity = BigDecimal("95")),
+                        line("l2", productBId, BigDecimal("50")).copy(countedQuantity = BigDecimal("50")),
+                    ),
+            )
+        whenever(repository.findById("s1")).thenReturn(Optional.of(s))
+        whenever(
+            movementService.createMovement(any<CreateStockMovementRequest>(), any(), any()),
+        ).thenAnswer {
+            StockMovement(
+                id = "mv1",
+                organizationId = orgId,
+                type = StockMovementType.ADJUSTMENT,
+                productId = productAId,
+                warehouseId = whId,
+                quantity = BigDecimal("-5"),
+                occurredAt = LocalDateTime.now(),
+                createdBy = userId,
+            )
+        }
+
+        val posted = service.postSession("s1", orgId, userId)
+
+        assertThat(posted.status).isEqualTo(InventoryCountStatus.POSTED)
+        assertThat(posted.lines[0].varianceQuantity).isEqualByComparingTo(BigDecimal("-5"))
+        assertThat(posted.lines[0].adjustmentMovementId).isEqualTo("mv1")
+        assertThat(posted.lines[1].varianceQuantity).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(posted.lines[1].adjustmentMovementId).isNull()
+    }
+
+    @Test
+    fun `cancel rejects POSTED`() {
+        whenever(repository.findById("s1")).thenReturn(Optional.of(session(InventoryCountStatus.POSTED)))
+        assertThatThrownBy { service.cancelSession("s1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    private fun session(status: InventoryCountStatus) =
+        InventoryCountSession(
+            id = "s1",
+            organizationId = orgId,
+            code = "Q3",
+            warehouseId = whId,
+            status = status,
+            lines = emptyList(),
+            createdBy = userId,
+        )
+
+    private fun line(
+        id: String,
+        productId: String,
+        expected: BigDecimal,
+    ) = InventoryCountLine(
+        id = id,
+        lineNumber = 1,
+        productId = productId,
+        productSku = productId,
+        productName = productId,
+        expectedQuantity = expected,
+    )
+
+    private fun product(
+        id: String,
+        sku: String,
+    ) = Product(
+        id = id,
+        sku = sku,
+        name = sku,
+        listPrice = BigDecimal.ONE,
+        priceCurrency = "USD",
+        organizationId = orgId,
+        isActive = true,
+    )
+}


### PR DESCRIPTION
## Summary
Physical count workflow that reconciles variances back to inventory via `ADJUSTMENT` stock movements, so the GL stays in sync with the floor.

- `inventory_count_sessions` + `inventory_count_lines` schema with `DRAFT` → `COUNTING` → `POSTED` (or `CANCELLED`) lifecycle.
- **Creating** a session snapshots current stock-on-hand for the chosen warehouse into count lines with `expected_quantity` set to the live value (lines whose on-hand is zero are skipped).
- **Recording a count** flips the session `DRAFT` → `COUNTING` on first hit and stamps `line.counted_quantity`.
- **Posting** computes `variance = counted − expected` per line, creates an `ADJUSTMENT` stock movement carrying reference `COUNT-<code>` for every **non-zero** variance, and stamps `line.variance_quantity` + `line.adjustment_movement_id`. Zero-variance lines leave the movement_id `NULL`. Rejects when any line is still un-counted.
- REST endpoints under `/inventory/counts`: create / list / get / record-count / post / cancel. **Reuses existing `inventory:read` / `inventory:write`** — no new permissions, no role-seeder churn.

Closes #120.

## Test plan
- [x] `./gradlew test --tests InventoryCountSessionServiceTest` — 6 cases green
- [x] `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck` — clean
- [ ] CI full suite
- [ ] Manual smoke: receive 10 of product X → create count session → record counted_quantity = 8 → post → verify ADJUSTMENT movement of -2 and on-hand updated