### PR TITLE
feat(integrations): CSV import & export for products/customers/vendors (#73)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/CsvImportExportController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/CsvImportExportController.kt
@@ -1,0 +1,73 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.CsvImportExportService
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/io/csv")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class CsvImportExportController(
+    private val csvService: CsvImportExportService,
+    private val authContext: AuthenticationContext,
+) {
+    @GetMapping("/products/export")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun exportProducts(): ResponseEntity<ByteArray> {
+        val orgId = authContext.organizationId() ?: return ResponseEntity.status(401).build()
+        return csv(csvService.exportProducts(orgId), "products.csv")
+    }
+
+    @GetMapping("/customers/export")
+    @PreAuthorize("hasAuthority('sales:read')")
+    fun exportCustomers(): ResponseEntity<ByteArray> {
+        val orgId = authContext.organizationId() ?: return ResponseEntity.status(401).build()
+        return csv(csvService.exportCustomers(orgId), "customers.csv")
+    }
+
+    @GetMapping("/vendors/export")
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun exportVendors(): ResponseEntity<ByteArray> {
+        val orgId = authContext.organizationId() ?: return ResponseEntity.status(401).build()
+        return csv(csvService.exportVendors(orgId), "vendors.csv")
+    }
+
+    @PostMapping("/products/import")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun importProducts(
+        @RequestParam("file") file: MultipartFile,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(csvService.importProducts(file.bytes, orgId))
+    }
+
+    @PostMapping("/customers/import")
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun importCustomers(
+        @RequestParam("file") file: MultipartFile,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(csvService.importCustomers(file.bytes, orgId))
+    }
+
+    private fun csv(
+        bytes: ByteArray,
+        filename: String,
+    ): ResponseEntity<ByteArray> =
+        ResponseEntity
+            .ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$filename\"")
+            .contentType(MediaType.parseMediaType("text/csv"))
+            .body(bytes)
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/CsvIoDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/CsvIoDtos.kt
@@ -1,0 +1,12 @@
+package com.aquinofroilan.tessera.dto
+
+data class CsvImportRowError(
+    val rowNumber: Int,
+    val error: String,
+)
+
+data class CsvImportResult(
+    val rowsParsed: Int,
+    val rowsCreated: Int,
+    val errors: List<CsvImportRowError>,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/CsvCodec.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/CsvCodec.kt
@@ -1,0 +1,107 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+
+/**
+ * Minimal RFC 4180-ish CSV encoder/decoder. Fields containing comma, quote,
+ * or newline are double-quoted; embedded quotes are doubled. Suitable for
+ * Excel and Google Sheets round-trips for plain catalog data. For exotic
+ * cases (multi-line headers, locale-dependent number formats, etc.) the
+ * caller should pre-stringify values.
+ */
+object CsvCodec {
+    fun encode(
+        headers: List<String>,
+        rows: List<Map<String, Any?>>,
+    ): String {
+        val sb = StringBuilder()
+        sb.append(headers.joinToString(",") { escape(it) })
+        sb.append("\r\n")
+        for (row in rows) {
+            sb.append(headers.joinToString(",") { escape(row[it]?.toString() ?: "") })
+            sb.append("\r\n")
+        }
+        return sb.toString()
+    }
+
+    fun decode(csv: String): List<Map<String, String>> {
+        val all = parseRows(csv)
+        if (all.isEmpty()) return emptyList()
+        val headers = all.first().map { it.trim() }
+        val seen = mutableSetOf<String>()
+        headers.forEach {
+            if (!seen.add(it)) throw BusinessRuleException("Duplicate header in CSV: '$it'")
+        }
+        return all.drop(1).filter { it.any { cell -> cell.isNotEmpty() } }.map { row ->
+            headers.mapIndexed { idx, h -> h to (row.getOrNull(idx) ?: "") }.toMap()
+        }
+    }
+
+    private fun escape(value: String): String {
+        if (value.contains(',') || value.contains('"') || value.contains('\n') || value.contains('\r')) {
+            return "\"" + value.replace("\"", "\"\"") + "\""
+        }
+        return value
+    }
+
+    private fun parseRows(csv: String): List<List<String>> {
+        val rows = mutableListOf<List<String>>()
+        val current = StringBuilder()
+        var row = mutableListOf<String>()
+        var inQuotes = false
+        var i = 0
+        while (i < csv.length) {
+            val c = csv[i]
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < csv.length && csv[i + 1] == '"') {
+                        current.append('"')
+                        i += 2
+                        continue
+                    }
+                    inQuotes = false
+                    i++
+                    continue
+                }
+                current.append(c)
+                i++
+            } else {
+                when (c) {
+                    '"' -> {
+                        inQuotes = true
+                        i++
+                    }
+                    ',' -> {
+                        row.add(current.toString())
+                        current.setLength(0)
+                        i++
+                    }
+                    '\r' -> {
+                        if (i + 1 < csv.length && csv[i + 1] == '\n') i++
+                        row.add(current.toString())
+                        current.setLength(0)
+                        rows.add(row)
+                        row = mutableListOf()
+                        i++
+                    }
+                    '\n' -> {
+                        row.add(current.toString())
+                        current.setLength(0)
+                        rows.add(row)
+                        row = mutableListOf()
+                        i++
+                    }
+                    else -> {
+                        current.append(c)
+                        i++
+                    }
+                }
+            }
+        }
+        if (current.isNotEmpty() || row.isNotEmpty()) {
+            row.add(current.toString())
+            rows.add(row)
+        }
+        return rows
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/CsvImportExportService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/CsvImportExportService.kt
@@ -1,0 +1,155 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateCustomerRequest
+import com.aquinofroilan.tessera.dto.CreateProductRequest
+import com.aquinofroilan.tessera.dto.CsvImportResult
+import com.aquinofroilan.tessera.dto.CsvImportRowError
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+
+/**
+ * CSV export/import for the catalog entities a hobby ERP user is most likely
+ * to bulk-edit (products, customers, vendors). Designed to round-trip with
+ * Excel and Google Sheets: a CSV exported with [exportProducts] re-imports
+ * cleanly with [importProducts] (modulo duplicate-SKU rejection).
+ *
+ * Vendors/customers can also be exported but only customers + products
+ * support import in this slice -- vendor import follows when bank details
+ * land.
+ */
+@Service
+class CsvImportExportService(
+    private val productService: ProductService,
+    private val customerService: CustomerService,
+    private val vendorService: VendorService,
+) {
+    private val productHeaders =
+        listOf("sku", "name", "description", "category", "imageUrl", "listPrice", "priceCurrency", "taxGroupId")
+    private val customerHeaders =
+        listOf("name", "contactName", "contactEmail", "contactPhone", "paymentTermDays", "defaultRevenueAccountId")
+    private val vendorHeaders =
+        listOf("name", "contactName", "contactEmail", "contactPhone", "paymentTermDays")
+
+    fun exportProducts(organizationId: String): ByteArray {
+        val rows =
+            productService
+                .listProducts(organizationId)
+                .map {
+                    mapOf(
+                        "sku" to it.sku,
+                        "name" to it.name,
+                        "description" to (it.description ?: ""),
+                        "category" to (it.category ?: ""),
+                        "imageUrl" to (it.imageUrl ?: ""),
+                        "listPrice" to it.listPrice.toPlainString(),
+                        "priceCurrency" to it.priceCurrency,
+                        "taxGroupId" to (it.taxGroupId ?: ""),
+                    )
+                }
+        return CsvCodec.encode(productHeaders, rows).toByteArray()
+    }
+
+    fun exportCustomers(organizationId: String): ByteArray {
+        val rows =
+            customerService
+                .listCustomers(organizationId)
+                .map {
+                    mapOf(
+                        "name" to it.name,
+                        "contactName" to (it.contactName ?: ""),
+                        "contactEmail" to (it.contactEmail ?: ""),
+                        "contactPhone" to (it.contactPhone ?: ""),
+                        "paymentTermDays" to it.paymentTermDays.toString(),
+                        "defaultRevenueAccountId" to (it.defaultRevenueAccountId ?: ""),
+                    )
+                }
+        return CsvCodec.encode(customerHeaders, rows).toByteArray()
+    }
+
+    fun exportVendors(organizationId: String): ByteArray {
+        val rows =
+            vendorService
+                .listVendors(organizationId)
+                .map {
+                    mapOf(
+                        "name" to it.name,
+                        "contactName" to (it.contactName ?: ""),
+                        "contactEmail" to (it.contactEmail ?: ""),
+                        "contactPhone" to (it.contactPhone ?: ""),
+                        "paymentTermDays" to it.paymentTermDays.toString(),
+                    )
+                }
+        return CsvCodec.encode(vendorHeaders, rows).toByteArray()
+    }
+
+    fun importProducts(
+        bytes: ByteArray,
+        organizationId: String,
+    ): CsvImportResult {
+        val parsed = CsvCodec.decode(String(bytes))
+        val errors = mutableListOf<CsvImportRowError>()
+        var created = 0
+        parsed.forEachIndexed { idx, row ->
+            try {
+                val sku = row["sku"]?.takeIf { it.isNotBlank() } ?: throw IllegalArgumentException("sku is required")
+                val name = row["name"]?.takeIf { it.isNotBlank() } ?: throw IllegalArgumentException("name is required")
+                val listPrice =
+                    (row["listPrice"]?.takeIf { it.isNotBlank() } ?: "0").toBigDecimalOrNull()
+                        ?: throw IllegalArgumentException("listPrice must be a number")
+                productService.createProduct(
+                    CreateProductRequest(
+                        sku = sku,
+                        name = name,
+                        description = row["description"]?.ifBlank { null },
+                        category = row["category"]?.ifBlank { null },
+                        imageUrl = row["imageUrl"]?.ifBlank { null },
+                        listPrice = listPrice,
+                        priceCurrency = row["priceCurrency"]?.ifBlank { null },
+                        taxGroupId = row["taxGroupId"]?.ifBlank { null },
+                    ),
+                    organizationId,
+                )
+                created++
+            } catch (e: Exception) {
+                errors.add(CsvImportRowError(rowNumber = idx + 2, error = e.message ?: e.javaClass.simpleName))
+            }
+        }
+        return CsvImportResult(rowsParsed = parsed.size, rowsCreated = created, errors = errors)
+    }
+
+    fun importCustomers(
+        bytes: ByteArray,
+        organizationId: String,
+    ): CsvImportResult {
+        val parsed = CsvCodec.decode(String(bytes))
+        val errors = mutableListOf<CsvImportRowError>()
+        var created = 0
+        parsed.forEachIndexed { idx, row ->
+            try {
+                val name = row["name"]?.takeIf { it.isNotBlank() } ?: throw IllegalArgumentException("name is required")
+                customerService.createCustomer(
+                    CreateCustomerRequest(
+                        name = name,
+                        contactName = row["contactName"]?.ifBlank { null },
+                        contactEmail = row["contactEmail"]?.ifBlank { null },
+                        contactPhone = row["contactPhone"]?.ifBlank { null },
+                        paymentTermDays = row["paymentTermDays"]?.toIntOrNull() ?: 30,
+                        defaultRevenueAccountId = row["defaultRevenueAccountId"]?.ifBlank { null },
+                    ),
+                    organizationId,
+                )
+                created++
+            } catch (e: Exception) {
+                errors.add(CsvImportRowError(rowNumber = idx + 2, error = e.message ?: e.javaClass.simpleName))
+            }
+        }
+        return CsvImportResult(rowsParsed = parsed.size, rowsCreated = created, errors = errors)
+    }
+
+    private fun String.toBigDecimalOrNull(): BigDecimal? =
+        try {
+            BigDecimal(this)
+        } catch (_: NumberFormatException) {
+            null
+        }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/CsvCodecTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/CsvCodecTest.kt
@@ -1,0 +1,53 @@
+package com.aquinofroilan.tessera.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CsvCodecTest {
+    @Test
+    fun `encode round-trips simple rows`() {
+        val csv =
+            CsvCodec.encode(
+                listOf("sku", "name"),
+                listOf(
+                    mapOf("sku" to "A", "name" to "Widget"),
+                    mapOf("sku" to "B", "name" to "Gadget"),
+                ),
+            )
+        assertThat(csv).contains("sku,name").contains("A,Widget").contains("B,Gadget")
+    }
+
+    @Test
+    fun `encode quotes fields containing commas and quotes`() {
+        val csv =
+            CsvCodec.encode(
+                listOf("name"),
+                listOf(mapOf("name" to "Smith, John \"Jr.\"")),
+            )
+        assertThat(csv).contains("\"Smith, John \"\"Jr.\"\"\"")
+    }
+
+    @Test
+    fun `decode parses headers + rows including quoted commas`() {
+        val csv = "sku,name\r\nA,\"Widget, Deluxe\"\r\nB,Gadget\r\n"
+        val rows = CsvCodec.decode(csv)
+        assertThat(rows).hasSize(2)
+        assertThat(rows[0]["sku"]).isEqualTo("A")
+        assertThat(rows[0]["name"]).isEqualTo("Widget, Deluxe")
+        assertThat(rows[1]["name"]).isEqualTo("Gadget")
+    }
+
+    @Test
+    fun `decode handles escaped quotes inside quoted field`() {
+        val csv = "name\r\n\"He said \"\"hi\"\"\"\r\n"
+        val rows = CsvCodec.decode(csv)
+        assertThat(rows[0]["name"]).isEqualTo("He said \"hi\"")
+    }
+
+    @Test
+    fun `decode skips blank trailing rows`() {
+        val csv = "sku\r\nA\r\n\r\n"
+        val rows = CsvCodec.decode(csv)
+        assertThat(rows).hasSize(1)
+    }
+}


### PR DESCRIPTION
## Summary
Bulk-edit utility for the catalog entities most often touched in spreadsheets. No new schema, no new permissions — reuses the entity perms (`inventory:*` for products, `sales:*` for customers, `procurement:*` for vendors).

- **`CsvCodec`** — small RFC 4180-ish encoder/decoder in pure Kotlin. Fields containing comma / quote / newline are double-quoted; embedded quotes are doubled; both CRLF and LF line endings parse. Designed for round-trip with Excel and Google Sheets on plain catalog data — no exotic locale handling.
- **`CsvImportExportService`**:
  - `exportProducts/Customers/Vendors → ByteArray`
  - `importProducts(bytes, orgId)` and `importCustomers(bytes, orgId)` return `CsvImportResult(rowsParsed, rowsCreated, errors)`. **Partial-success semantics**: bad rows captured with CSV row number + error message; good rows still persist.
  - Vendor import intentionally deferred until bank-details land — export only.
- **`CsvImportExportController`** under `/io/csv`:
  - `GET /io/csv/{products,customers,vendors}/export` → `text/csv` with `Content-Disposition: attachment`
  - `POST /io/csv/{products,customers}/import` (multipart `file`) → `CsvImportResult` JSON

Closes #73.

## Test plan
- [x] `./gradlew test --tests CsvCodecTest` — 5 cases green (header+rows, quoted commas, escaped quotes, CRLF, trailing blanks)
- [x] `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck` — clean
- [ ] CI full suite
- [ ] Manual smoke: export products → edit a row in Excel → re-import a fresh row → confirm errors array reports row numbers for duplicates