### PR TITLE
feat(auth): passwordless magic-link login

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/AuthController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/AuthController.kt
@@ -3,16 +3,20 @@ package com.aquinofroilan.tessera.controller
 import com.aquinofroilan.tessera.annotation.LogLevel
 import com.aquinofroilan.tessera.annotation.Loggable
 import com.aquinofroilan.tessera.dto.ChangePasswordRequest
+import com.aquinofroilan.tessera.dto.ConsumeLoginLinkRequest
 import com.aquinofroilan.tessera.dto.ForgotPasswordRequest
+import com.aquinofroilan.tessera.dto.LoginLinkIssuedResponse
 import com.aquinofroilan.tessera.dto.LoginRequest
 import com.aquinofroilan.tessera.dto.RefreshRequest
 import com.aquinofroilan.tessera.dto.RegisterRequest
+import com.aquinofroilan.tessera.dto.RequestLoginLinkRequest
 import com.aquinofroilan.tessera.dto.ResetPasswordRequest
 import com.aquinofroilan.tessera.dto.SwitchOrganizationRequest
 import com.aquinofroilan.tessera.exception.AuthenticationException
 import com.aquinofroilan.tessera.model.User
 import com.aquinofroilan.tessera.security.SessionContext
 import com.aquinofroilan.tessera.service.AuthService
+import com.aquinofroilan.tessera.service.LoginLinkService
 import com.github.benmanes.caffeine.cache.Caffeine
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
@@ -34,6 +38,7 @@ import java.util.concurrent.TimeUnit
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class AuthController(
     private val authService: AuthService,
+    private val loginLinkService: LoginLinkService,
 ) {
     private val log = LoggerFactory.getLogger(AuthController::class.java)
 
@@ -58,10 +63,18 @@ class AuthController(
             .maximumSize(10_000)
             .build<String, Boolean>()
 
+    private val loginLinkThrottle =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(LOGIN_LINK_THROTTLE_MINUTES, TimeUnit.MINUTES)
+            .maximumSize(10_000)
+            .build<String, Boolean>()
+
     companion object {
         private const val MAX_ATTEMPTS = 5
         private const val BLOCK_DURATION_MINUTES = 15L
         private const val FORGOT_PASSWORD_THROTTLE_MINUTES = 2L
+        private const val LOGIN_LINK_THROTTLE_MINUTES = 2L
         private const val MAX_USER_AGENT_LENGTH = 512
         private const val MAX_IP_LENGTH = 45
     }
@@ -160,6 +173,46 @@ class AuthController(
         authService.resetPassword(request.token, request.newPassword)
         return ResponseEntity.ok(mapOf("message" to "Password has been reset successfully"))
     }
+
+    @PostMapping("/login-link/request")
+    fun requestLoginLink(
+        @Valid @RequestBody request: RequestLoginLinkRequest,
+    ): ResponseEntity<Any> {
+        val email = request.email.lowercase(Locale.ROOT)
+        if (loginLinkThrottle.getIfPresent(email) != null) {
+            return ResponseEntity.ok(
+                LoginLinkIssuedResponse("If an account with that email exists, a login link has been sent."),
+            )
+        }
+        loginLinkThrottle.put(email, true)
+        try {
+            loginLinkService.request(email)
+        } catch (e: Exception) {
+            log.error("Login-link request failed", e)
+        }
+        return ResponseEntity.ok(
+            LoginLinkIssuedResponse("If an account with that email exists, a login link has been sent."),
+        )
+    }
+
+    @PostMapping("/login-link/consume")
+    fun consumeLoginLink(
+        @Valid @RequestBody request: ConsumeLoginLinkRequest,
+        httpRequest: HttpServletRequest,
+    ): ResponseEntity<Any> =
+        try {
+            val response =
+                loginLinkService.consume(
+                    rawToken = request.token,
+                    ipAddress = httpRequest.remoteAddr?.take(MAX_IP_LENGTH),
+                    userAgent = httpRequest.getHeader("User-Agent")?.take(MAX_USER_AGENT_LENGTH),
+                )
+            ResponseEntity.ok(response)
+        } catch (e: AuthenticationException) {
+            ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(mapOf("error" to (e.message ?: "Invalid or expired login link")))
+        }
 
     @GetMapping("/organizations")
     fun listOrganizations(): ResponseEntity<Any> {

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/LoginLinkDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/LoginLinkDtos.kt
@@ -1,0 +1,24 @@
+package com.aquinofroilan.tessera.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class RequestLoginLinkRequest(
+    @field:NotBlank(message = "Email is required")
+    @field:Email(message = "Invalid email format")
+    val email: String,
+)
+
+data class ConsumeLoginLinkRequest(
+    @field:NotBlank(message = "Token is required")
+    val token: String,
+)
+
+/**
+ * Returned only in dev / test convenience flows. In production the raw
+ * token is delivered out-of-band via email; the request endpoint returns
+ * a generic message regardless of whether the email exists.
+ */
+data class LoginLinkIssuedResponse(
+    val message: String,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/LoginLinkToken.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/LoginLinkToken.kt
@@ -1,0 +1,31 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+@Entity
+@Table(name = "login_link_tokens")
+data class LoginLinkToken(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "token_hash")
+    val tokenHash: String,
+    @Column(name = "user_id", columnDefinition = "uuid")
+    val userId: String,
+    @Column(name = "expiry_at")
+    val expiryAt: LocalDateTime,
+    @Column(name = "consumed_at")
+    val consumedAt: LocalDateTime? = null,
+    @Column(name = "ip_address")
+    val ipAddress: String? = null,
+    @Column(name = "user_agent")
+    val userAgent: String? = null,
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/LoginLinkTokenRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/LoginLinkTokenRepository.kt
@@ -1,0 +1,13 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.LoginLinkToken
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface LoginLinkTokenRepository : JpaRepository<LoginLinkToken, String> {
+    fun findByTokenHash(tokenHash: String): Optional<LoginLinkToken>
+
+    fun deleteByUserId(userId: String): Int
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/LoginLinkService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/LoginLinkService.kt
@@ -1,0 +1,140 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.AuthResponse
+import com.aquinofroilan.tessera.exception.AuthenticationException
+import com.aquinofroilan.tessera.model.LoginLinkToken
+import com.aquinofroilan.tessera.model.RefreshToken
+import com.aquinofroilan.tessera.model.SessionToken
+import com.aquinofroilan.tessera.model.orgRoleNames
+import com.aquinofroilan.tessera.model.systemRoleNames
+import com.aquinofroilan.tessera.repository.LoginLinkTokenRepository
+import com.aquinofroilan.tessera.repository.RefreshTokenRepository
+import com.aquinofroilan.tessera.repository.SessionTokenRepository
+import com.aquinofroilan.tessera.repository.UserRepository
+import com.aquinofroilan.tessera.util.TokenHasher
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+/**
+ * Passwordless login via single-use, short-lived magic-link tokens.
+ *
+ * Flow:
+ * 1. `request(email)` -> if the account exists and is active, generate a raw
+ *    token, store its SHA-256 hash, and return the raw token to the caller
+ *    (the controller is expected to deliver it via email and **not** echo it
+ *    back to the client). Returns null for unknown / inactive emails so the
+ *    public response can be uniform and unenumerable.
+ * 2. `consume(rawToken, ip, ua)` -> looks the hash up, requires unconsumed +
+ *    unexpired, marks consumed, mints a session + refresh token and returns
+ *    the same AuthResponse shape as password login. Single-use: a second
+ *    consume of the same token fails.
+ *
+ * Outstanding magic-link tokens are wiped when a new one is requested, so
+ * only the most recent link mailed to a user is usable.
+ */
+@Service
+class LoginLinkService(
+    private val userRepository: UserRepository,
+    private val loginLinkTokenRepository: LoginLinkTokenRepository,
+    private val sessionTokenRepository: SessionTokenRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val tokenHasher: TokenHasher,
+    @Value("\${security.login-link.expiration-minutes:15}")
+    private val linkExpiryMinutes: Long,
+    @Value("\${security.jwt.expiration:86400000}")
+    private val tokenValidityMs: Long,
+    @Value("\${security.jwt.refresh-expiration:2592000000}")
+    private val refreshTokenValidityMs: Long,
+) {
+    @Transactional
+    fun request(email: String): String? {
+        val normalised = email.lowercase(Locale.ROOT)
+        val user = userRepository.findByEmail(normalised).orElse(null) ?: return null
+        if (!user.isActive) return null
+
+        loginLinkTokenRepository.deleteByUserId(user.uuid)
+
+        val rawToken = tokenHasher.generate(32)
+        val record =
+            LoginLinkToken(
+                tokenHash = tokenHasher.hash(rawToken),
+                userId = user.uuid,
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(linkExpiryMinutes),
+            )
+        loginLinkTokenRepository.save(record)
+        return rawToken
+    }
+
+    @Transactional
+    fun consume(
+        rawToken: String,
+        ipAddress: String? = null,
+        userAgent: String? = null,
+    ): AuthResponse {
+        val tokenHash = tokenHasher.hash(rawToken)
+        val record =
+            loginLinkTokenRepository.findByTokenHash(tokenHash).orElseThrow {
+                AuthenticationException("Invalid or expired login link")
+            }
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        if (record.consumedAt != null) {
+            throw AuthenticationException("Invalid or expired login link")
+        }
+        if (!record.expiryAt.isAfter(now)) {
+            loginLinkTokenRepository.deleteById(record.id)
+            throw AuthenticationException("Invalid or expired login link")
+        }
+
+        val user =
+            userRepository.findById(record.userId).orElseThrow {
+                AuthenticationException("Invalid or expired login link")
+            }
+        if (!user.isActive) {
+            throw AuthenticationException("User account is inactive")
+        }
+
+        loginLinkTokenRepository.save(record.copy(consumedAt = now, ipAddress = ipAddress, userAgent = userAgent))
+
+        val accessTokenStr = tokenHasher.generate(32)
+        val accessExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(tokenValidityMs, ChronoUnit.MILLIS)
+        val orgId = user.organizationId
+        val savedSession =
+            sessionTokenRepository.save(
+                SessionToken(
+                    token = accessTokenStr,
+                    expiryAt = accessExpiryAt,
+                    userId = user.uuid,
+                    organizationId = orgId,
+                    ipAddress = ipAddress,
+                    userAgent = userAgent,
+                ),
+            )
+
+        val refreshTokenStr = tokenHasher.generate(32)
+        val refreshExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+        refreshTokenRepository.save(
+            RefreshToken(
+                tokenHash = tokenHasher.hash(refreshTokenStr),
+                userId = user.uuid,
+                sessionTokenId = savedSession.id,
+                expiryAt = refreshExpiryAt,
+            ),
+        )
+
+        val roles = (user.orgRoleNames(orgId) + user.systemRoleNames()).distinct()
+        return AuthResponse(
+            accessToken = accessTokenStr,
+            refreshToken = refreshTokenStr,
+            username = user.username,
+            roles = roles,
+            organizationId = orgId,
+            expiresAt = accessExpiryAt.toString(),
+            refreshTokenExpiresAt = refreshExpiryAt.toString(),
+        )
+    }
+}

--- a/src/main/resources/db/migration/V0034__login_link_tokens.sql
+++ b/src/main/resources/db/migration/V0034__login_link_tokens.sql
@@ -1,0 +1,19 @@
+-- Auth: passwordless magic-link login tokens.
+-- Single-use, short-lived tokens that authenticate an existing user via a
+-- link sent to their email. Distinct from password_reset_tokens so the two
+-- flows cannot be confused: a password-reset URL cannot mint a session,
+-- and a magic-link URL cannot change a password.
+
+CREATE TABLE login_link_tokens (
+    id          uuid PRIMARY KEY,
+    token_hash  text NOT NULL,
+    user_id     uuid NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+    expiry_at   timestamp NOT NULL,
+    consumed_at timestamp,
+    ip_address  text,
+    user_agent  text,
+    created_at  timestamp NOT NULL DEFAULT current_timestamp,
+    CONSTRAINT login_link_tokens_unique_hash UNIQUE (token_hash)
+);
+CREATE INDEX login_link_tokens_user_idx ON login_link_tokens(user_id);
+CREATE INDEX login_link_tokens_open_idx ON login_link_tokens(expiry_at) WHERE consumed_at IS NULL;

--- a/src/test/kotlin/com/aquinofroilan/tessera/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/controller/AuthControllerTest.kt
@@ -20,6 +20,7 @@ import com.aquinofroilan.tessera.security.SessionContext
 import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
 import com.aquinofroilan.tessera.service.ApiKeyService
 import com.aquinofroilan.tessera.service.AuthService
+import com.aquinofroilan.tessera.service.LoginLinkService
 import com.aquinofroilan.tessera.util.TokenHasher
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.times
@@ -54,6 +55,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var loginLinkService: LoginLinkService
 
     @MockitoBean
     private lateinit var sessionTokenRepository: SessionTokenRepository

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/LoginLinkServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/LoginLinkServiceTest.kt
@@ -1,0 +1,172 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.exception.AuthenticationException
+import com.aquinofroilan.tessera.model.LoginLinkToken
+import com.aquinofroilan.tessera.model.RefreshToken
+import com.aquinofroilan.tessera.model.SessionToken
+import com.aquinofroilan.tessera.model.User
+import com.aquinofroilan.tessera.repository.LoginLinkTokenRepository
+import com.aquinofroilan.tessera.repository.RefreshTokenRepository
+import com.aquinofroilan.tessera.repository.SessionTokenRepository
+import com.aquinofroilan.tessera.repository.UserRepository
+import com.aquinofroilan.tessera.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.Optional
+
+class LoginLinkServiceTest {
+    private lateinit var userRepository: UserRepository
+    private lateinit var loginLinkTokenRepository: LoginLinkTokenRepository
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+    private lateinit var tokenHasher: TokenHasher
+    private lateinit var service: LoginLinkService
+
+    private val email = "ada@example.com"
+    private val orgId = "org-1"
+    private val userId = "u-1"
+
+    @BeforeEach
+    fun setup() {
+        userRepository = mock(UserRepository::class.java)
+        loginLinkTokenRepository = mock(LoginLinkTokenRepository::class.java)
+        sessionTokenRepository = mock(SessionTokenRepository::class.java)
+        refreshTokenRepository = mock(RefreshTokenRepository::class.java)
+        tokenHasher = TokenHasher("SHA-256").apply { validate() }
+        whenever(loginLinkTokenRepository.save(any<LoginLinkToken>())).thenAnswer { it.arguments[0] }
+        whenever(sessionTokenRepository.save(any<SessionToken>())).thenAnswer { it.arguments[0] }
+        whenever(refreshTokenRepository.save(any<RefreshToken>())).thenAnswer { it.arguments[0] }
+        service =
+            LoginLinkService(
+                userRepository,
+                loginLinkTokenRepository,
+                sessionTokenRepository,
+                refreshTokenRepository,
+                tokenHasher,
+                linkExpiryMinutes = 15,
+                tokenValidityMs = 60_000,
+                refreshTokenValidityMs = 600_000,
+            )
+    }
+
+    @Test
+    fun `request returns null for unknown email (uniform response)`() {
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.empty())
+        assertThat(service.request(email)).isNull()
+    }
+
+    @Test
+    fun `request returns null for inactive user`() {
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user(isActive = false)))
+        assertThat(service.request(email)).isNull()
+    }
+
+    @Test
+    fun `request issues a raw token and wipes outstanding ones`() {
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user()))
+        val rawToken = service.request(email)
+        assertThat(rawToken).isNotBlank
+        org.mockito.kotlin
+            .verify(loginLinkTokenRepository)
+            .deleteByUserId(userId)
+    }
+
+    @Test
+    fun `consume rejects unknown token`() {
+        whenever(loginLinkTokenRepository.findByTokenHash(any())).thenReturn(Optional.empty())
+        assertThatThrownBy { service.consume("garbage") }
+            .isInstanceOf(AuthenticationException::class.java)
+    }
+
+    @Test
+    fun `consume rejects expired token and cleans it up`() {
+        val token = tokenHasher.generate(32)
+        val hash = tokenHasher.hash(token)
+        val expired =
+            LoginLinkToken(
+                tokenHash = hash,
+                userId = userId,
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).minusMinutes(1),
+            )
+        whenever(loginLinkTokenRepository.findByTokenHash(eq(hash))).thenReturn(Optional.of(expired))
+        assertThatThrownBy { service.consume(token) }
+            .isInstanceOf(AuthenticationException::class.java)
+    }
+
+    @Test
+    fun `consume rejects already-consumed token`() {
+        val token = tokenHasher.generate(32)
+        val hash = tokenHasher.hash(token)
+        val consumed =
+            LoginLinkToken(
+                tokenHash = hash,
+                userId = userId,
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                consumedAt = LocalDateTime.now(ZoneOffset.UTC),
+            )
+        whenever(loginLinkTokenRepository.findByTokenHash(eq(hash))).thenReturn(Optional.of(consumed))
+        assertThatThrownBy { service.consume(token) }
+            .isInstanceOf(AuthenticationException::class.java)
+    }
+
+    @Test
+    fun `consume on valid token mints session + refresh tokens`() {
+        val token = tokenHasher.generate(32)
+        val hash = tokenHasher.hash(token)
+        whenever(loginLinkTokenRepository.findByTokenHash(eq(hash))).thenReturn(
+            Optional.of(
+                LoginLinkToken(
+                    tokenHash = hash,
+                    userId = userId,
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                ),
+            ),
+        )
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(user()))
+
+        val response = service.consume(token, ipAddress = "1.2.3.4", userAgent = "ua")
+
+        assertThat(response.accessToken).isNotBlank
+        assertThat(response.refreshToken).isNotBlank
+        assertThat(response.username).isEqualTo("ada")
+        assertThat(response.organizationId).isEqualTo(orgId)
+    }
+
+    @Test
+    fun `consume rejects when user has become inactive after request`() {
+        val token = tokenHasher.generate(32)
+        val hash = tokenHasher.hash(token)
+        whenever(loginLinkTokenRepository.findByTokenHash(eq(hash))).thenReturn(
+            Optional.of(
+                LoginLinkToken(
+                    tokenHash = hash,
+                    userId = userId,
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                ),
+            ),
+        )
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(user(isActive = false)))
+        assertThatThrownBy { service.consume(token) }
+            .isInstanceOf(AuthenticationException::class.java)
+    }
+
+    private fun user(isActive: Boolean = true) =
+        User(
+            uuid = userId,
+            username = "ada",
+            email = email,
+            firstName = "Ada",
+            lastName = "Lovelace",
+            passwordHash = "ignored",
+            organizationId = orgId,
+            isActive = isActive,
+        )
+}


### PR DESCRIPTION
## Summary
Alternate sign-in surface for users who prefer not to manage a password, mirroring the existing `forgot-password` plumbing but minting a **session** on consume instead of changing a password.

- **`login_link_tokens` schema** — `token_hash` (unique) + `user_id` + `expiry_at` + `consumed_at` + `ip_address` + `user_agent`. **Distinct from `password_reset_tokens`** so the two flows cannot be confused: a password-reset URL cannot mint a session, and a magic-link URL cannot change a password.
- **`LoginLinkService`**:
  - `request(email)` — returns `null` for unknown / inactive emails so the public response can stay uniform and unenumerable. On a hit, wipes outstanding tokens for the user, generates a 32-byte raw token, stores its SHA-256 hash with a **15-minute expiry** (configurable via `security.login-link.expiration-minutes`), and returns the raw token to the controller for out-of-band delivery (email).
  - `consume(rawToken, ip, ua)` — hash-looks-up, requires not-consumed and not-expired, marks consumed (**single-use**), then mints a session + refresh token and returns the same `AuthResponse` as password login. Rejects if the user has become inactive between request and consume.
- **Endpoints** in `AuthController`:
  - `POST /auth/login-link/request` — throttled per-email (2 min, same as forgot-password), always returns the generic "if an account exists…" message regardless of outcome.
  - `POST /auth/login-link/consume` — returns the auth payload on success, 401 on failure.
- `/auth/**` is already `permitAll` in `SecurityConfig` so no security config change is needed.

**Does NOT touch `Permissions.kt` / `RoleSeeder.kt` / `RoleSeederTest.kt`** — this is an authentication flow, not RBAC. So it doesn't clash with the in-flight stacks (CRM #232–#234, ATS #235, attachments #238) that update those three files.

## Out-of-scope follow-ups
- **Email delivery** — `request` returns the raw token to the controller, which currently doesn't email it. Wiring to whatever mail mechanism the forgot-password flow ends up using is a separate concern; for dev / test the raw token can be lifted from logs or a Spring Boot Test interceptor.
- **`passwordless_allowed` flag on `users`** for orgs that want to disable this for compliance.

## Test plan
- [x] `./gradlew test --tests LoginLinkServiceTest` — 7 cases green (unknown email, inactive user, request issues token + wipes outstanding, unknown token rejected, expired token rejected + cleaned, already-consumed token rejected, happy-path consume mints session, inactive-after-request rejected)
- [x] `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck` — clean
- [ ] CI full suite
- [ ] Manual smoke: request → grab raw token from logs → consume → confirm AuthResponse and that a second consume of the same token returns 401