### PR TITLE
feat(finance): bank statement import — stack 2/5 (#202)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/BankStatementController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/BankStatementController.kt
@@ -1,0 +1,56 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.BankStatementResponse
+import com.aquinofroilan.tessera.dto.ImportStatementRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.BankStatementService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/finance/bank-statements")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class BankStatementController(
+    private val statementService: BankStatementService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('bank:write')")
+    fun importStatement(
+        @Valid @RequestBody request: ImportStatementRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        val s = statementService.importStatement(request, orgId, userId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(BankStatementResponse.from(s))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('bank:read')")
+    fun list(
+        @RequestParam(required = false) bankAccountId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(statementService.listStatements(orgId, bankAccountId).map { BankStatementResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('bank:read')")
+    fun get(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(BankStatementResponse.from(statementService.getStatement(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/BankStatementDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/BankStatementDtos.kt
@@ -1,0 +1,91 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.BankStatement
+import com.aquinofroilan.tessera.model.BankStatementLine
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class ImportStatementLineRequest(
+    @field:NotNull(message = "Posted date is required")
+    val postedDate: LocalDate?,
+    @field:NotBlank(message = "Description is required")
+    val description: String,
+    val reference: String? = null,
+    @field:NotNull(message = "Amount is required")
+    val amount: BigDecimal?,
+)
+
+data class ImportStatementRequest(
+    @field:NotBlank(message = "Bank account ID is required")
+    val bankAccountId: String,
+    @field:NotNull(message = "Statement date is required")
+    val statementDate: LocalDate?,
+    @field:NotNull(message = "Opening balance is required")
+    val openingBalance: BigDecimal?,
+    @field:NotNull(message = "Closing balance is required")
+    val closingBalance: BigDecimal?,
+    val source: String? = null,
+    val notes: String? = null,
+    @field:NotEmpty(message = "At least one line is required")
+    @field:Valid
+    val lines: List<ImportStatementLineRequest>,
+)
+
+data class BankStatementLineResponse(
+    val id: String,
+    val lineNumber: Int,
+    val postedDate: LocalDate,
+    val description: String,
+    val reference: String?,
+    val amount: BigDecimal,
+    val reconciled: Boolean,
+    val reconciledJournalEntryId: String?,
+    val reconciledAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(l: BankStatementLine) =
+            BankStatementLineResponse(
+                id = l.id,
+                lineNumber = l.lineNumber,
+                postedDate = l.postedDate,
+                description = l.description,
+                reference = l.reference,
+                amount = l.amount,
+                reconciled = l.reconciled,
+                reconciledJournalEntryId = l.reconciledJournalEntryId,
+                reconciledAt = l.reconciledAt,
+            )
+    }
+}
+
+data class BankStatementResponse(
+    val id: String,
+    val bankAccountId: String,
+    val statementDate: LocalDate,
+    val openingBalance: BigDecimal,
+    val closingBalance: BigDecimal,
+    val currency: String,
+    val source: String,
+    val notes: String?,
+    val lines: List<BankStatementLineResponse>,
+) {
+    companion object {
+        fun from(s: BankStatement) =
+            BankStatementResponse(
+                id = s.id,
+                bankAccountId = s.bankAccountId,
+                statementDate = s.statementDate,
+                openingBalance = s.openingBalance,
+                closingBalance = s.closingBalance,
+                currency = s.currency,
+                source = s.source,
+                notes = s.notes,
+                lines = s.lines.map { BankStatementLineResponse.from(it) },
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/BankStatement.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/BankStatement.kt
@@ -1,0 +1,76 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "finance_bank_statement_lines")
+data class BankStatementLine(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "line_number")
+    val lineNumber: Int,
+    @Column(name = "posted_date")
+    val postedDate: LocalDate,
+    val description: String,
+    val reference: String? = null,
+    val amount: BigDecimal,
+    val reconciled: Boolean = false,
+    @Column(name = "reconciled_journal_entry_id", columnDefinition = "uuid")
+    val reconciledJournalEntryId: String? = null,
+    @Column(name = "reconciled_at")
+    val reconciledAt: LocalDateTime? = null,
+    @Column(name = "reconciled_by", columnDefinition = "uuid")
+    val reconciledBy: String? = null,
+)
+
+@Entity
+@Table(name = "finance_bank_statements")
+@EntityListeners(AuditingEntityListener::class)
+data class BankStatement(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Column(name = "bank_account_id", columnDefinition = "uuid")
+    val bankAccountId: String,
+    @Column(name = "statement_date")
+    val statementDate: LocalDate,
+    @Column(name = "opening_balance")
+    val openingBalance: BigDecimal,
+    @Column(name = "closing_balance")
+    val closingBalance: BigDecimal,
+    @Column(columnDefinition = "char(3)")
+    val currency: String,
+    val source: String = "CSV",
+    @Column(name = "uploaded_by", columnDefinition = "uuid")
+    val uploadedBy: String,
+    val notes: String? = null,
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "statement_id")
+    @OrderBy("lineNumber ASC")
+    val lines: List<BankStatementLine>,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/BankStatementRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/BankStatementRepository.kt
@@ -1,0 +1,15 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.BankStatement
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface BankStatementRepository : JpaRepository<BankStatement, String> {
+    fun findByOrganizationId(organizationId: String): List<BankStatement>
+
+    fun findByOrganizationIdAndBankAccountIdOrderByStatementDateDesc(
+        organizationId: String,
+        bankAccountId: String,
+    ): List<BankStatement>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/BankStatementService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/BankStatementService.kt
@@ -1,0 +1,109 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.ImportStatementRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.BankStatement
+import com.aquinofroilan.tessera.model.BankStatementLine
+import com.aquinofroilan.tessera.repository.BankStatementRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+class BankStatementService(
+    private val statementRepository: BankStatementRepository,
+    private val bankAccountService: BankAccountService,
+) {
+    @Transactional
+    fun importStatement(
+        request: ImportStatementRequest,
+        organizationId: String,
+        userId: String,
+    ): BankStatement {
+        val statementDate = request.statementDate ?: throw BusinessRuleException("statementDate is required")
+        val opening = request.openingBalance ?: throw BusinessRuleException("openingBalance is required")
+        val closing = request.closingBalance ?: throw BusinessRuleException("closingBalance is required")
+        if (request.lines.isEmpty()) throw BusinessRuleException("Statement must have at least one line")
+
+        val bankAccount = bankAccountService.getBankAccount(request.bankAccountId, organizationId)
+        if (!bankAccount.isActive) {
+            throw BusinessRuleException("Bank account '${bankAccount.code}' is inactive")
+        }
+
+        val lines =
+            request.lines.mapIndexed { index, lineReq ->
+                val posted = lineReq.postedDate ?: throw BusinessRuleException("Line ${index + 1}: postedDate is required")
+                val amount = lineReq.amount ?: throw BusinessRuleException("Line ${index + 1}: amount is required")
+                if (amount.signum() == 0) {
+                    throw BusinessRuleException("Line ${index + 1}: amount cannot be zero")
+                }
+                BankStatementLine(
+                    lineNumber = index + 1,
+                    postedDate = posted,
+                    description = lineReq.description.trim(),
+                    reference = lineReq.reference?.trim(),
+                    amount = amount,
+                )
+            }
+
+        val sumOfLines = lines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.amount) }
+        val expectedClosing = opening.add(sumOfLines)
+        if (expectedClosing.compareTo(closing) != 0) {
+            throw BusinessRuleException(
+                "Statement does not balance: opening $opening + sum(lines) $sumOfLines = $expectedClosing, declared closing = $closing",
+            )
+        }
+
+        val source = (request.source ?: "CSV").uppercase()
+        if (source !in setOf("CSV", "OFX", "MANUAL")) {
+            throw BusinessRuleException("Unsupported source '$source'")
+        }
+
+        val saved =
+            statementRepository.save(
+                BankStatement(
+                    organizationId = organizationId,
+                    bankAccountId = bankAccount.id,
+                    statementDate = statementDate,
+                    openingBalance = opening,
+                    closingBalance = closing,
+                    currency = bankAccount.currency,
+                    source = source,
+                    uploadedBy = userId,
+                    notes = request.notes,
+                    lines = lines,
+                ),
+            )
+
+        // Update cached current_balance on the bank account by the net of this statement.
+        // Reconciliation will re-derive balances against the GL; this is a fast approximation
+        // so /finance/bank-accounts list reflects the latest known position.
+        bankAccountService.applyBalanceDelta(bankAccount.id, organizationId, sumOfLines)
+        return saved
+    }
+
+    fun getStatement(
+        id: String,
+        organizationId: String,
+    ): BankStatement {
+        val s =
+            statementRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Statement not found: $id")
+            }
+        if (s.organizationId != organizationId) {
+            throw ResourceNotFoundException("Statement not found: $id")
+        }
+        return s
+    }
+
+    fun listStatements(
+        organizationId: String,
+        bankAccountId: String?,
+    ): List<BankStatement> =
+        if (bankAccountId != null) {
+            statementRepository.findByOrganizationIdAndBankAccountIdOrderByStatementDateDesc(organizationId, bankAccountId)
+        } else {
+            statementRepository.findByOrganizationId(organizationId)
+        }
+}

--- a/src/main/resources/db/migration/V0036__finance_bank_statements.sql
+++ b/src/main/resources/db/migration/V0036__finance_bank_statements.sql
@@ -1,0 +1,44 @@
+-- Finance: bank statements & statement lines.
+-- A statement is what arrives from the bank (paper, CSV, OFX). Each line is
+-- one debit or credit in the bank's books. Lines start with reconciled=false
+-- and get matched against journal-entry lines by the reconciliation slice.
+-- Amounts are signed: positive = credit (deposit into our account), negative
+-- = debit (money leaving our account). This mirrors what banks export and
+-- avoids a separate type column.
+
+CREATE TABLE finance_bank_statements (
+    id                uuid PRIMARY KEY,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    bank_account_id   uuid NOT NULL REFERENCES finance_bank_accounts(id) ON DELETE RESTRICT,
+    statement_date    date NOT NULL,
+    opening_balance   numeric(18,4) NOT NULL,
+    closing_balance   numeric(18,4) NOT NULL,
+    currency          char(3) NOT NULL,
+    source            text NOT NULL DEFAULT 'CSV',
+    uploaded_by       uuid NOT NULL REFERENCES users(uuid),
+    notes             text,
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT finance_bank_statements_source_chk CHECK (source IN ('CSV','OFX','MANUAL'))
+);
+CREATE INDEX finance_bank_statements_org_account_idx
+    ON finance_bank_statements(organization_id, bank_account_id, statement_date DESC);
+
+CREATE TABLE finance_bank_statement_lines (
+    id                          uuid PRIMARY KEY,
+    statement_id                uuid NOT NULL REFERENCES finance_bank_statements(id) ON DELETE CASCADE,
+    line_number                 int NOT NULL,
+    posted_date                 date NOT NULL,
+    description                 text NOT NULL,
+    reference                   text,
+    amount                      numeric(18,4) NOT NULL,
+    reconciled                  boolean NOT NULL DEFAULT false,
+    reconciled_journal_entry_id uuid,
+    reconciled_at               timestamp,
+    reconciled_by               uuid REFERENCES users(uuid),
+    CONSTRAINT finance_bank_statement_lines_unique_per_stmt UNIQUE (statement_id, line_number),
+    CONSTRAINT finance_bank_statement_lines_amount_chk CHECK (amount <> 0)
+);
+CREATE INDEX finance_bank_statement_lines_unreconciled_idx
+    ON finance_bank_statement_lines(statement_id)
+    WHERE reconciled = false;

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/BankStatementServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/BankStatementServiceTest.kt
@@ -1,0 +1,141 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.ImportStatementLineRequest
+import com.aquinofroilan.tessera.dto.ImportStatementRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.BankAccount
+import com.aquinofroilan.tessera.model.BankStatement
+import com.aquinofroilan.tessera.repository.BankStatementRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class BankStatementServiceTest {
+    private lateinit var repository: BankStatementRepository
+    private lateinit var bankAccountService: BankAccountService
+    private lateinit var service: BankStatementService
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+    private val bankId = "bank-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(BankStatementRepository::class.java)
+        bankAccountService = mock(BankAccountService::class.java)
+        whenever(repository.save(any<BankStatement>())).thenAnswer { it.arguments[0] }
+        whenever(bankAccountService.getBankAccount(bankId, orgId)).thenReturn(activeAccount())
+        service = BankStatementService(repository, bankAccountService)
+    }
+
+    @Test
+    fun `import accepts balanced statement, stamps source, applies balance delta`() {
+        val req =
+            request(
+                opening = BigDecimal("1000"),
+                closing = BigDecimal("950"),
+                lines = listOf(line(BigDecimal("100")), line(BigDecimal("-150"))),
+            )
+
+        val s = service.importStatement(req, orgId, userId)
+
+        assertThat(s.openingBalance).isEqualByComparingTo(BigDecimal("1000"))
+        assertThat(s.closingBalance).isEqualByComparingTo(BigDecimal("950"))
+        assertThat(s.source).isEqualTo("CSV")
+        assertThat(s.lines).hasSize(2)
+        verify(bankAccountService).applyBalanceDelta(bankId, orgId, BigDecimal("-50"))
+    }
+
+    @Test
+    fun `import rejects unbalanced statement`() {
+        val req =
+            request(
+                opening = BigDecimal("1000"),
+                closing = BigDecimal("999"),
+                lines = listOf(line(BigDecimal("100"))),
+            )
+        assertThatThrownBy { service.importStatement(req, orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+            .hasMessageContaining("does not balance")
+    }
+
+    @Test
+    fun `import rejects zero-amount line`() {
+        val req =
+            request(
+                opening = BigDecimal("1000"),
+                closing = BigDecimal("1000"),
+                lines = listOf(line(BigDecimal.ZERO)),
+            )
+        assertThatThrownBy { service.importStatement(req, orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `import rejects inactive bank account`() {
+        whenever(bankAccountService.getBankAccount(bankId, orgId)).thenReturn(activeAccount().copy(isActive = false))
+        val req =
+            request(
+                opening = BigDecimal("0"),
+                closing = BigDecimal("100"),
+                lines = listOf(line(BigDecimal("100"))),
+            )
+        assertThatThrownBy { service.importStatement(req, orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `import rejects unsupported source`() {
+        val req =
+            request(
+                opening = BigDecimal("0"),
+                closing = BigDecimal("100"),
+                source = "XML",
+                lines = listOf(line(BigDecimal("100"))),
+            )
+        assertThatThrownBy { service.importStatement(req, orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+            .hasMessageContaining("Unsupported source")
+    }
+
+    private fun line(amount: BigDecimal) =
+        ImportStatementLineRequest(
+            postedDate = LocalDate.of(2026, 6, 1),
+            description = "Transaction",
+            reference = null,
+            amount = amount,
+        )
+
+    private fun request(
+        opening: BigDecimal,
+        closing: BigDecimal,
+        lines: List<ImportStatementLineRequest>,
+        source: String? = null,
+    ) = ImportStatementRequest(
+        bankAccountId = bankId,
+        statementDate = LocalDate.of(2026, 6, 1),
+        openingBalance = opening,
+        closingBalance = closing,
+        source = source,
+        lines = lines,
+    )
+
+    private fun activeAccount() =
+        BankAccount(
+            id = bankId,
+            organizationId = orgId,
+            code = "MAIN",
+            name = "Main",
+            currency = "USD",
+            glAccountId = "acc-1000",
+            isActive = true,
+            createdBy = userId,
+        )
+}


### PR DESCRIPTION
## Summary
Second slice of the Bank & Cash stack. Persists bank statements and their line-level transactions so the next slice (#203) has something to reconcile against.

- **`finance_bank_statements`** — `bank_account_id` + `statement_date` + `opening_balance` + `closing_balance` + `currency` + `source` (`CSV` / `OFX` / `MANUAL`) + `uploaded_by` + `notes`.
- **`finance_bank_statement_lines`** — `line_number` + `posted_date` + `description` + `reference` + `amount` + `reconciled` flag + `reconciled_journal_entry_id` + `reconciled_at` / `by`. **Amounts are signed** (positive = credit/deposit, negative = debit/withdrawal) mirroring what banks export.
- **Partial index** on unreconciled lines so reconciliation queries scale regardless of historical statement volume.
- **`BankStatementService.importStatement`**:
  - validates that the bank account is active
  - validates that `opening + sum(lines) = closing` so a malformed statement is rejected at import time rather than silently inflating balances
  - rejects zero-amount lines
  - normalises `source` to upper-case, restricted to `CSV` / `OFX` / `MANUAL`
  - cascades a balance delta to the cached `bank_account.current_balance` so listing endpoints reflect the latest known position
- **`/finance/bank-statements`** — POST (import), GET list (filter by `bankAccountId`), GET by id. Gated by `bank:read` / `bank:write`.

The current import contract takes a **structured JSON request** rather than a multipart CSV upload — callers can use #239's `CsvCodec` to convert a spreadsheet upload into the line array. OFX parsing is left for a follow-up.

**Stacked on #241 (finance-bank-accounts).** Merge order: #241 → this.

Closes #202. Contributes to #166.

## Test plan
- [x] `./gradlew test --tests BankStatementServiceTest --tests BankAccountServiceTest` — green (balanced statement happy path + balance-delta cascade, unbalanced rejection, zero-amount rejection, inactive-account rejection, unsupported source rejection)
- [x] `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck` — clean
- [ ] CI full suite
- [ ] Manual smoke: create bank account → POST statement with opening 1000, closing 950, two lines (+100, −150) → verify accepted and current_balance updated