### PR TITLE
feat(finance): bank reconciliation — stack 3/5 (#203)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/BankReconciliationController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/BankReconciliationController.kt
@@ -1,0 +1,75 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.AutoMatchRequest
+import com.aquinofroilan.tessera.dto.BankStatementResponse
+import com.aquinofroilan.tessera.dto.ManualMatchRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.BankReconciliationService
+import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/finance/reconciliation")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class BankReconciliationController(
+    private val reconciliationService: BankReconciliationService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping("/statements/{statementId}/auto-match")
+    @PreAuthorize("hasAuthority('bank:approve')")
+    fun autoMatch(
+        @PathVariable statementId: String,
+        @Valid @RequestBody(required = false) request: AutoMatchRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        val drift = request?.maxDateDriftDays ?: 5
+        return ResponseEntity.ok(reconciliationService.autoMatch(statementId, orgId, userId, drift))
+    }
+
+    @PostMapping("/statements/{statementId}/lines/{lineId}/match")
+    @PreAuthorize("hasAuthority('bank:approve')")
+    fun manualMatch(
+        @PathVariable statementId: String,
+        @PathVariable lineId: String,
+        @Valid @RequestBody request: ManualMatchRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        val updated = reconciliationService.manualMatch(statementId, lineId, request.journalEntryId, orgId, userId)
+        return ResponseEntity.ok(BankStatementResponse.from(updated))
+    }
+
+    @PostMapping("/statements/{statementId}/lines/{lineId}/unmatch")
+    @PreAuthorize("hasAuthority('bank:approve')")
+    fun unmatch(
+        @PathVariable statementId: String,
+        @PathVariable lineId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val updated = reconciliationService.unmatch(statementId, lineId, orgId)
+        return ResponseEntity.ok(BankStatementResponse.from(updated))
+    }
+
+    @GetMapping("/bank-accounts/{bankAccountId}/summary")
+    @PreAuthorize("hasAuthority('bank:read')")
+    fun summary(
+        @PathVariable bankAccountId: String,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) asOf: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(reconciliationService.summary(bankAccountId, orgId, asOf))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/ReconciliationDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/ReconciliationDtos.kt
@@ -1,0 +1,38 @@
+package com.aquinofroilan.tessera.dto
+
+import jakarta.validation.constraints.NotBlank
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class ManualMatchRequest(
+    @field:NotBlank(message = "Journal entry ID is required")
+    val journalEntryId: String,
+)
+
+data class AutoMatchRequest(
+    val maxDateDriftDays: Int = 5,
+)
+
+data class MatchedLineResponse(
+    val statementLineId: String,
+    val journalEntryId: String,
+    val amount: BigDecimal,
+    val driftDays: Int,
+)
+
+data class AutoMatchResponse(
+    val statementId: String,
+    val matched: List<MatchedLineResponse>,
+    val unmatchedLineIds: List<String>,
+    val ambiguousLineIds: List<String>,
+)
+
+data class ReconciliationSummaryResponse(
+    val bankAccountId: String,
+    val glAccountId: String,
+    val bankSideBalance: BigDecimal,
+    val glSideBalance: BigDecimal,
+    val variance: BigDecimal,
+    val unreconciledLineCount: Long,
+    val asOfDate: LocalDate,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/BankReconciliationService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/BankReconciliationService.kt
@@ -1,0 +1,262 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.AutoMatchResponse
+import com.aquinofroilan.tessera.dto.MatchedLineResponse
+import com.aquinofroilan.tessera.dto.ReconciliationSummaryResponse
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.BankStatement
+import com.aquinofroilan.tessera.model.JournalEntry
+import com.aquinofroilan.tessera.model.JournalEntryStatus
+import com.aquinofroilan.tessera.repository.BankStatementRepository
+import com.aquinofroilan.tessera.repository.JournalEntryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import kotlin.math.abs
+
+/**
+ * Matches bank statement lines (what the bank says) against journal-entry
+ * lines posting to the bank's GL account (what our books say). Auto-match
+ * is conservative: it links a statement line to a single journal entry only
+ * when there's exactly one POSTED journal entry within the date drift window
+ * carrying the same signed amount against this bank account's GL. Anything
+ * else surfaces as ambiguous or unmatched for a human to resolve via
+ * [manualMatch] / [unmatch].
+ */
+@Service
+class BankReconciliationService(
+    private val statementRepository: BankStatementRepository,
+    private val bankAccountService: BankAccountService,
+    private val journalEntryRepository: JournalEntryRepository,
+) {
+    @Transactional
+    fun autoMatch(
+        statementId: String,
+        organizationId: String,
+        userId: String,
+        maxDateDriftDays: Int,
+    ): AutoMatchResponse {
+        if (maxDateDriftDays < 0) throw BusinessRuleException("maxDateDriftDays must be >= 0")
+        val statement = getStatement(statementId, organizationId)
+        val bank = bankAccountService.getBankAccount(statement.bankAccountId, organizationId)
+
+        val unreconciled = statement.lines.filter { !it.reconciled }
+        if (unreconciled.isEmpty()) {
+            return AutoMatchResponse(
+                statementId = statement.id,
+                matched = emptyList(),
+                unmatchedLineIds = emptyList(),
+                ambiguousLineIds = emptyList(),
+            )
+        }
+
+        val earliest = unreconciled.minOf { it.postedDate }.minusDays(maxDateDriftDays.toLong())
+        val latest = unreconciled.maxOf { it.postedDate }.plusDays(maxDateDriftDays.toLong())
+        val candidates =
+            journalEntryRepository
+                .findByOrganizationIdAndStatusAndDateBetween(organizationId, JournalEntryStatus.POSTED, earliest, latest)
+                .filter { je ->
+                    je.lines.any { it.accountId == bank.glAccountId }
+                }
+
+        val alreadyMatched = statement.lines.mapNotNull { it.reconciledJournalEntryId }.toMutableSet()
+        val matched = mutableListOf<MatchedLineResponse>()
+        val unmatched = mutableListOf<String>()
+        val ambiguous = mutableListOf<String>()
+
+        val now = LocalDateTime.now()
+        val updatedLines =
+            statement.lines.toMutableList().also { mut ->
+                unreconciled.forEach { line ->
+                    val winners =
+                        candidates.filter { je ->
+                            je.id !in alreadyMatched &&
+                                signedAmountFor(je, bank.glAccountId).compareTo(line.amount) == 0 &&
+                                abs(ChronoUnit.DAYS.between(je.date, line.postedDate).toInt()) <= maxDateDriftDays
+                        }
+                    when (winners.size) {
+                        0 -> unmatched.add(line.id)
+                        1 -> {
+                            val winner = winners.first()
+                            alreadyMatched.add(winner.id)
+                            val idx = mut.indexOfFirst { it.id == line.id }
+                            mut[idx] =
+                                line.copy(
+                                    reconciled = true,
+                                    reconciledJournalEntryId = winner.id,
+                                    reconciledAt = now,
+                                    reconciledBy = userId,
+                                )
+                            matched.add(
+                                MatchedLineResponse(
+                                    statementLineId = line.id,
+                                    journalEntryId = winner.id,
+                                    amount = line.amount,
+                                    driftDays = abs(ChronoUnit.DAYS.between(winner.date, line.postedDate).toInt()),
+                                ),
+                            )
+                        }
+                        else -> ambiguous.add(line.id)
+                    }
+                }
+            }
+        statementRepository.save(statement.copy(lines = updatedLines))
+
+        return AutoMatchResponse(
+            statementId = statement.id,
+            matched = matched,
+            unmatchedLineIds = unmatched,
+            ambiguousLineIds = ambiguous,
+        )
+    }
+
+    @Transactional
+    fun manualMatch(
+        statementId: String,
+        lineId: String,
+        journalEntryId: String,
+        organizationId: String,
+        userId: String,
+    ): BankStatement {
+        val statement = getStatement(statementId, organizationId)
+        val bank = bankAccountService.getBankAccount(statement.bankAccountId, organizationId)
+        val line =
+            statement.lines.firstOrNull { it.id == lineId }
+                ?: throw ResourceNotFoundException("Statement line not found: $lineId")
+        if (line.reconciled) throw BusinessRuleException("Statement line is already reconciled")
+
+        val je =
+            journalEntryRepository.findById(journalEntryId).orElseThrow {
+                ResourceNotFoundException("Journal entry not found: $journalEntryId")
+            }
+        if (je.organizationId != organizationId) {
+            throw ResourceNotFoundException("Journal entry not found: $journalEntryId")
+        }
+        if (je.status != JournalEntryStatus.POSTED) {
+            throw BusinessRuleException("Cannot match against a ${je.status} journal entry")
+        }
+        val jeSignedAmount = signedAmountFor(je, bank.glAccountId)
+        if (jeSignedAmount.signum() == 0) {
+            throw BusinessRuleException("Journal entry does not post to this bank account's GL account")
+        }
+        if (jeSignedAmount.compareTo(line.amount) != 0) {
+            throw BusinessRuleException(
+                "Amount mismatch: statement line $${line.amount} vs journal entry $$jeSignedAmount",
+            )
+        }
+        if (statement.lines.any { it.reconciledJournalEntryId == je.id }) {
+            throw BusinessRuleException("Journal entry is already matched to another statement line")
+        }
+
+        val updated =
+            statement.lines.map {
+                if (it.id == lineId) {
+                    it.copy(
+                        reconciled = true,
+                        reconciledJournalEntryId = je.id,
+                        reconciledAt = LocalDateTime.now(),
+                        reconciledBy = userId,
+                    )
+                } else {
+                    it
+                }
+            }
+        return statementRepository.save(statement.copy(lines = updated))
+    }
+
+    @Transactional
+    fun unmatch(
+        statementId: String,
+        lineId: String,
+        organizationId: String,
+    ): BankStatement {
+        val statement = getStatement(statementId, organizationId)
+        val line =
+            statement.lines.firstOrNull { it.id == lineId }
+                ?: throw ResourceNotFoundException("Statement line not found: $lineId")
+        if (!line.reconciled) throw BusinessRuleException("Statement line is not reconciled")
+        val updated =
+            statement.lines.map {
+                if (it.id == lineId) {
+                    it.copy(
+                        reconciled = false,
+                        reconciledJournalEntryId = null,
+                        reconciledAt = null,
+                        reconciledBy = null,
+                    )
+                } else {
+                    it
+                }
+            }
+        return statementRepository.save(statement.copy(lines = updated))
+    }
+
+    fun summary(
+        bankAccountId: String,
+        organizationId: String,
+        asOfDate: LocalDate?,
+    ): ReconciliationSummaryResponse {
+        val bank = bankAccountService.getBankAccount(bankAccountId, organizationId)
+        val asOf = asOfDate ?: LocalDate.now()
+        val allStatements =
+            statementRepository.findByOrganizationIdAndBankAccountIdOrderByStatementDateDesc(organizationId, bankAccountId)
+        val latestStatement = allStatements.firstOrNull { !it.statementDate.isAfter(asOf) }
+        val bankSide = latestStatement?.closingBalance ?: bank.openingBalance
+
+        val postedEntries =
+            journalEntryRepository
+                .findByOrganizationIdAndStatusAndDateLessThanEqual(organizationId, JournalEntryStatus.POSTED, asOf)
+        val glBalance =
+            bank.openingBalance.add(
+                postedEntries.fold(BigDecimal.ZERO) { acc, je ->
+                    acc.add(signedAmountFor(je, bank.glAccountId))
+                },
+            )
+
+        val unreconciledCount =
+            allStatements
+                .flatMap { it.lines }
+                .count { !it.reconciled }
+                .toLong()
+
+        return ReconciliationSummaryResponse(
+            bankAccountId = bank.id,
+            glAccountId = bank.glAccountId,
+            bankSideBalance = bankSide,
+            glSideBalance = glBalance,
+            variance = bankSide.subtract(glBalance),
+            unreconciledLineCount = unreconciledCount,
+            asOfDate = asOf,
+        )
+    }
+
+    private fun signedAmountFor(
+        je: JournalEntry,
+        glAccountId: String,
+    ): BigDecimal {
+        // A debit to the bank GL increases cash (positive); a credit decreases (negative).
+        var net = BigDecimal.ZERO
+        je.lines.filter { it.accountId == glAccountId }.forEach { l ->
+            net = net.add(l.debit).subtract(l.credit)
+        }
+        return net
+    }
+
+    private fun getStatement(
+        id: String,
+        organizationId: String,
+    ): BankStatement {
+        val s =
+            statementRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Statement not found: $id")
+            }
+        if (s.organizationId != organizationId) {
+            throw ResourceNotFoundException("Statement not found: $id")
+        }
+        return s
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/BankReconciliationServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/BankReconciliationServiceTest.kt
@@ -1,0 +1,241 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.BankAccount
+import com.aquinofroilan.tessera.model.BankStatement
+import com.aquinofroilan.tessera.model.BankStatementLine
+import com.aquinofroilan.tessera.model.JournalEntry
+import com.aquinofroilan.tessera.model.JournalEntryLine
+import com.aquinofroilan.tessera.model.JournalEntryStatus
+import com.aquinofroilan.tessera.repository.BankStatementRepository
+import com.aquinofroilan.tessera.repository.JournalEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class BankReconciliationServiceTest {
+    private lateinit var statementRepository: BankStatementRepository
+    private lateinit var bankAccountService: BankAccountService
+    private lateinit var journalEntryRepository: JournalEntryRepository
+    private lateinit var service: BankReconciliationService
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+    private val bankId = "bank-1"
+    private val glAccountId = "acc-1000"
+
+    @BeforeEach
+    fun setup() {
+        statementRepository = mock(BankStatementRepository::class.java)
+        bankAccountService = mock(BankAccountService::class.java)
+        journalEntryRepository = mock(JournalEntryRepository::class.java)
+        whenever(statementRepository.save(any<BankStatement>())).thenAnswer { it.arguments[0] }
+        whenever(bankAccountService.getBankAccount(bankId, orgId)).thenReturn(bankAccount())
+        service = BankReconciliationService(statementRepository, bankAccountService, journalEntryRepository)
+    }
+
+    @Test
+    fun `auto-match links a single candidate JE within drift window`() {
+        val stmt =
+            statement(
+                listOf(
+                    line("l1", BigDecimal("100"), LocalDate.of(2026, 6, 5)),
+                ),
+            )
+        whenever(statementRepository.findById("s1")).thenReturn(Optional.of(stmt))
+        whenever(
+            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(any(), any(), any(), any()),
+        ).thenReturn(
+            listOf(
+                journalEntry("je1", LocalDate.of(2026, 6, 4), debit = BigDecimal("100"), credit = BigDecimal.ZERO),
+            ),
+        )
+
+        val result = service.autoMatch("s1", orgId, userId, maxDateDriftDays = 5)
+
+        assertThat(result.matched).hasSize(1)
+        assertThat(result.matched[0].journalEntryId).isEqualTo("je1")
+        assertThat(result.unmatchedLineIds).isEmpty()
+        assertThat(result.ambiguousLineIds).isEmpty()
+    }
+
+    @Test
+    fun `auto-match flags ambiguous when multiple JEs match`() {
+        val stmt =
+            statement(
+                listOf(
+                    line("l1", BigDecimal("100"), LocalDate.of(2026, 6, 5)),
+                ),
+            )
+        whenever(statementRepository.findById("s1")).thenReturn(Optional.of(stmt))
+        whenever(
+            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(any(), any(), any(), any()),
+        ).thenReturn(
+            listOf(
+                journalEntry("je1", LocalDate.of(2026, 6, 4), debit = BigDecimal("100"), credit = BigDecimal.ZERO),
+                journalEntry("je2", LocalDate.of(2026, 6, 6), debit = BigDecimal("100"), credit = BigDecimal.ZERO),
+            ),
+        )
+
+        val result = service.autoMatch("s1", orgId, userId, maxDateDriftDays = 5)
+
+        assertThat(result.matched).isEmpty()
+        assertThat(result.ambiguousLineIds).containsExactly("l1")
+    }
+
+    @Test
+    fun `auto-match unmatched when no candidate amount agrees`() {
+        val stmt =
+            statement(
+                listOf(
+                    line("l1", BigDecimal("100"), LocalDate.of(2026, 6, 5)),
+                ),
+            )
+        whenever(statementRepository.findById("s1")).thenReturn(Optional.of(stmt))
+        whenever(
+            journalEntryRepository.findByOrganizationIdAndStatusAndDateBetween(any(), any(), any(), any()),
+        ).thenReturn(
+            listOf(
+                journalEntry("je1", LocalDate.of(2026, 6, 4), debit = BigDecimal("99"), credit = BigDecimal.ZERO),
+            ),
+        )
+
+        val result = service.autoMatch("s1", orgId, userId, maxDateDriftDays = 5)
+
+        assertThat(result.unmatchedLineIds).containsExactly("l1")
+    }
+
+    @Test
+    fun `manual-match rejects an amount mismatch`() {
+        val stmt =
+            statement(
+                listOf(
+                    line("l1", BigDecimal("100"), LocalDate.of(2026, 6, 5)),
+                ),
+            )
+        whenever(statementRepository.findById("s1")).thenReturn(Optional.of(stmt))
+        whenever(journalEntryRepository.findById("je1")).thenReturn(
+            Optional.of(journalEntry("je1", LocalDate.of(2026, 6, 5), debit = BigDecimal("50"), credit = BigDecimal.ZERO)),
+        )
+        assertThatThrownBy { service.manualMatch("s1", "l1", "je1", orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+            .hasMessageContaining("Amount mismatch")
+    }
+
+    @Test
+    fun `manual-match rejects non-POSTED journal entry`() {
+        val stmt =
+            statement(
+                listOf(
+                    line("l1", BigDecimal("100"), LocalDate.of(2026, 6, 5)),
+                ),
+            )
+        whenever(statementRepository.findById("s1")).thenReturn(Optional.of(stmt))
+        whenever(journalEntryRepository.findById("je1")).thenReturn(
+            Optional.of(
+                journalEntry(
+                    "je1",
+                    LocalDate.of(2026, 6, 5),
+                    debit = BigDecimal("100"),
+                    credit = BigDecimal.ZERO,
+                    status = JournalEntryStatus.DRAFT,
+                ),
+            ),
+        )
+        assertThatThrownBy { service.manualMatch("s1", "l1", "je1", orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `unmatch clears reconciliation fields`() {
+        val matched =
+            line("l1", BigDecimal("100"), LocalDate.of(2026, 6, 5)).copy(
+                reconciled = true,
+                reconciledJournalEntryId = "je1",
+            )
+        val stmt = statement(listOf(matched))
+        whenever(statementRepository.findById("s1")).thenReturn(Optional.of(stmt))
+
+        val updated = service.unmatch("s1", "l1", orgId)
+        val cleared = updated.lines.first { it.id == "l1" }
+        assertThat(cleared.reconciled).isFalse
+        assertThat(cleared.reconciledJournalEntryId).isNull()
+    }
+
+    private fun bankAccount() =
+        BankAccount(
+            id = bankId,
+            organizationId = orgId,
+            code = "MAIN",
+            name = "Main",
+            currency = "USD",
+            glAccountId = glAccountId,
+            isActive = true,
+            createdBy = userId,
+        )
+
+    private fun statement(lines: List<BankStatementLine>) =
+        BankStatement(
+            id = "s1",
+            organizationId = orgId,
+            bankAccountId = bankId,
+            statementDate = LocalDate.of(2026, 6, 30),
+            openingBalance = BigDecimal.ZERO,
+            closingBalance = lines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.amount) },
+            currency = "USD",
+            uploadedBy = userId,
+            lines = lines,
+        )
+
+    private fun line(
+        id: String,
+        amount: BigDecimal,
+        date: LocalDate,
+    ) = BankStatementLine(
+        id = id,
+        lineNumber = 1,
+        postedDate = date,
+        description = "Transaction",
+        amount = amount,
+    )
+
+    private fun journalEntry(
+        id: String,
+        date: LocalDate,
+        debit: BigDecimal,
+        credit: BigDecimal,
+        status: JournalEntryStatus = JournalEntryStatus.POSTED,
+    ) = JournalEntry(
+        id = id,
+        entryNumber = "JE-$id",
+        date = date,
+        description = "Auto",
+        organizationId = orgId,
+        status = status,
+        lines =
+            listOf(
+                JournalEntryLine(
+                    accountId = glAccountId,
+                    accountCode = "1000",
+                    accountName = "Cash",
+                    debit = debit,
+                    credit = credit,
+                ),
+                JournalEntryLine(
+                    accountId = "acc-other",
+                    accountCode = "4000",
+                    accountName = "Revenue",
+                    debit = credit,
+                    credit = debit,
+                ),
+            ),
+        createdBy = userId,
+    )
+}


### PR DESCRIPTION
## Summary
Third slice of the Bank & Cash stack. Matches imported statement lines against POSTED journal entries posting to the bank's GL account so the bank-side and GL-side balances can be reconciled to zero variance.

- **`autoMatch(statementId, maxDateDriftDays)`** — for each unreconciled line, finds POSTED journal entries that
  - include a line referencing the bank's `gl_account_id`,
  - carry a **net signed amount** equal to the statement line's amount (positive = debit-to-cash, negative = credit-from-cash),
  - fall within ±`maxDateDriftDays` of the statement line's `posted_date` (default 5).

  **Conservative resolution**: exactly-one candidate ⇒ link, multiple ⇒ ambiguous for human resolution, none ⇒ unmatched. A journal entry is never matched twice within the same auto-match run.
- **`manualMatch(statementId, lineId, journalEntryId)`** — explicit one-to-one override. Validates POSTED status, amount agreement, GL-account involvement, and one-shot uniqueness.
- **`unmatch(statementId, lineId)`** — clears `reconciled` / `reconciledJournalEntryId` + audit timestamps so an erroneous match can be revisited.
- **`summary(bankAccountId, asOf?)`** — returns `bankSideBalance` (closing of the most recent statement on or before `asOf`), `glSideBalance` (opening + net of POSTED journal entries against the bank GL through `asOf`), `variance`, and `unreconciledLineCount` — the headline number for a real bank-rec UI.

**REST endpoints** under `/finance/reconciliation`:
- `POST /statements/{id}/auto-match`
- `POST /statements/{id}/lines/{lid}/match` (manual)
- `POST /statements/{id}/lines/{lid}/unmatch`
- `GET  /bank-accounts/{id}/summary?asOf=YYYY-MM-DD`

All gated by `bank:read` or `bank:approve`. **No new schema** — reuses the `reconciled` / `reconciled_journal_entry_id` / `reconciled_at` / `reconciled_by` columns already on `finance_bank_statement_lines` from stack 2.

**Stacked on #242 → #241.** Merge order: #241 → #242 → this.

Closes #203. Contributes to #166.

## Test plan
- [x] `./gradlew test --tests BankReconciliationServiceTest --tests BankStatementServiceTest` — green (single-candidate auto-match, multi-candidate ambiguous, no-candidate unmatched, manual-match amount mismatch rejection, non-POSTED rejection, unmatch clears fields)
- [x] `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck` — clean
- [ ] CI full suite
- [ ] Manual smoke: import statement → post journal entries against bank GL → call auto-match → call summary → confirm variance = 0