### PR TITLE
feat(finance): batch payment runs — stack 4/5 (#204)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/PaymentRunController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/PaymentRunController.kt
@@ -1,0 +1,98 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CreatePaymentRunRequest
+import com.aquinofroilan.tessera.dto.PaymentRunResponse
+import com.aquinofroilan.tessera.model.PaymentRunStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.PaymentRunService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/finance/payment-runs")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class PaymentRunController(
+    private val paymentRunService: PaymentRunService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('bank:write')")
+    fun create(
+        @Valid @RequestBody request: CreatePaymentRunRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        val r = paymentRunService.createPaymentRun(request, orgId, userId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(PaymentRunResponse.from(r))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('bank:read')")
+    fun list(
+        @RequestParam(required = false) status: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val parsed =
+            if (status != null) {
+                try {
+                    PaymentRunStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(paymentRunService.listPaymentRuns(orgId, parsed).map { PaymentRunResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('bank:read')")
+    fun get(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PaymentRunResponse.from(paymentRunService.getPaymentRun(id, orgId)))
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('bank:approve')")
+    fun approve(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(PaymentRunResponse.from(paymentRunService.approvePaymentRun(id, orgId, userId)))
+    }
+
+    @PostMapping("/{id}/execute")
+    @PreAuthorize("hasAuthority('bank:approve')")
+    fun execute(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(PaymentRunResponse.from(paymentRunService.executePaymentRun(id, orgId, userId)))
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('bank:write')")
+    fun cancel(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(PaymentRunResponse.from(paymentRunService.cancelPaymentRun(id, orgId, userId)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/PaymentRunDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/PaymentRunDtos.kt
@@ -1,0 +1,79 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.PaymentRun
+import com.aquinofroilan.tessera.model.PaymentRunLine
+import com.aquinofroilan.tessera.model.PaymentRunLineStatus
+import com.aquinofroilan.tessera.model.PaymentRunStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreatePaymentRunRequest(
+    @field:NotBlank(message = "Code is required")
+    val code: String,
+    @field:NotBlank(message = "Bank account ID is required")
+    val bankAccountId: String,
+    @field:NotNull(message = "Run date is required")
+    val runDate: LocalDate?,
+    @field:NotEmpty(message = "At least one bill ID is required")
+    val billIds: List<String>,
+    val notes: String? = null,
+)
+
+data class PaymentRunLineResponse(
+    val id: String,
+    val lineNumber: Int,
+    val billId: String,
+    val vendorId: String,
+    val vendorName: String,
+    val billNumber: String,
+    val amount: BigDecimal,
+    val status: PaymentRunLineStatus,
+    val billPaymentId: String?,
+    val notes: String?,
+) {
+    companion object {
+        fun from(l: PaymentRunLine) =
+            PaymentRunLineResponse(
+                id = l.id,
+                lineNumber = l.lineNumber,
+                billId = l.billId,
+                vendorId = l.vendorId,
+                vendorName = l.vendorName,
+                billNumber = l.billNumber,
+                amount = l.amount,
+                status = l.status,
+                billPaymentId = l.billPaymentId,
+                notes = l.notes,
+            )
+    }
+}
+
+data class PaymentRunResponse(
+    val id: String,
+    val code: String,
+    val bankAccountId: String,
+    val runDate: LocalDate,
+    val status: PaymentRunStatus,
+    val totalAmount: BigDecimal,
+    val currency: String,
+    val notes: String?,
+    val lines: List<PaymentRunLineResponse>,
+) {
+    companion object {
+        fun from(p: PaymentRun) =
+            PaymentRunResponse(
+                id = p.id,
+                code = p.code,
+                bankAccountId = p.bankAccountId,
+                runDate = p.runDate,
+                status = p.status,
+                totalAmount = p.totalAmount,
+                currency = p.currency,
+                notes = p.notes,
+                lines = p.lines.map { PaymentRunLineResponse.from(it) },
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/PaymentRun.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/PaymentRun.kt
@@ -1,0 +1,106 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class PaymentRunStatus {
+    DRAFT,
+    APPROVED,
+    EXECUTED,
+    CANCELLED,
+}
+
+enum class PaymentRunLineStatus {
+    PENDING,
+    PAID,
+    SKIPPED,
+    FAILED,
+}
+
+@Entity
+@Table(name = "finance_payment_run_lines")
+data class PaymentRunLine(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "line_number")
+    val lineNumber: Int,
+    @Column(name = "bill_id", columnDefinition = "uuid")
+    val billId: String,
+    @Column(name = "vendor_id", columnDefinition = "uuid")
+    val vendorId: String,
+    @Column(name = "vendor_name")
+    val vendorName: String,
+    @Column(name = "bill_number")
+    val billNumber: String,
+    val amount: BigDecimal,
+    @Enumerated(EnumType.STRING)
+    val status: PaymentRunLineStatus = PaymentRunLineStatus.PENDING,
+    @Column(name = "bill_payment_id", columnDefinition = "uuid")
+    val billPaymentId: String? = null,
+    val notes: String? = null,
+)
+
+@Entity
+@Table(name = "finance_payment_runs")
+@EntityListeners(AuditingEntityListener::class)
+data class PaymentRun(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    val code: String,
+    @Column(name = "bank_account_id", columnDefinition = "uuid")
+    val bankAccountId: String,
+    @Column(name = "run_date")
+    val runDate: LocalDate,
+    @Enumerated(EnumType.STRING)
+    val status: PaymentRunStatus = PaymentRunStatus.DRAFT,
+    @Column(name = "total_amount")
+    val totalAmount: BigDecimal = BigDecimal.ZERO,
+    @Column(columnDefinition = "char(3)")
+    val currency: String,
+    val notes: String? = null,
+    @Column(name = "created_by", columnDefinition = "uuid")
+    val createdBy: String,
+    @Column(name = "approved_at")
+    val approvedAt: LocalDateTime? = null,
+    @Column(name = "approved_by", columnDefinition = "uuid")
+    val approvedBy: String? = null,
+    @Column(name = "executed_at")
+    val executedAt: LocalDateTime? = null,
+    @Column(name = "executed_by", columnDefinition = "uuid")
+    val executedBy: String? = null,
+    @Column(name = "cancelled_at")
+    val cancelledAt: LocalDateTime? = null,
+    @Column(name = "cancelled_by", columnDefinition = "uuid")
+    val cancelledBy: String? = null,
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "payment_run_id")
+    @OrderBy("lineNumber ASC")
+    val lines: List<PaymentRunLine>,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/PaymentRunRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/PaymentRunRepository.kt
@@ -1,0 +1,22 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.PaymentRun
+import com.aquinofroilan.tessera.model.PaymentRunStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface PaymentRunRepository : JpaRepository<PaymentRun, String> {
+    fun findByOrganizationId(organizationId: String): List<PaymentRun>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: PaymentRunStatus,
+    ): List<PaymentRun>
+
+    fun findByOrganizationIdAndCode(
+        organizationId: String,
+        code: String,
+    ): Optional<PaymentRun>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/BillService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/BillService.kt
@@ -314,6 +314,7 @@ class BillService(
         request: RecordPaymentRequest,
         organizationId: String,
         createdBy: String,
+        cashAccountOverride: Account? = null,
     ): BillPayment {
         val bill = getBill(billId, organizationId)
 
@@ -333,7 +334,13 @@ class BillService(
         }
 
         val apAccount = getApAccount(organizationId)
-        val cashAccount = getCashAccount(organizationId)
+        val cashAccount =
+            cashAccountOverride?.also {
+                if (it.organizationId != organizationId) {
+                    throw BusinessRuleException("Cash account override is not in this organization")
+                }
+                if (!it.isActive) throw BusinessRuleException("Cash account override is inactive")
+            } ?: getCashAccount(organizationId)
 
         val paymentId = UUID.randomUUID().toString()
         val baseDecimals = currencyService.getCurrency(getBaseCurrency(organizationId)).decimalPlaces

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/PaymentRunService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/PaymentRunService.kt
@@ -1,0 +1,206 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreatePaymentRunRequest
+import com.aquinofroilan.tessera.dto.RecordPaymentRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.BillStatus
+import com.aquinofroilan.tessera.model.PaymentMethod
+import com.aquinofroilan.tessera.model.PaymentRun
+import com.aquinofroilan.tessera.model.PaymentRunLine
+import com.aquinofroilan.tessera.model.PaymentRunLineStatus
+import com.aquinofroilan.tessera.model.PaymentRunStatus
+import com.aquinofroilan.tessera.repository.PaymentRunRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@Service
+class PaymentRunService(
+    private val paymentRunRepository: PaymentRunRepository,
+    private val bankAccountService: BankAccountService,
+    private val billService: BillService,
+    private val accountService: AccountService,
+) {
+    @Transactional
+    fun createPaymentRun(
+        request: CreatePaymentRunRequest,
+        organizationId: String,
+        userId: String,
+    ): PaymentRun {
+        val runDate = request.runDate ?: throw BusinessRuleException("runDate is required")
+        if (request.billIds.isEmpty()) throw BusinessRuleException("At least one bill ID is required")
+        if (request.billIds.distinct().size != request.billIds.size) {
+            throw BusinessRuleException("Duplicate bill IDs in request")
+        }
+        val code = request.code.trim().uppercase()
+        if (code.isBlank()) throw BusinessRuleException("Code cannot be blank")
+        paymentRunRepository.findByOrganizationIdAndCode(organizationId, code).ifPresent {
+            throw BusinessRuleException("Payment run with code '$code' already exists")
+        }
+        val bankAccount = bankAccountService.getBankAccount(request.bankAccountId, organizationId)
+        if (!bankAccount.isActive) throw BusinessRuleException("Bank account '${bankAccount.code}' is inactive")
+
+        val lines =
+            request.billIds.mapIndexed { idx, billId ->
+                val bill = billService.getBill(billId, organizationId)
+                if (bill.status != BillStatus.APPROVED && bill.status != BillStatus.PARTIALLY_PAID) {
+                    throw BusinessRuleException(
+                        "Bill ${bill.billNumber} is ${bill.status}; only APPROVED / PARTIALLY_PAID bills can be paid",
+                    )
+                }
+                if (bill.currencyCode != bankAccount.currency) {
+                    throw BusinessRuleException(
+                        "Bill ${bill.billNumber} currency ${bill.currencyCode} does not match bank ${bankAccount.currency}",
+                    )
+                }
+                val remaining = bill.totalAmount.subtract(bill.amountPaid)
+                if (remaining.signum() <= 0) {
+                    throw BusinessRuleException("Bill ${bill.billNumber} has no remaining balance")
+                }
+                PaymentRunLine(
+                    lineNumber = idx + 1,
+                    billId = bill.id,
+                    vendorId = bill.vendorId,
+                    vendorName = bill.vendorName,
+                    billNumber = bill.billNumber,
+                    amount = remaining,
+                )
+            }
+        val total = lines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.amount) }
+        return try {
+            paymentRunRepository.save(
+                PaymentRun(
+                    organizationId = organizationId,
+                    code = code,
+                    bankAccountId = bankAccount.id,
+                    runDate = runDate,
+                    status = PaymentRunStatus.DRAFT,
+                    totalAmount = total,
+                    currency = bankAccount.currency,
+                    notes = request.notes,
+                    lines = lines,
+                    createdBy = userId,
+                ),
+            )
+        } catch (e: DataIntegrityViolationException) {
+            throw BusinessRuleException("Payment run with code '$code' already exists")
+        }
+    }
+
+    fun getPaymentRun(
+        id: String,
+        organizationId: String,
+    ): PaymentRun {
+        val r =
+            paymentRunRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Payment run not found: $id")
+            }
+        if (r.organizationId != organizationId) {
+            throw ResourceNotFoundException("Payment run not found: $id")
+        }
+        return r
+    }
+
+    fun listPaymentRuns(
+        organizationId: String,
+        status: PaymentRunStatus?,
+    ): List<PaymentRun> =
+        if (status != null) {
+            paymentRunRepository.findByOrganizationIdAndStatus(organizationId, status)
+        } else {
+            paymentRunRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun approvePaymentRun(
+        id: String,
+        organizationId: String,
+        userId: String,
+    ): PaymentRun {
+        val run = getPaymentRun(id, organizationId)
+        if (run.status != PaymentRunStatus.DRAFT) {
+            throw BusinessRuleException("Only DRAFT payment runs can be approved (current: ${run.status})")
+        }
+        return paymentRunRepository.save(
+            run.copy(
+                status = PaymentRunStatus.APPROVED,
+                approvedAt = LocalDateTime.now(),
+                approvedBy = userId,
+            ),
+        )
+    }
+
+    @Transactional
+    fun executePaymentRun(
+        id: String,
+        organizationId: String,
+        userId: String,
+    ): PaymentRun {
+        val run = getPaymentRun(id, organizationId)
+        if (run.status != PaymentRunStatus.APPROVED) {
+            throw BusinessRuleException("Only APPROVED payment runs can be executed (current: ${run.status})")
+        }
+        val bankAccount = bankAccountService.getBankAccount(run.bankAccountId, organizationId)
+        val glAccount = accountService.getAccount(bankAccount.glAccountId, organizationId)
+
+        var paidTotal = BigDecimal.ZERO
+        val executedLines =
+            run.lines.map { line ->
+                if (line.status != PaymentRunLineStatus.PENDING) return@map line
+                try {
+                    val payment =
+                        billService.recordPayment(
+                            billId = line.billId,
+                            request =
+                                RecordPaymentRequest(
+                                    paymentDate = run.runDate,
+                                    amount = line.amount,
+                                    paymentMethod = PaymentMethod.BANK_TRANSFER,
+                                    referenceNumber = "PAYRUN-${run.code}",
+                                ),
+                            organizationId = organizationId,
+                            createdBy = userId,
+                            cashAccountOverride = glAccount,
+                        )
+                    paidTotal = paidTotal.add(line.amount)
+                    line.copy(status = PaymentRunLineStatus.PAID, billPaymentId = payment.id)
+                } catch (e: Exception) {
+                    line.copy(status = PaymentRunLineStatus.FAILED, notes = e.message?.take(500))
+                }
+            }
+        if (paidTotal.signum() > 0) {
+            bankAccountService.applyBalanceDelta(run.bankAccountId, organizationId, paidTotal.negate())
+        }
+        return paymentRunRepository.save(
+            run.copy(
+                status = PaymentRunStatus.EXECUTED,
+                executedAt = LocalDateTime.now(),
+                executedBy = userId,
+                lines = executedLines,
+            ),
+        )
+    }
+
+    @Transactional
+    fun cancelPaymentRun(
+        id: String,
+        organizationId: String,
+        userId: String,
+    ): PaymentRun {
+        val run = getPaymentRun(id, organizationId)
+        if (run.status == PaymentRunStatus.EXECUTED) {
+            throw BusinessRuleException("Cannot cancel an EXECUTED payment run")
+        }
+        if (run.status == PaymentRunStatus.CANCELLED) return run
+        return paymentRunRepository.save(
+            run.copy(
+                status = PaymentRunStatus.CANCELLED,
+                cancelledAt = LocalDateTime.now(),
+                cancelledBy = userId,
+            ),
+        )
+    }
+}

--- a/src/main/resources/db/migration/V0037__finance_payment_runs.sql
+++ b/src/main/resources/db/migration/V0037__finance_payment_runs.sql
@@ -1,0 +1,50 @@
+-- Finance: batch payment runs.
+-- A payment run is a batch of bills selected to be paid out of a single
+-- bank account on a given date. Status flows DRAFT -> APPROVED -> EXECUTED
+-- (or CANCELLED). EXECUTED means each line has been turned into a
+-- bill-payment record + journal entry; the bank account's cached current
+-- balance has been decremented accordingly.
+
+CREATE TABLE finance_payment_runs (
+    id                uuid PRIMARY KEY,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    code              text NOT NULL,
+    bank_account_id   uuid NOT NULL REFERENCES finance_bank_accounts(id) ON DELETE RESTRICT,
+    run_date          date NOT NULL,
+    status            text NOT NULL DEFAULT 'DRAFT',
+    total_amount      numeric(18,4) NOT NULL DEFAULT 0,
+    currency          char(3) NOT NULL,
+    notes             text,
+    created_by        uuid NOT NULL REFERENCES users(uuid),
+    approved_at       timestamp,
+    approved_by       uuid REFERENCES users(uuid),
+    executed_at       timestamp,
+    executed_by       uuid REFERENCES users(uuid),
+    cancelled_at      timestamp,
+    cancelled_by      uuid REFERENCES users(uuid),
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT finance_payment_runs_status_chk CHECK (status IN ('DRAFT','APPROVED','EXECUTED','CANCELLED')),
+    CONSTRAINT finance_payment_runs_total_chk  CHECK (total_amount >= 0),
+    CONSTRAINT finance_payment_runs_unique_code_per_org UNIQUE (organization_id, code)
+);
+CREATE INDEX finance_payment_runs_org_status_idx  ON finance_payment_runs(organization_id, status);
+CREATE INDEX finance_payment_runs_org_account_idx ON finance_payment_runs(organization_id, bank_account_id);
+
+CREATE TABLE finance_payment_run_lines (
+    id                  uuid PRIMARY KEY,
+    payment_run_id      uuid NOT NULL REFERENCES finance_payment_runs(id) ON DELETE CASCADE,
+    line_number         int NOT NULL,
+    bill_id             uuid NOT NULL REFERENCES bills(id) ON DELETE RESTRICT,
+    vendor_id           uuid NOT NULL REFERENCES vendors(id) ON DELETE RESTRICT,
+    vendor_name         text NOT NULL,
+    bill_number         text NOT NULL,
+    amount              numeric(18,4) NOT NULL,
+    status              text NOT NULL DEFAULT 'PENDING',
+    bill_payment_id     uuid,
+    notes               text,
+    CONSTRAINT finance_payment_run_lines_status_chk CHECK (status IN ('PENDING','PAID','SKIPPED','FAILED')),
+    CONSTRAINT finance_payment_run_lines_amount_chk CHECK (amount > 0),
+    CONSTRAINT finance_payment_run_lines_unique_line_per_run UNIQUE (payment_run_id, line_number)
+);
+CREATE INDEX finance_payment_run_lines_bill_idx ON finance_payment_run_lines(bill_id);

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/PaymentRunServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/PaymentRunServiceTest.kt
@@ -1,0 +1,265 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreatePaymentRunRequest
+import com.aquinofroilan.tessera.dto.RecordPaymentRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.Account
+import com.aquinofroilan.tessera.model.AccountType
+import com.aquinofroilan.tessera.model.BankAccount
+import com.aquinofroilan.tessera.model.Bill
+import com.aquinofroilan.tessera.model.BillPayment
+import com.aquinofroilan.tessera.model.BillStatus
+import com.aquinofroilan.tessera.model.PaymentRun
+import com.aquinofroilan.tessera.model.PaymentRunLineStatus
+import com.aquinofroilan.tessera.model.PaymentRunStatus
+import com.aquinofroilan.tessera.repository.PaymentRunRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class PaymentRunServiceTest {
+    private lateinit var repository: PaymentRunRepository
+    private lateinit var bankAccountService: BankAccountService
+    private lateinit var billService: BillService
+    private lateinit var accountService: AccountService
+    private lateinit var service: PaymentRunService
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+    private val bankId = "bank-1"
+    private val glAccountId = "acc-1000"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(PaymentRunRepository::class.java)
+        bankAccountService = mock(BankAccountService::class.java)
+        billService = mock(BillService::class.java)
+        accountService = mock(AccountService::class.java)
+        whenever(repository.save(any<PaymentRun>())).thenAnswer { it.arguments[0] }
+        whenever(repository.findByOrganizationIdAndCode(any(), any())).thenReturn(Optional.empty())
+        whenever(bankAccountService.getBankAccount(bankId, orgId)).thenReturn(bankAccount())
+        whenever(accountService.getAccount(glAccountId, orgId)).thenReturn(glAccount())
+        service = PaymentRunService(repository, bankAccountService, billService, accountService)
+    }
+
+    @Test
+    fun `create rolls up remaining bill amounts into total`() {
+        whenever(billService.getBill("b1", orgId)).thenReturn(bill("b1", "BILL-1", BigDecimal("500"), BigDecimal.ZERO))
+        whenever(billService.getBill("b2", orgId)).thenReturn(bill("b2", "BILL-2", BigDecimal("300"), BigDecimal("100")))
+
+        val run =
+            service.createPaymentRun(
+                CreatePaymentRunRequest(
+                    code = "may-2026",
+                    bankAccountId = bankId,
+                    runDate = LocalDate.of(2026, 5, 31),
+                    billIds = listOf("b1", "b2"),
+                ),
+                orgId,
+                userId,
+            )
+
+        assertThat(run.code).isEqualTo("MAY-2026")
+        assertThat(run.status).isEqualTo(PaymentRunStatus.DRAFT)
+        assertThat(run.lines).hasSize(2)
+        // b1 remaining=500, b2 remaining=200, total=700
+        assertThat(run.totalAmount).isEqualByComparingTo(BigDecimal("700"))
+    }
+
+    @Test
+    fun `create rejects DRAFT bill`() {
+        whenever(billService.getBill("b1", orgId)).thenReturn(
+            bill("b1", "BILL-1", BigDecimal("500"), BigDecimal.ZERO).copy(status = BillStatus.DRAFT),
+        )
+        assertThatThrownBy {
+            service.createPaymentRun(
+                CreatePaymentRunRequest(code = "X", bankAccountId = bankId, runDate = LocalDate.now(), billIds = listOf("b1")),
+                orgId,
+                userId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `create rejects mismatched currency`() {
+        whenever(billService.getBill("b1", orgId)).thenReturn(
+            bill("b1", "BILL-1", BigDecimal("500"), BigDecimal.ZERO).copy(currencyCode = "EUR"),
+        )
+        assertThatThrownBy {
+            service.createPaymentRun(
+                CreatePaymentRunRequest(code = "X", bankAccountId = bankId, runDate = LocalDate.now(), billIds = listOf("b1")),
+                orgId,
+                userId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+            .hasMessageContaining("currency")
+    }
+
+    @Test
+    fun `create rejects duplicate bill IDs`() {
+        assertThatThrownBy {
+            service.createPaymentRun(
+                CreatePaymentRunRequest(code = "X", bankAccountId = bankId, runDate = LocalDate.now(), billIds = listOf("b1", "b1")),
+                orgId,
+                userId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `approve flips DRAFT to APPROVED`() {
+        val draft = draftRun()
+        whenever(repository.findById("r1")).thenReturn(Optional.of(draft))
+        val approved = service.approvePaymentRun("r1", orgId, userId)
+        assertThat(approved.status).isEqualTo(PaymentRunStatus.APPROVED)
+        assertThat(approved.approvedBy).isEqualTo(userId)
+    }
+
+    @Test
+    fun `approve rejects non-DRAFT`() {
+        val approved = draftRun().copy(status = PaymentRunStatus.APPROVED)
+        whenever(repository.findById("r1")).thenReturn(Optional.of(approved))
+        assertThatThrownBy { service.approvePaymentRun("r1", orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `execute records bill payments with bank GL as cash override`() {
+        val approved = draftRun().copy(status = PaymentRunStatus.APPROVED)
+        whenever(repository.findById("r1")).thenReturn(Optional.of(approved))
+        whenever(
+            billService.recordPayment(any(), any<RecordPaymentRequest>(), any(), any(), any<Account>()),
+        ).thenReturn(payment())
+
+        val executed = service.executePaymentRun("r1", orgId, userId)
+
+        assertThat(executed.status).isEqualTo(PaymentRunStatus.EXECUTED)
+        assertThat(executed.lines.all { it.status == PaymentRunLineStatus.PAID }).isTrue
+        verify(billService).recordPayment(
+            eq(approved.lines[0].billId),
+            any<RecordPaymentRequest>(),
+            eq(orgId),
+            eq(userId),
+            eq(glAccount()),
+        )
+        verify(bankAccountService).applyBalanceDelta(bankId, orgId, BigDecimal("-500"))
+    }
+
+    @Test
+    fun `execute marks line FAILED when bill payment throws`() {
+        val approved = draftRun().copy(status = PaymentRunStatus.APPROVED)
+        whenever(repository.findById("r1")).thenReturn(Optional.of(approved))
+        whenever(
+            billService.recordPayment(any(), any<RecordPaymentRequest>(), any(), any(), any<Account>()),
+        ).thenThrow(BusinessRuleException("boom"))
+
+        val executed = service.executePaymentRun("r1", orgId, userId)
+
+        assertThat(executed.status).isEqualTo(PaymentRunStatus.EXECUTED)
+        assertThat(executed.lines[0].status).isEqualTo(PaymentRunLineStatus.FAILED)
+        assertThat(executed.lines[0].notes).contains("boom")
+    }
+
+    @Test
+    fun `cancel rejects EXECUTED`() {
+        val executed = draftRun().copy(status = PaymentRunStatus.EXECUTED)
+        whenever(repository.findById("r1")).thenReturn(Optional.of(executed))
+        assertThatThrownBy { service.cancelPaymentRun("r1", orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    private fun bankAccount() =
+        BankAccount(
+            id = bankId,
+            organizationId = orgId,
+            code = "MAIN",
+            name = "Main",
+            currency = "USD",
+            glAccountId = glAccountId,
+            isActive = true,
+            createdBy = userId,
+        )
+
+    private fun glAccount() =
+        Account(
+            id = glAccountId,
+            code = "1000",
+            name = "Cash - Main",
+            type = AccountType.ASSET,
+            organizationId = orgId,
+            isActive = true,
+        )
+
+    private fun bill(
+        id: String,
+        billNumber: String,
+        total: BigDecimal,
+        paid: BigDecimal,
+    ) = Bill(
+        id = id,
+        billNumber = billNumber,
+        vendorId = "v-$id",
+        vendorName = "Vendor $id",
+        organizationId = orgId,
+        date = LocalDate.now(),
+        dueDate = LocalDate.now().plusDays(30),
+        status = BillStatus.APPROVED,
+        taxAmount = BigDecimal.ZERO,
+        totalAmount = total,
+        amountPaid = paid,
+        currencyCode = "USD",
+        baseCurrencyAmount = total,
+        baseCurrencyAmountPaid = paid,
+        exchangeRate = BigDecimal.ONE,
+        lines = emptyList(),
+        createdBy = userId,
+    )
+
+    private fun draftRun() =
+        PaymentRun(
+            id = "r1",
+            organizationId = orgId,
+            code = "MAY-2026",
+            bankAccountId = bankId,
+            runDate = LocalDate.of(2026, 5, 31),
+            status = PaymentRunStatus.DRAFT,
+            totalAmount = BigDecimal("500"),
+            currency = "USD",
+            lines =
+                listOf(
+                    com.aquinofroilan.tessera.model.PaymentRunLine(
+                        lineNumber = 1,
+                        billId = "b1",
+                        vendorId = "v-1",
+                        vendorName = "Vendor 1",
+                        billNumber = "BILL-1",
+                        amount = BigDecimal("500"),
+                    ),
+                ),
+            createdBy = userId,
+        )
+
+    private fun payment() =
+        BillPayment(
+            id = "p1",
+            billId = "b1",
+            paymentDate = LocalDate.now(),
+            amount = BigDecimal("500"),
+            baseCurrencyAmount = BigDecimal("500"),
+            exchangeRate = BigDecimal.ONE,
+            paymentMethod = com.aquinofroilan.tessera.model.PaymentMethod.BANK_TRANSFER,
+            referenceNumber = "PAYRUN-MAY-2026",
+            journalEntryId = "je-1",
+            organizationId = orgId,
+            createdBy = userId,
+        )
+}


### PR DESCRIPTION
## Summary
Fourth slice of the Bank & Cash stack. Pay a batch of approved bills out of a single bank account in one approval-gated action.

- **`finance_payment_runs` + `finance_payment_run_lines`** schema. Run lifecycle `DRAFT` → `APPROVED` → `EXECUTED` with `CANCELLED` as a parallel terminal state. Line lifecycle `PENDING` → `PAID` (or `SKIPPED` / `FAILED`).
- **`BillService.recordPayment` now accepts an optional `cashAccountOverride`** (default `null` preserves the existing behaviour of looking up the org-default `1000 Cash` account). `PaymentRunService` passes the bank account's `gl_account_id` so payments hit the right cash bucket rather than always the default.
- **`PaymentRunService`**:
  - `createPaymentRun` — validates bank account is active, rejects duplicate bill IDs, validates each bill is `APPROVED` or `PARTIALLY_PAID` with a positive remaining balance, rejects mismatched bill / bank currency. Each line is initialised to the bill's remaining balance and the run total is the sum.
  - `approvePaymentRun` — DRAFT → APPROVED, stamps `approved_at` / `by`.
  - `executePaymentRun` — APPROVED → EXECUTED. Iterates lines; for each `PENDING` line calls `BillService.recordPayment` with the bank's GL as the cash account, then marks `PAID` + records the resulting `bill_payment_id`; on failure marks `FAILED` + records the error message (truncated to 500 chars). Cascades the net paid amount to the bank account's cached `current_balance` via `applyBalanceDelta`.
  - `cancelPaymentRun` — DRAFT / APPROVED → CANCELLED. **EXECUTED runs cannot be cancelled** (would require reversal which is out of scope).
- REST endpoints under `/finance/payment-runs`: CRUD-ish + `/approve` + `/execute` + `/cancel`. Gated by `bank:read` / `bank:write` / `bank:approve`.

**Stacked on #243 → #242 → #241.** Merge order: #241 → #242 → #243 → this.

Closes #204. Contributes to #166.

## Test plan
- [x] `./gradlew test --tests PaymentRunServiceTest` — 8 cases green (remaining-amount rollup, DRAFT-bill rejection, currency-mismatch rejection, duplicate-bill rejection, approve flip + non-DRAFT rejection, execute uses GL override + bank-balance delta, line FAILED on exception, EXECUTED-cancel rejection)
- [x] `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck` — clean
- [ ] CI full suite
- [ ] Manual smoke: approve 2 bills → create run → approve → execute → confirm bills paid, bank balance decreased by total