### PR TITLE
feat(finance): cash-flow forecast — stack 5/5 (#205)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/CashFlowForecastController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/CashFlowForecastController.kt
@@ -1,0 +1,32 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.CashFlowForecastService
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/finance/cash-flow")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class CashFlowForecastController(
+    private val forecastService: CashFlowForecastService,
+    private val authContext: AuthenticationContext,
+) {
+    @GetMapping("/forecast")
+    @PreAuthorize("hasAuthority('bank:read')")
+    fun forecast(
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) asOf: LocalDate?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) horizonEnd: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(forecastService.forecast(orgId, asOf, horizonEnd))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/CashFlowForecastDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/CashFlowForecastDtos.kt
@@ -1,0 +1,25 @@
+package com.aquinofroilan.tessera.dto
+
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CashFlowBucket(
+    val periodEnd: LocalDate,
+    val inflow: BigDecimal,
+    val outflow: BigDecimal,
+    val net: BigDecimal,
+    val runningBalance: BigDecimal,
+)
+
+data class CashFlowForecastResponse(
+    val asOfDate: LocalDate,
+    val horizonEnd: LocalDate,
+    val currency: String,
+    val startingCash: BigDecimal,
+    val totalInflow: BigDecimal,
+    val totalOutflow: BigDecimal,
+    val projectedEndingCash: BigDecimal,
+    val overdueAr: BigDecimal,
+    val overdueAp: BigDecimal,
+    val buckets: List<CashFlowBucket>,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/CashFlowForecastService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/CashFlowForecastService.kt
@@ -1,0 +1,140 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CashFlowBucket
+import com.aquinofroilan.tessera.dto.CashFlowForecastResponse
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.BillStatus
+import com.aquinofroilan.tessera.model.InvoiceStatus
+import com.aquinofroilan.tessera.repository.BankAccountRepository
+import com.aquinofroilan.tessera.repository.BillRepository
+import com.aquinofroilan.tessera.repository.InvoiceRepository
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+
+/**
+ * Read-only cash-flow projection. Starts from the current cash position
+ * (sum of active bank accounts' current_balance), then walks open AR
+ * invoices and open AP bills with due dates inside the horizon to
+ * project per-week inflow and outflow. Anything overdue at the start of
+ * the run is reported separately so a user can see latent risk before
+ * deciding what to chase or pay.
+ *
+ * Single-currency for now: amounts are summed in their native currency
+ * regardless of bank account currency mix; multi-currency normalisation
+ * is a follow-up that depends on the org-level base currency exchange
+ * rates the FX service exposes.
+ */
+@Service
+class CashFlowForecastService(
+    private val bankAccountRepository: BankAccountRepository,
+    private val invoiceRepository: InvoiceRepository,
+    private val billRepository: BillRepository,
+) {
+    fun forecast(
+        organizationId: String,
+        asOfDate: LocalDate?,
+        horizonEnd: LocalDate?,
+    ): CashFlowForecastResponse {
+        val asOf = asOfDate ?: LocalDate.now()
+        val horizon = horizonEnd ?: asOf.plusWeeks(13)
+        if (!horizon.isAfter(asOf)) {
+            throw BusinessRuleException("horizonEnd must be after asOfDate")
+        }
+
+        val activeBanks = bankAccountRepository.findByOrganizationIdAndIsActive(organizationId, true)
+        val startingCash = activeBanks.fold(BigDecimal.ZERO) { acc, b -> acc.add(b.currentBalance) }
+        val currency = activeBanks.firstOrNull()?.currency ?: "USD"
+
+        val openInvoices =
+            invoiceRepository
+                .findByOrganizationIdAndStatusIn(organizationId, listOf(InvoiceStatus.APPROVED, InvoiceStatus.PARTIALLY_PAID))
+                .map { inv ->
+                    OpenItem(
+                        dueDate = inv.dueDate,
+                        amountRemaining = inv.totalAmount.subtract(inv.amountReceived),
+                    )
+                }.filter { it.amountRemaining.signum() > 0 }
+        val openBills =
+            billRepository
+                .findByOrganizationIdAndStatusIn(organizationId, listOf(BillStatus.APPROVED, BillStatus.PARTIALLY_PAID))
+                .map { bill ->
+                    OpenItem(
+                        dueDate = bill.dueDate,
+                        amountRemaining = bill.totalAmount.subtract(bill.amountPaid),
+                    )
+                }.filter { it.amountRemaining.signum() > 0 }
+
+        val overdueAr =
+            openInvoices.filter { it.dueDate.isBefore(asOf) }.fold(BigDecimal.ZERO) { acc, i -> acc.add(i.amountRemaining) }
+        val overdueAp =
+            openBills.filter { it.dueDate.isBefore(asOf) }.fold(BigDecimal.ZERO) { acc, i -> acc.add(i.amountRemaining) }
+
+        // Bucket future items by ISO week ending (Sunday).
+        val futureInflows = openInvoices.filter { !it.dueDate.isBefore(asOf) && !it.dueDate.isAfter(horizon) }
+        val futureOutflows = openBills.filter { !it.dueDate.isBefore(asOf) && !it.dueDate.isAfter(horizon) }
+
+        val bucketEnds = generateWeekEnds(asOf, horizon)
+        val inflowByBucket =
+            futureInflows
+                .groupBy { bucketEndFor(it.dueDate, bucketEnds) }
+                .mapValues { (_, items) -> items.fold(BigDecimal.ZERO) { acc, i -> acc.add(i.amountRemaining) } }
+        val outflowByBucket =
+            futureOutflows
+                .groupBy { bucketEndFor(it.dueDate, bucketEnds) }
+                .mapValues { (_, items) -> items.fold(BigDecimal.ZERO) { acc, i -> acc.add(i.amountRemaining) } }
+
+        var running = startingCash
+        val buckets =
+            bucketEnds.map { end ->
+                val inflow = inflowByBucket[end] ?: BigDecimal.ZERO
+                val outflow = outflowByBucket[end] ?: BigDecimal.ZERO
+                val net = inflow.subtract(outflow)
+                running = running.add(net)
+                CashFlowBucket(periodEnd = end, inflow = inflow, outflow = outflow, net = net, runningBalance = running)
+            }
+
+        val totalIn = buckets.fold(BigDecimal.ZERO) { acc, b -> acc.add(b.inflow) }
+        val totalOut = buckets.fold(BigDecimal.ZERO) { acc, b -> acc.add(b.outflow) }
+
+        return CashFlowForecastResponse(
+            asOfDate = asOf,
+            horizonEnd = horizon,
+            currency = currency,
+            startingCash = startingCash,
+            totalInflow = totalIn,
+            totalOutflow = totalOut,
+            projectedEndingCash = running,
+            overdueAr = overdueAr,
+            overdueAp = overdueAp,
+            buckets = buckets,
+        )
+    }
+
+    private data class OpenItem(
+        val dueDate: LocalDate,
+        val amountRemaining: BigDecimal,
+    )
+
+    private fun generateWeekEnds(
+        asOf: LocalDate,
+        horizon: LocalDate,
+    ): List<LocalDate> {
+        val first = asOf.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+        val result = mutableListOf<LocalDate>()
+        var cursor = first
+        while (!cursor.isAfter(horizon)) {
+            result.add(cursor)
+            cursor = cursor.plusWeeks(1)
+        }
+        if (result.isEmpty() || result.last() != horizon) result.add(horizon)
+        return result
+    }
+
+    private fun bucketEndFor(
+        date: LocalDate,
+        bucketEnds: List<LocalDate>,
+    ): LocalDate = bucketEnds.firstOrNull { !date.isAfter(it) } ?: bucketEnds.last()
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/CashFlowForecastServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/CashFlowForecastServiceTest.kt
@@ -1,0 +1,180 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.BankAccount
+import com.aquinofroilan.tessera.model.Bill
+import com.aquinofroilan.tessera.model.BillStatus
+import com.aquinofroilan.tessera.model.Invoice
+import com.aquinofroilan.tessera.model.InvoiceStatus
+import com.aquinofroilan.tessera.repository.BankAccountRepository
+import com.aquinofroilan.tessera.repository.BillRepository
+import com.aquinofroilan.tessera.repository.InvoiceRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class CashFlowForecastServiceTest {
+    private lateinit var bankRepository: BankAccountRepository
+    private lateinit var invoiceRepository: InvoiceRepository
+    private lateinit var billRepository: BillRepository
+    private lateinit var service: CashFlowForecastService
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+    private val asOf = LocalDate.of(2026, 6, 1)
+    private val horizon = LocalDate.of(2026, 7, 31)
+
+    @BeforeEach
+    fun setup() {
+        bankRepository = mock(BankAccountRepository::class.java)
+        invoiceRepository = mock(InvoiceRepository::class.java)
+        billRepository = mock(BillRepository::class.java)
+        service = CashFlowForecastService(bankRepository, invoiceRepository, billRepository)
+    }
+
+    @Test
+    fun `forecast returns starting cash from active bank accounts`() {
+        whenever(bankRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(
+            listOf(
+                bankAccount("MAIN", BigDecimal("10000")),
+                bankAccount("SAVINGS", BigDecimal("5000")),
+            ),
+        )
+        whenever(invoiceRepository.findByOrganizationIdAndStatusIn(any(), any())).thenReturn(emptyList())
+        whenever(billRepository.findByOrganizationIdAndStatusIn(any(), any())).thenReturn(emptyList())
+
+        val r = service.forecast(orgId, asOf, horizon)
+
+        assertThat(r.startingCash).isEqualByComparingTo(BigDecimal("15000"))
+        assertThat(r.totalInflow).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(r.totalOutflow).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(r.projectedEndingCash).isEqualByComparingTo(BigDecimal("15000"))
+    }
+
+    @Test
+    fun `forecast nets future inflows and outflows`() {
+        whenever(bankRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(
+            listOf(bankAccount("MAIN", BigDecimal("1000"))),
+        )
+        whenever(invoiceRepository.findByOrganizationIdAndStatusIn(any(), any())).thenReturn(
+            listOf(invoice(LocalDate.of(2026, 6, 15), BigDecimal("500"))),
+        )
+        whenever(billRepository.findByOrganizationIdAndStatusIn(any(), any())).thenReturn(
+            listOf(bill(LocalDate.of(2026, 6, 20), BigDecimal("200"))),
+        )
+
+        val r = service.forecast(orgId, asOf, horizon)
+
+        assertThat(r.totalInflow).isEqualByComparingTo(BigDecimal("500"))
+        assertThat(r.totalOutflow).isEqualByComparingTo(BigDecimal("200"))
+        assertThat(r.projectedEndingCash).isEqualByComparingTo(BigDecimal("1300"))
+    }
+
+    @Test
+    fun `forecast surfaces overdue AR and AP separately`() {
+        whenever(bankRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(
+            listOf(bankAccount("MAIN", BigDecimal("1000"))),
+        )
+        whenever(invoiceRepository.findByOrganizationIdAndStatusIn(any(), any())).thenReturn(
+            listOf(
+                invoice(LocalDate.of(2026, 5, 1), BigDecimal("300")),
+                invoice(LocalDate.of(2026, 6, 30), BigDecimal("400")),
+            ),
+        )
+        whenever(billRepository.findByOrganizationIdAndStatusIn(any(), any())).thenReturn(
+            listOf(bill(LocalDate.of(2026, 4, 15), BigDecimal("250"))),
+        )
+
+        val r = service.forecast(orgId, asOf, horizon)
+
+        assertThat(r.overdueAr).isEqualByComparingTo(BigDecimal("300"))
+        assertThat(r.overdueAp).isEqualByComparingTo(BigDecimal("250"))
+        // Overdue items are NOT in future buckets.
+        assertThat(r.totalInflow).isEqualByComparingTo(BigDecimal("400"))
+        assertThat(r.totalOutflow).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `forecast rejects horizon at or before asOf`() {
+        assertThatThrownBy { service.forecast(orgId, asOf, asOf) }
+            .isInstanceOf(BusinessRuleException::class.java)
+        assertThatThrownBy { service.forecast(orgId, asOf, asOf.minusDays(1)) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `forecast skips fully-settled items`() {
+        whenever(bankRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(
+            listOf(bankAccount("MAIN", BigDecimal("0"))),
+        )
+        // Invoice fully paid -> remaining=0 -> skipped.
+        val fullyPaid = invoice(LocalDate.of(2026, 6, 15), BigDecimal("500")).copy(amountReceived = BigDecimal("500"))
+        whenever(invoiceRepository.findByOrganizationIdAndStatusIn(any(), any())).thenReturn(listOf(fullyPaid))
+        whenever(billRepository.findByOrganizationIdAndStatusIn(any(), any())).thenReturn(emptyList())
+
+        val r = service.forecast(orgId, asOf, horizon)
+        assertThat(r.totalInflow).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    private fun bankAccount(
+        code: String,
+        balance: BigDecimal,
+    ) = BankAccount(
+        organizationId = orgId,
+        code = code,
+        name = code,
+        currency = "USD",
+        glAccountId = "gl-$code",
+        currentBalance = balance,
+        createdBy = userId,
+    )
+
+    private fun invoice(
+        dueDate: LocalDate,
+        amount: BigDecimal,
+    ) = Invoice(
+        invoiceNumber = "INV-1",
+        customerId = "c-1",
+        customerName = "Customer 1",
+        date = dueDate.minusDays(30),
+        dueDate = dueDate,
+        organizationId = orgId,
+        status = InvoiceStatus.APPROVED,
+        lines = emptyList(),
+        totalAmount = amount,
+        amountReceived = BigDecimal.ZERO,
+        currencyCode = "USD",
+        baseCurrencyAmount = amount,
+        baseCurrencyAmountReceived = BigDecimal.ZERO,
+        exchangeRate = BigDecimal.ONE,
+        createdBy = userId,
+    )
+
+    private fun bill(
+        dueDate: LocalDate,
+        amount: BigDecimal,
+    ) = Bill(
+        billNumber = "BILL-1",
+        vendorId = "v-1",
+        vendorName = "Vendor 1",
+        date = dueDate.minusDays(30),
+        dueDate = dueDate,
+        organizationId = orgId,
+        status = BillStatus.APPROVED,
+        lines = emptyList(),
+        totalAmount = amount,
+        taxAmount = BigDecimal.ZERO,
+        amountPaid = BigDecimal.ZERO,
+        currencyCode = "USD",
+        baseCurrencyAmount = amount,
+        baseCurrencyAmountPaid = BigDecimal.ZERO,
+        exchangeRate = BigDecimal.ONE,
+        createdBy = userId,
+    )
+}


### PR DESCRIPTION
## Summary
Final slice of the Bank & Cash stack. Read-only projection of how much cash the org will have at each future point given the current bank balances and the bills / invoices already on the books.

- **`CashFlowForecastService.forecast(asOf?, horizonEnd?)`**:
  - **Starting cash** = sum of active bank accounts' `current_balance`
  - Walks open AR invoices (`APPROVED` / `PARTIALLY_PAID`) and open AP bills (`APPROVED` / `PARTIALLY_PAID`), reducing each by amounts already settled
  - Items with `due_date < asOf` are reported as **`overdueAr` / `overdueAp`** so the user can see latent risk before deciding what to chase / pay
  - Items with `due_date ∈ [asOf, horizonEnd]` are bucketed into **ISO weeks ending Sunday**; each bucket carries per-week inflow / outflow / net + the rolling cash position
  - Default horizon = `asOf + 13 weeks` (one quarter)
- **Single-currency for now**: amounts are summed in their native currency regardless of bank account currency mix. Multi-currency normalisation via base-currency exchange rates is a deliberate follow-up.
- `GET /finance/cash-flow/forecast?asOf=&horizonEnd=` gated by `bank:read`.
- **No new schema** — pure read-side computation over existing inventory of bank accounts + bills + invoices.

**Stacked on #244 → #243 → #242 → #241.** Final merge order: #241 → #242 → #243 → #244 → this. Once this lands, the Bank & Cash module (#201–#205) is complete.

Closes #205. Contributes to #166.

## Test plan
- [x] `./gradlew test --tests CashFlowForecastServiceTest` — 5 cases green (starting cash from active banks, future netting, overdue surfacing, horizon-validation rejection, fully-settled skip)
- [x] `./gradlew ktlintMainSourceSetCheck ktlintTestSourceSetCheck` — clean
- [ ] CI full suite
- [ ] Manual smoke: post a few approved invoices + bills with due dates spread over the next 8 weeks → call `/forecast` → confirm buckets line up with calendar and runningBalance crosses zero where expected