### PR TITLE
release: v0.11.0 — Projects, HR org/attendance/self-service, procurement requests, magic-link auth, CSV I/O

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "com.aquinofroilan"
-version = "0.10.0"
+version = "0.11.0"
 description = "Tessera an ERP System"
 
 java {

--- a/src/main/kotlin/com/aquinofroilan/tessera/config/RoleSeeder.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/config/RoleSeeder.kt
@@ -85,6 +85,9 @@ class RoleSeeder(
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
                             Permissions.HR_APPROVE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
+                            Permissions.PROJECT_APPROVE,
                         ),
                 ),
                 Role(
@@ -137,6 +140,9 @@ class RoleSeeder(
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
                             Permissions.HR_APPROVE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
+                            Permissions.PROJECT_APPROVE,
                         ),
                 ),
                 Role(
@@ -168,6 +174,8 @@ class RoleSeeder(
                             Permissions.SALES_WRITE,
                             Permissions.HR_READ,
                             Permissions.HR_WRITE,
+                            Permissions.PROJECT_READ,
+                            Permissions.PROJECT_WRITE,
                         ),
                 ),
                 Role(
@@ -189,6 +197,7 @@ class RoleSeeder(
                             Permissions.PROCUREMENT_READ,
                             Permissions.SALES_READ,
                             Permissions.HR_READ,
+                            Permissions.PROJECT_READ,
                         ),
                 ),
             )

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/AttendanceController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/AttendanceController.kt
@@ -1,0 +1,80 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.AttendanceResponse
+import com.aquinofroilan.tessera.dto.ClockRequest
+import com.aquinofroilan.tessera.dto.RecordAttendanceRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.AttendanceService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/hr/attendance")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class AttendanceController(
+    private val attendanceService: AttendanceService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping("/clock-in")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun clockIn(
+        @Valid @RequestBody request: ClockRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val record = attendanceService.clockIn(request.employeeId, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(AttendanceResponse.from(record))
+    }
+
+    @PostMapping("/clock-out")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun clockOut(
+        @Valid @RequestBody request: ClockRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(AttendanceResponse.from(attendanceService.clockOut(request.employeeId, orgId)))
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun recordAttendance(
+        @Valid @RequestBody request: RecordAttendanceRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val record = attendanceService.recordAttendance(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(AttendanceResponse.from(record))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun listTimesheet(
+        @RequestParam(required = false) employeeId: String?,
+        @RequestParam(required = false) from: LocalDate?,
+        @RequestParam(required = false) to: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(
+            attendanceService.listTimesheet(orgId, employeeId, from, to).map { AttendanceResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getAttendance(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(AttendanceResponse.from(attendanceService.getAttendance(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/AuthController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/AuthController.kt
@@ -3,16 +3,20 @@ package com.aquinofroilan.tessera.controller
 import com.aquinofroilan.tessera.annotation.LogLevel
 import com.aquinofroilan.tessera.annotation.Loggable
 import com.aquinofroilan.tessera.dto.ChangePasswordRequest
+import com.aquinofroilan.tessera.dto.ConsumeLoginLinkRequest
 import com.aquinofroilan.tessera.dto.ForgotPasswordRequest
+import com.aquinofroilan.tessera.dto.LoginLinkIssuedResponse
 import com.aquinofroilan.tessera.dto.LoginRequest
 import com.aquinofroilan.tessera.dto.RefreshRequest
 import com.aquinofroilan.tessera.dto.RegisterRequest
+import com.aquinofroilan.tessera.dto.RequestLoginLinkRequest
 import com.aquinofroilan.tessera.dto.ResetPasswordRequest
 import com.aquinofroilan.tessera.dto.SwitchOrganizationRequest
 import com.aquinofroilan.tessera.exception.AuthenticationException
 import com.aquinofroilan.tessera.model.User
 import com.aquinofroilan.tessera.security.SessionContext
 import com.aquinofroilan.tessera.service.AuthService
+import com.aquinofroilan.tessera.service.LoginLinkService
 import com.github.benmanes.caffeine.cache.Caffeine
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
@@ -34,6 +38,7 @@ import java.util.concurrent.TimeUnit
 @Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
 class AuthController(
     private val authService: AuthService,
+    private val loginLinkService: LoginLinkService,
 ) {
     private val log = LoggerFactory.getLogger(AuthController::class.java)
 
@@ -58,10 +63,18 @@ class AuthController(
             .maximumSize(10_000)
             .build<String, Boolean>()
 
+    private val loginLinkThrottle =
+        Caffeine
+            .newBuilder()
+            .expireAfterWrite(LOGIN_LINK_THROTTLE_MINUTES, TimeUnit.MINUTES)
+            .maximumSize(10_000)
+            .build<String, Boolean>()
+
     companion object {
         private const val MAX_ATTEMPTS = 5
         private const val BLOCK_DURATION_MINUTES = 15L
         private const val FORGOT_PASSWORD_THROTTLE_MINUTES = 2L
+        private const val LOGIN_LINK_THROTTLE_MINUTES = 2L
         private const val MAX_USER_AGENT_LENGTH = 512
         private const val MAX_IP_LENGTH = 45
     }
@@ -160,6 +173,46 @@ class AuthController(
         authService.resetPassword(request.token, request.newPassword)
         return ResponseEntity.ok(mapOf("message" to "Password has been reset successfully"))
     }
+
+    @PostMapping("/login-link/request")
+    fun requestLoginLink(
+        @Valid @RequestBody request: RequestLoginLinkRequest,
+    ): ResponseEntity<Any> {
+        val email = request.email.lowercase(Locale.ROOT)
+        if (loginLinkThrottle.getIfPresent(email) != null) {
+            return ResponseEntity.ok(
+                LoginLinkIssuedResponse("If an account with that email exists, a login link has been sent."),
+            )
+        }
+        loginLinkThrottle.put(email, true)
+        try {
+            loginLinkService.request(email)
+        } catch (e: Exception) {
+            log.error("Login-link request failed", e)
+        }
+        return ResponseEntity.ok(
+            LoginLinkIssuedResponse("If an account with that email exists, a login link has been sent."),
+        )
+    }
+
+    @PostMapping("/login-link/consume")
+    fun consumeLoginLink(
+        @Valid @RequestBody request: ConsumeLoginLinkRequest,
+        httpRequest: HttpServletRequest,
+    ): ResponseEntity<Any> =
+        try {
+            val response =
+                loginLinkService.consume(
+                    rawToken = request.token,
+                    ipAddress = httpRequest.remoteAddr?.take(MAX_IP_LENGTH),
+                    userAgent = httpRequest.getHeader("User-Agent")?.take(MAX_USER_AGENT_LENGTH),
+                )
+            ResponseEntity.ok(response)
+        } catch (e: AuthenticationException) {
+            ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(mapOf("error" to (e.message ?: "Invalid or expired login link")))
+        }
 
     @GetMapping("/organizations")
     fun listOrganizations(): ResponseEntity<Any> {

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/CsvImportExportController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/CsvImportExportController.kt
@@ -1,0 +1,73 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.CsvImportExportService
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/io/csv")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class CsvImportExportController(
+    private val csvService: CsvImportExportService,
+    private val authContext: AuthenticationContext,
+) {
+    @GetMapping("/products/export")
+    @PreAuthorize("hasAuthority('inventory:read')")
+    fun exportProducts(): ResponseEntity<ByteArray> {
+        val orgId = authContext.organizationId() ?: return ResponseEntity.status(401).build()
+        return csv(csvService.exportProducts(orgId), "products.csv")
+    }
+
+    @GetMapping("/customers/export")
+    @PreAuthorize("hasAuthority('sales:read')")
+    fun exportCustomers(): ResponseEntity<ByteArray> {
+        val orgId = authContext.organizationId() ?: return ResponseEntity.status(401).build()
+        return csv(csvService.exportCustomers(orgId), "customers.csv")
+    }
+
+    @GetMapping("/vendors/export")
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun exportVendors(): ResponseEntity<ByteArray> {
+        val orgId = authContext.organizationId() ?: return ResponseEntity.status(401).build()
+        return csv(csvService.exportVendors(orgId), "vendors.csv")
+    }
+
+    @PostMapping("/products/import")
+    @PreAuthorize("hasAuthority('inventory:write')")
+    fun importProducts(
+        @RequestParam("file") file: MultipartFile,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(csvService.importProducts(file.bytes, orgId))
+    }
+
+    @PostMapping("/customers/import")
+    @PreAuthorize("hasAuthority('sales:write')")
+    fun importCustomers(
+        @RequestParam("file") file: MultipartFile,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(csvService.importCustomers(file.bytes, orgId))
+    }
+
+    private fun csv(
+        bytes: ByteArray,
+        filename: String,
+    ): ResponseEntity<ByteArray> =
+        ResponseEntity
+            .ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"$filename\"")
+            .contentType(MediaType.parseMediaType("text/csv"))
+            .body(bytes)
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/DepartmentController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/DepartmentController.kt
@@ -4,6 +4,7 @@ import com.aquinofroilan.tessera.annotation.LogLevel
 import com.aquinofroilan.tessera.annotation.Loggable
 import com.aquinofroilan.tessera.dto.CreateDepartmentRequest
 import com.aquinofroilan.tessera.dto.DepartmentResponse
+import com.aquinofroilan.tessera.dto.SetDepartmentParentRequest
 import com.aquinofroilan.tessera.dto.UpdateDepartmentRequest
 import com.aquinofroilan.tessera.security.AuthenticationContext
 import com.aquinofroilan.tessera.service.DepartmentService
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -47,6 +49,13 @@ class DepartmentController(
         return ResponseEntity.ok(departmentService.listDepartments(orgId, activeOnly).map { DepartmentResponse.from(it) })
     }
 
+    @GetMapping("/org-chart")
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun getOrgChart(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(departmentService.getOrgChart(orgId))
+    }
+
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('hr:read')")
     fun getDepartment(
@@ -64,6 +73,16 @@ class DepartmentController(
     ): ResponseEntity<Any> {
         val orgId = authContext.organizationId() ?: return authContext.unauthorized()
         return ResponseEntity.ok(DepartmentResponse.from(departmentService.updateDepartment(id, request, orgId)))
+    }
+
+    @PutMapping("/{id}/parent")
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun setParent(
+        @PathVariable id: String,
+        @Valid @RequestBody request: SetDepartmentParentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(DepartmentResponse.from(departmentService.setParent(id, request.parentId, orgId)))
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectBillingController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectBillingController.kt
@@ -1,0 +1,44 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.GenerateProjectInvoiceRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.ProjectBillingService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/projects/{projectId}/billing")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProjectBillingController(
+    private val projectBillingService: ProjectBillingService,
+    private val invoiceController: InvoiceController,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping("/invoice")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun generateInvoice(
+        @PathVariable projectId: String,
+        @Valid @RequestBody(required = false) request: GenerateProjectInvoiceRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
+        val invoice =
+            projectBillingService.generateInvoice(
+                projectId,
+                request ?: GenerateProjectInvoiceRequest(),
+                orgId,
+                createdBy,
+            )
+        // Reuse the invoice controller's mapping for a consistent InvoiceResponse.
+        return ResponseEntity.status(HttpStatus.CREATED).body(invoiceController.getInvoice(invoice.id).body)
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectBudgetController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectBudgetController.kt
@@ -1,0 +1,55 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.ProjectBudgetResponse
+import com.aquinofroilan.tessera.dto.SetProjectBudgetRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.ProjectBudgetService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/projects/{projectId}/budget")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProjectBudgetController(
+    private val projectBudgetService: ProjectBudgetService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun setBudget(
+        @PathVariable projectId: String,
+        @Valid @RequestBody request: SetProjectBudgetRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val budget = projectBudgetService.setBudget(projectId, request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ProjectBudgetResponse.from(budget))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listBudgets(
+        @PathVariable projectId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(projectBudgetService.listBudgets(projectId, orgId).map { ProjectBudgetResponse.from(it) })
+    }
+
+    @GetMapping("/vs-actual")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun budgetVsActual(
+        @PathVariable projectId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(projectBudgetService.budgetVsActual(projectId, orgId))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectController.kt
@@ -1,0 +1,116 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.ProjectResponse
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.ProjectService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/projects")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProjectController(
+    private val projectService: ProjectService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createProject(
+        @Valid @RequestBody request: CreateProjectRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val created = projectService.createProject(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ProjectResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listProjects(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) customerId: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val projectStatus =
+            if (status != null) {
+                try {
+                    ProjectStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(projectService.listProjects(orgId, projectStatus, customerId).map { ProjectResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun getProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.getProject(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateProject(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateProjectRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.updateProject(id, request, orgId)))
+    }
+
+    @PostMapping("/{id}/activate")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun activateProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.activateProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/hold")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun holdProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.holdProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/close")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun closeProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.closeProject(id, orgId)))
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun cancelProject(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectResponse.from(projectService.cancelProject(id, orgId)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectTaskController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/ProjectTaskController.kt
@@ -1,0 +1,93 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CreateProjectTaskRequest
+import com.aquinofroilan.tessera.dto.ProjectTaskResponse
+import com.aquinofroilan.tessera.dto.SetTaskParentRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectTaskRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.ProjectTaskService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/projects/{projectId}/tasks")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class ProjectTaskController(
+    private val projectTaskService: ProjectTaskService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createTask(
+        @PathVariable projectId: String,
+        @Valid @RequestBody request: CreateProjectTaskRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val created = projectTaskService.createTask(projectId, request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ProjectTaskResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listTasks(
+        @PathVariable projectId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(projectTaskService.listTasks(projectId, orgId).map { ProjectTaskResponse.from(it) })
+    }
+
+    @GetMapping("/tree")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun taskTree(
+        @PathVariable projectId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(projectTaskService.getTaskTree(projectId, orgId))
+    }
+
+    @GetMapping("/{taskId}")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun getTask(
+        @PathVariable projectId: String,
+        @PathVariable taskId: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectTaskResponse.from(projectTaskService.getTask(projectId, taskId, orgId)))
+    }
+
+    @PatchMapping("/{taskId}")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateTask(
+        @PathVariable projectId: String,
+        @PathVariable taskId: String,
+        @Valid @RequestBody request: UpdateProjectTaskRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(ProjectTaskResponse.from(projectTaskService.updateTask(projectId, taskId, request, orgId)))
+    }
+
+    @PutMapping("/{taskId}/parent")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun setParent(
+        @PathVariable projectId: String,
+        @PathVariable taskId: String,
+        @Valid @RequestBody request: SetTaskParentRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(
+            ProjectTaskResponse.from(projectTaskService.setParent(projectId, taskId, request.parentTaskId, orgId)),
+        )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/PurchaseRequestController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/PurchaseRequestController.kt
@@ -1,0 +1,133 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.PurchaseOrderResponse
+import com.aquinofroilan.tessera.dto.PurchaseRequestResponse
+import com.aquinofroilan.tessera.dto.RejectPurchaseRequestRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.PurchaseRequestService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/procurement/purchase-requests")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class PurchaseRequestController(
+    private val purchaseRequestService: PurchaseRequestService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun createPurchaseRequest(
+        @Valid @RequestBody request: CreatePurchaseRequestRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val requestedBy = authContext.userId() ?: "api-key"
+        val created = purchaseRequestService.createPurchaseRequest(request, orgId, requestedBy)
+        return ResponseEntity.status(HttpStatus.CREATED).body(PurchaseRequestResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun listPurchaseRequests(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) requestedBy: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val prStatus =
+            if (status != null) {
+                try {
+                    PurchaseRequestStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(
+            purchaseRequestService.listPurchaseRequests(orgId, prStatus, requestedBy).map { PurchaseRequestResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun getPurchaseRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PurchaseRequestResponse.from(purchaseRequestService.getPurchaseRequest(id, orgId)))
+    }
+
+    @PostMapping("/{id}/submit")
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun submitPurchaseRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PurchaseRequestResponse.from(purchaseRequestService.submitPurchaseRequest(id, orgId)))
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun approvePurchaseRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val decidedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(PurchaseRequestResponse.from(purchaseRequestService.approvePurchaseRequest(id, orgId, decidedBy)))
+    }
+
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun rejectPurchaseRequest(
+        @PathVariable id: String,
+        @RequestBody(required = false) request: RejectPurchaseRequestRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val decidedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(
+            PurchaseRequestResponse.from(purchaseRequestService.rejectPurchaseRequest(id, request?.reason, orgId, decidedBy)),
+        )
+    }
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun cancelPurchaseRequest(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(PurchaseRequestResponse.from(purchaseRequestService.cancelPurchaseRequest(id, orgId)))
+    }
+
+    @PostMapping("/{id}/convert")
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun convertPurchaseRequest(
+        @PathVariable id: String,
+        @Valid @RequestBody(required = false) request: ConvertPurchaseRequestRequest?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val createdBy = authContext.userId() ?: "api-key"
+        val po =
+            purchaseRequestService.convertToPurchaseOrder(
+                id,
+                request ?: ConvertPurchaseRequestRequest(),
+                orgId,
+                createdBy,
+            )
+        return ResponseEntity.status(HttpStatus.CREATED).body(PurchaseOrderResponse.from(po))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/SelfServiceController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/SelfServiceController.kt
@@ -1,0 +1,95 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.EmployeeCompensationResponse
+import com.aquinofroilan.tessera.dto.EmployeeResponse
+import com.aquinofroilan.tessera.dto.LeaveRequestResponse
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.SelfServiceService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Employee self-service surface. Open to any authenticated user; each endpoint
+ * resolves the caller's own employee record, so a user can only access their
+ * own profile, leave, and compensation.
+ */
+@RestController
+@RequestMapping("/hr/me")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class SelfServiceController(
+    private val selfServiceService: SelfServiceService,
+    private val authContext: AuthenticationContext,
+) {
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myProfile(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(EmployeeResponse.from(selfServiceService.myProfile(userId, orgId)))
+    }
+
+    @GetMapping("/leave-requests")
+    @PreAuthorize("isAuthenticated()")
+    fun myLeaveRequests(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(selfServiceService.myLeaveRequests(userId, orgId).map { LeaveRequestResponse.from(it) })
+    }
+
+    @PostMapping("/leave-requests")
+    @PreAuthorize("isAuthenticated()")
+    fun submitLeave(
+        @Valid @RequestBody request: SubmitSelfLeaveRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        val created = selfServiceService.submitLeave(userId, orgId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(LeaveRequestResponse.from(created))
+    }
+
+    @GetMapping("/leave-balance")
+    @PreAuthorize("isAuthenticated()")
+    fun myLeaveBalance(
+        @RequestParam leaveTypeId: String,
+        @RequestParam(required = false) year: Int?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        val resolvedYear = year ?: LocalDate.now(ZoneOffset.UTC).year
+        return ResponseEntity.ok(selfServiceService.myLeaveBalance(userId, orgId, leaveTypeId, resolvedYear))
+    }
+
+    @GetMapping("/compensation")
+    @PreAuthorize("isAuthenticated()")
+    fun myCompensationHistory(): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(
+            selfServiceService.myCompensationHistory(userId, orgId).map { EmployeeCompensationResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/compensation/current")
+    @PreAuthorize("isAuthenticated()")
+    fun myCurrentCompensation(
+        @RequestParam(required = false) asOf: LocalDate?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val userId = authContext.userId() ?: return authContext.unauthorized()
+        val resolved = asOf ?: LocalDate.now(ZoneOffset.UTC)
+        return ResponseEntity.ok(EmployeeCompensationResponse.from(selfServiceService.myCurrentCompensation(userId, orgId, resolved)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/TimeEntryController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/TimeEntryController.kt
@@ -1,0 +1,112 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.annotation.LogLevel
+import com.aquinofroilan.tessera.annotation.Loggable
+import com.aquinofroilan.tessera.dto.CreateTimeEntryRequest
+import com.aquinofroilan.tessera.dto.TimeEntryResponse
+import com.aquinofroilan.tessera.dto.UpdateTimeEntryRequest
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.TimeEntryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+
+@RestController
+@RequestMapping("/projects/time-entries")
+@Loggable(logParameters = false, logReturnValue = false, level = LogLevel.INFO)
+class TimeEntryController(
+    private val timeEntryService: TimeEntryService,
+    private val authContext: AuthenticationContext,
+) {
+    @PostMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createTimeEntry(
+        @Valid @RequestBody request: CreateTimeEntryRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val created = timeEntryService.createTimeEntry(request, orgId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(TimeEntryResponse.from(created))
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun listTimeEntries(
+        @RequestParam(required = false) employeeId: String?,
+        @RequestParam(required = false) projectId: String?,
+        @RequestParam(required = false) status: String?,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val entryStatus =
+            if (status != null) {
+                try {
+                    TimeEntryStatus.valueOf(status.uppercase(Locale.ROOT))
+                } catch (e: IllegalArgumentException) {
+                    return ResponseEntity.badRequest().body(mapOf("error" to "Invalid status '$status'"))
+                }
+            } else {
+                null
+            }
+        return ResponseEntity.ok(
+            timeEntryService.listTimeEntries(orgId, employeeId, projectId, entryStatus).map { TimeEntryResponse.from(it) },
+        )
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun getTimeEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.getTimeEntry(id, orgId)))
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateTimeEntry(
+        @PathVariable id: String,
+        @Valid @RequestBody request: UpdateTimeEntryRequest,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.updateTimeEntry(id, request, orgId)))
+    }
+
+    @PostMapping("/{id}/submit")
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun submitTimeEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.submitTimeEntry(id, orgId)))
+    }
+
+    @PostMapping("/{id}/approve")
+    @PreAuthorize("hasAuthority('projects:approve')")
+    fun approveTimeEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val approvedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.approveTimeEntry(id, orgId, approvedBy)))
+    }
+
+    @PostMapping("/{id}/reject")
+    @PreAuthorize("hasAuthority('projects:approve')")
+    fun rejectTimeEntry(
+        @PathVariable id: String,
+    ): ResponseEntity<Any> {
+        val orgId = authContext.organizationId() ?: return authContext.unauthorized()
+        val decidedBy = authContext.userId() ?: "api-key"
+        return ResponseEntity.ok(TimeEntryResponse.from(timeEntryService.rejectTimeEntry(id, orgId, decidedBy)))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/AttendanceDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/AttendanceDtos.kt
@@ -1,0 +1,59 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.AttendanceRecord
+import com.aquinofroilan.tessera.model.AttendanceStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class ClockRequest(
+    @field:NotBlank(message = "Employee ID is required")
+    val employeeId: String,
+)
+
+/**
+ * Manual attendance entry/correction for a given day (e.g. recording an
+ * absence or fixing clock times). [status] defaults to PRESENT when omitted.
+ */
+data class RecordAttendanceRequest(
+    @field:NotBlank(message = "Employee ID is required")
+    val employeeId: String,
+    @field:NotNull(message = "Work date is required")
+    val workDate: LocalDate?,
+    val clockIn: LocalDateTime? = null,
+    val clockOut: LocalDateTime? = null,
+    val status: AttendanceStatus? = null,
+    val notes: String? = null,
+)
+
+data class AttendanceResponse(
+    val id: String,
+    val employeeId: String,
+    val workDate: String,
+    val clockIn: String?,
+    val clockOut: String?,
+    val workedMinutes: Int?,
+    val status: AttendanceStatus,
+    val notes: String?,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(record: AttendanceRecord) =
+            AttendanceResponse(
+                id = record.id,
+                employeeId = record.employeeId,
+                workDate = record.workDate.toString(),
+                clockIn = record.clockIn?.toString(),
+                clockOut = record.clockOut?.toString(),
+                workedMinutes = record.workedMinutes,
+                status = record.status,
+                notes = record.notes,
+                organizationId = record.organizationId,
+                createdAt = record.createdAt?.toString(),
+                updatedAt = record.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/CsvIoDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/CsvIoDtos.kt
@@ -1,0 +1,12 @@
+package com.aquinofroilan.tessera.dto
+
+data class CsvImportRowError(
+    val rowNumber: Int,
+    val error: String,
+)
+
+data class CsvImportResult(
+    val rowsParsed: Int,
+    val rowsCreated: Int,
+    val errors: List<CsvImportRowError>,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/DepartmentDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/DepartmentDtos.kt
@@ -11,6 +11,7 @@ data class CreateDepartmentRequest(
     @field:NotBlank(message = "Name is required")
     val name: String,
     val description: String? = null,
+    val parentId: String? = null,
 )
 
 data class UpdateDepartmentRequest(
@@ -18,11 +19,20 @@ data class UpdateDepartmentRequest(
     val description: String? = null,
 )
 
+/**
+ * Sets (or clears) a department's parent for the org chart. A null [parentId]
+ * promotes the department to a root.
+ */
+data class SetDepartmentParentRequest(
+    val parentId: String? = null,
+)
+
 data class DepartmentResponse(
     val id: String,
     val code: String,
     val name: String,
     val description: String?,
+    val parentId: String?,
     val organizationId: String,
     val isActive: Boolean,
     val createdAt: String?,
@@ -35,10 +45,35 @@ data class DepartmentResponse(
                 code = department.code,
                 name = department.name,
                 description = department.description,
+                parentId = department.parentId,
                 organizationId = department.organizationId,
                 isActive = department.isActive,
                 createdAt = department.createdAt?.toString(),
                 updatedAt = department.updatedAt?.toString(),
             )
+    }
+}
+
+/**
+ * A node in the department org chart: the department plus its nested children.
+ */
+data class DepartmentTreeNode(
+    val id: String,
+    val code: String,
+    val name: String,
+    val isActive: Boolean,
+    val children: List<DepartmentTreeNode>,
+) {
+    companion object {
+        fun from(
+            department: Department,
+            children: List<DepartmentTreeNode>,
+        ) = DepartmentTreeNode(
+            id = department.id,
+            code = department.code,
+            name = department.name,
+            isActive = department.isActive,
+            children = children,
+        )
     }
 }

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/EmployeeDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/EmployeeDtos.kt
@@ -16,6 +16,7 @@ data class CreateEmployeeRequest(
     val email: String? = null,
     val jobTitle: String? = null,
     val departmentId: String? = null,
+    val userId: String? = null,
     @field:NotNull(message = "Hire date is required")
     val hireDate: LocalDate?,
 )
@@ -26,6 +27,7 @@ data class UpdateEmployeeRequest(
     @field:Email(message = "Email must be valid")
     val email: String? = null,
     val jobTitle: String? = null,
+    val userId: String? = null,
 )
 
 data class TerminateEmployeeRequest(
@@ -41,6 +43,7 @@ data class EmployeeResponse(
     val email: String?,
     val jobTitle: String?,
     val departmentId: String?,
+    val userId: String?,
     val hireDate: String,
     val status: EmploymentStatus,
     val terminationDate: String?,
@@ -58,6 +61,7 @@ data class EmployeeResponse(
                 email = employee.email,
                 jobTitle = employee.jobTitle,
                 departmentId = employee.departmentId,
+                userId = employee.userId,
                 hireDate = employee.hireDate.toString(),
                 status = employee.status,
                 terminationDate = employee.terminationDate?.toString(),

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/GenerateProjectInvoiceRequest.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/GenerateProjectInvoiceRequest.kt
@@ -1,0 +1,15 @@
+package com.aquinofroilan.tessera.dto
+
+import java.time.LocalDate
+
+/**
+ * Options for generating a sales invoice from a project's billable time.
+ * [revenueAccountId] falls back to the customer's default revenue account;
+ * [date] defaults to today and [dueDate] to date + the customer's payment term.
+ */
+data class GenerateProjectInvoiceRequest(
+    val revenueAccountId: String? = null,
+    val date: LocalDate? = null,
+    val dueDate: LocalDate? = null,
+    val currencyCode: String? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/LoginLinkDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/LoginLinkDtos.kt
@@ -1,0 +1,24 @@
+package com.aquinofroilan.tessera.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class RequestLoginLinkRequest(
+    @field:NotBlank(message = "Email is required")
+    @field:Email(message = "Invalid email format")
+    val email: String,
+)
+
+data class ConsumeLoginLinkRequest(
+    @field:NotBlank(message = "Token is required")
+    val token: String,
+)
+
+/**
+ * Returned only in dev / test convenience flows. In production the raw
+ * token is delivered out-of-band via email; the request endpoint returns
+ * a generic message regardless of whether the email exists.
+ */
+data class LoginLinkIssuedResponse(
+    val message: String,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectBudgetDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectBudgetDtos.kt
@@ -1,0 +1,54 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.ProjectBudget
+import com.aquinofroilan.tessera.model.ProjectCostCategory
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+
+data class SetProjectBudgetRequest(
+    @field:NotNull(message = "Category is required")
+    val category: ProjectCostCategory?,
+    @field:NotNull(message = "Budget amount is required")
+    val budgetAmount: BigDecimal?,
+    val currency: String? = null,
+)
+
+data class ProjectBudgetResponse(
+    val id: String,
+    val projectId: String,
+    val category: ProjectCostCategory,
+    val budgetAmount: BigDecimal,
+    val currency: String?,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(budget: ProjectBudget) =
+            ProjectBudgetResponse(
+                id = budget.id,
+                projectId = budget.projectId,
+                category = budget.category,
+                budgetAmount = budget.budgetAmount,
+                currency = budget.currency,
+                organizationId = budget.organizationId,
+                createdAt = budget.createdAt?.toString(),
+                updatedAt = budget.updatedAt?.toString(),
+            )
+    }
+}
+
+data class BudgetVarianceLine(
+    val category: ProjectCostCategory,
+    val budgeted: BigDecimal,
+    val actual: BigDecimal,
+    val remaining: BigDecimal,
+)
+
+data class ProjectBudgetVsActualResponse(
+    val projectId: String,
+    val lines: List<BudgetVarianceLine>,
+    val totalBudgeted: BigDecimal,
+    val totalActual: BigDecimal,
+    val totalRemaining: BigDecimal,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectDtos.kt
@@ -1,0 +1,64 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectBillingType
+import com.aquinofroilan.tessera.model.ProjectStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class CreateProjectRequest(
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    val description: String? = null,
+    val customerId: String? = null,
+    val managerEmployeeId: String? = null,
+    @field:NotNull(message = "Start date is required")
+    val startDate: LocalDate?,
+    val endDate: LocalDate? = null,
+    val billingType: ProjectBillingType? = null,
+)
+
+data class UpdateProjectRequest(
+    val name: String? = null,
+    val description: String? = null,
+    val customerId: String? = null,
+    val managerEmployeeId: String? = null,
+    val endDate: LocalDate? = null,
+    val billingType: ProjectBillingType? = null,
+)
+
+data class ProjectResponse(
+    val id: String,
+    val projectNumber: String,
+    val name: String,
+    val description: String?,
+    val customerId: String?,
+    val managerEmployeeId: String?,
+    val startDate: String,
+    val endDate: String?,
+    val status: ProjectStatus,
+    val billingType: ProjectBillingType,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(project: Project) =
+            ProjectResponse(
+                id = project.id,
+                projectNumber = project.projectNumber,
+                name = project.name,
+                description = project.description,
+                customerId = project.customerId,
+                managerEmployeeId = project.managerEmployeeId,
+                startDate = project.startDate.toString(),
+                endDate = project.endDate?.toString(),
+                status = project.status,
+                billingType = project.billingType,
+                organizationId = project.organizationId,
+                createdAt = project.createdAt?.toString(),
+                updatedAt = project.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectTaskDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/ProjectTaskDtos.kt
@@ -1,0 +1,81 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.ProjectTask
+import com.aquinofroilan.tessera.model.TaskStatus
+import jakarta.validation.constraints.NotBlank
+import java.math.BigDecimal
+
+data class CreateProjectTaskRequest(
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    val description: String? = null,
+    val parentTaskId: String? = null,
+    val assigneeEmployeeId: String? = null,
+    val estimatedHours: BigDecimal? = null,
+)
+
+data class UpdateProjectTaskRequest(
+    val name: String? = null,
+    val description: String? = null,
+    val assigneeEmployeeId: String? = null,
+    val estimatedHours: BigDecimal? = null,
+    val status: TaskStatus? = null,
+)
+
+/** Sets or clears a task's parent within the same project. */
+data class SetTaskParentRequest(
+    val parentTaskId: String? = null,
+)
+
+data class ProjectTaskResponse(
+    val id: String,
+    val projectId: String,
+    val parentTaskId: String?,
+    val name: String,
+    val description: String?,
+    val assigneeEmployeeId: String?,
+    val estimatedHours: BigDecimal?,
+    val status: TaskStatus,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(task: ProjectTask) =
+            ProjectTaskResponse(
+                id = task.id,
+                projectId = task.projectId,
+                parentTaskId = task.parentTaskId,
+                name = task.name,
+                description = task.description,
+                assigneeEmployeeId = task.assigneeEmployeeId,
+                estimatedHours = task.estimatedHours,
+                status = task.status,
+                organizationId = task.organizationId,
+                createdAt = task.createdAt?.toString(),
+                updatedAt = task.updatedAt?.toString(),
+            )
+    }
+}
+
+/** A node in the project work-breakdown tree: the task plus its nested children. */
+data class ProjectTaskTreeNode(
+    val id: String,
+    val name: String,
+    val status: TaskStatus,
+    val assigneeEmployeeId: String?,
+    val children: List<ProjectTaskTreeNode>,
+) {
+    companion object {
+        fun from(
+            task: ProjectTask,
+            children: List<ProjectTaskTreeNode>,
+        ) = ProjectTaskTreeNode(
+            id = task.id,
+            name = task.name,
+            status = task.status,
+            assigneeEmployeeId = task.assigneeEmployeeId,
+            children = children,
+        )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/PurchaseRequestDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/PurchaseRequestDtos.kt
@@ -1,0 +1,116 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.PurchaseRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreatePurchaseRequestLineRequest(
+    @field:NotBlank(message = "Product ID is required")
+    val productId: String,
+    @field:NotNull(message = "Quantity is required")
+    @field:Positive(message = "Quantity must be positive")
+    val quantity: BigDecimal?,
+    val estimatedUnitCost: BigDecimal? = null,
+    val description: String? = null,
+)
+
+data class CreatePurchaseRequestRequest(
+    val suggestedVendorId: String? = null,
+    val warehouseId: String? = null,
+    val justification: String? = null,
+    @field:NotEmpty(message = "At least one line item is required")
+    @field:Valid
+    val lines: List<CreatePurchaseRequestLineRequest>,
+)
+
+data class RejectPurchaseRequestRequest(
+    val reason: String? = null,
+)
+
+/**
+ * Per-line unit-cost override applied when converting a request into a PO.
+ * Lines without an override fall back to their estimated unit cost.
+ */
+data class ConvertPurchaseRequestLineCost(
+    @field:NotBlank(message = "Line ID is required")
+    val lineId: String,
+    @field:NotNull(message = "Unit cost is required")
+    val unitCost: BigDecimal?,
+)
+
+data class ConvertPurchaseRequestRequest(
+    val vendorId: String? = null,
+    val warehouseId: String? = null,
+    val orderDate: LocalDate? = null,
+    val expectedDate: LocalDate? = null,
+    @field:Valid
+    val lineCosts: List<ConvertPurchaseRequestLineCost>? = null,
+)
+
+data class PurchaseRequestLineResponse(
+    val id: String,
+    val lineNumber: Int,
+    val productId: String,
+    val productSku: String,
+    val productName: String,
+    val quantity: BigDecimal,
+    val estimatedUnitCost: BigDecimal?,
+    val description: String?,
+)
+
+data class PurchaseRequestResponse(
+    val id: String,
+    val prNumber: String,
+    val organizationId: String,
+    val status: PurchaseRequestStatus,
+    val suggestedVendorId: String?,
+    val warehouseId: String?,
+    val justification: String?,
+    val lines: List<PurchaseRequestLineResponse>,
+    val requestedBy: String,
+    val decidedBy: String?,
+    val decidedAt: String?,
+    val decisionReason: String?,
+    val convertedPurchaseOrderId: String?,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(request: PurchaseRequest) =
+            PurchaseRequestResponse(
+                id = request.id,
+                prNumber = request.prNumber,
+                organizationId = request.organizationId,
+                status = request.status,
+                suggestedVendorId = request.suggestedVendorId,
+                warehouseId = request.warehouseId,
+                justification = request.justification,
+                lines =
+                    request.lines.map { line ->
+                        PurchaseRequestLineResponse(
+                            id = line.id,
+                            lineNumber = line.lineNumber,
+                            productId = line.productId,
+                            productSku = line.productSku,
+                            productName = line.productName,
+                            quantity = line.quantity,
+                            estimatedUnitCost = line.estimatedUnitCost,
+                            description = line.description,
+                        )
+                    },
+                requestedBy = request.requestedBy,
+                decidedBy = request.decidedBy,
+                decidedAt = request.decidedAt?.toString(),
+                decisionReason = request.decisionReason,
+                convertedPurchaseOrderId = request.convertedPurchaseOrderId,
+                createdAt = request.createdAt?.toString(),
+                updatedAt = request.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/SubmitSelfLeaveRequest.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/SubmitSelfLeaveRequest.kt
@@ -1,0 +1,19 @@
+package com.aquinofroilan.tessera.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+/**
+ * A leave request submitted by an employee for themselves. The employee is
+ * resolved from the authenticated user, so no employee ID is supplied.
+ */
+data class SubmitSelfLeaveRequest(
+    @field:NotBlank(message = "Leave type ID is required")
+    val leaveTypeId: String,
+    @field:NotNull(message = "Start date is required")
+    val startDate: LocalDate?,
+    @field:NotNull(message = "End date is required")
+    val endDate: LocalDate?,
+    val reason: String? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/dto/TimeEntryDtos.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/dto/TimeEntryDtos.kt
@@ -1,0 +1,74 @@
+package com.aquinofroilan.tessera.dto
+
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreateTimeEntryRequest(
+    @field:NotBlank(message = "Employee ID is required")
+    val employeeId: String,
+    @field:NotBlank(message = "Project ID is required")
+    val projectId: String,
+    val taskId: String? = null,
+    @field:NotNull(message = "Entry date is required")
+    val entryDate: LocalDate?,
+    @field:NotNull(message = "Hours are required")
+    @field:Positive(message = "Hours must be positive")
+    val hours: BigDecimal?,
+    val billable: Boolean = true,
+    val rate: BigDecimal? = null,
+    val notes: String? = null,
+)
+
+data class UpdateTimeEntryRequest(
+    val taskId: String? = null,
+    val entryDate: LocalDate? = null,
+    @field:Positive(message = "Hours must be positive")
+    val hours: BigDecimal? = null,
+    val billable: Boolean? = null,
+    val rate: BigDecimal? = null,
+    val notes: String? = null,
+)
+
+data class TimeEntryResponse(
+    val id: String,
+    val employeeId: String,
+    val projectId: String,
+    val taskId: String?,
+    val entryDate: String,
+    val hours: BigDecimal,
+    val billable: Boolean,
+    val rate: BigDecimal?,
+    val status: TimeEntryStatus,
+    val notes: String?,
+    val approvedBy: String?,
+    val approvedAt: String?,
+    val organizationId: String,
+    val createdAt: String?,
+    val updatedAt: String?,
+) {
+    companion object {
+        fun from(entry: TimeEntry) =
+            TimeEntryResponse(
+                id = entry.id,
+                employeeId = entry.employeeId,
+                projectId = entry.projectId,
+                taskId = entry.taskId,
+                entryDate = entry.entryDate.toString(),
+                hours = entry.hours,
+                billable = entry.billable,
+                rate = entry.rate,
+                status = entry.status,
+                notes = entry.notes,
+                approvedBy = entry.approvedBy,
+                approvedAt = entry.approvedAt?.toString(),
+                organizationId = entry.organizationId,
+                createdAt = entry.createdAt?.toString(),
+                updatedAt = entry.updatedAt?.toString(),
+            )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/AttendanceGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/AttendanceGraphqlController.kt
@@ -1,0 +1,54 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.AttendanceController
+import com.aquinofroilan.tessera.dto.ClockRequest
+import com.aquinofroilan.tessera.dto.RecordAttendanceRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+import java.time.LocalDate
+
+/**
+ * GraphQL bridge for the HR attendance routes — clock-in/out, manual entry and
+ * timesheets — delegating to the REST controller via the shared JSON-scalar
+ * pass-through. Authorization mirrors the REST endpoints (`hr:read`/`hr:write`).
+ */
+@Controller
+class AttendanceGraphqlController(
+    private val attendanceController: AttendanceController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun attendance(
+        @Argument employeeId: String?,
+        @Argument from: String?,
+        @Argument to: String?,
+    ): Any = support.unwrap(attendanceController.listTimesheet(employeeId, from?.let(LocalDate::parse), to?.let(LocalDate::parse)))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun attendanceRecord(
+        @Argument id: String,
+    ): Any = support.unwrap(attendanceController.getAttendance(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun clockIn(
+        @Argument input: Any,
+    ): Any = support.unwrap(attendanceController.clockIn(support.toRequest<ClockRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun clockOut(
+        @Argument input: Any,
+    ): Any = support.unwrap(attendanceController.clockOut(support.toRequest<ClockRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun recordAttendance(
+        @Argument input: Any,
+    ): Any = support.unwrap(attendanceController.recordAttendance(support.toRequest<RecordAttendanceRequest>(input)))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlController.kt
@@ -15,6 +15,7 @@ import com.aquinofroilan.tessera.dto.CreateLeaveTypeRequest
 import com.aquinofroilan.tessera.dto.CreatePayrollRunRequest
 import com.aquinofroilan.tessera.dto.CreatePositionRequest
 import com.aquinofroilan.tessera.dto.RejectLeaveRequestRequest
+import com.aquinofroilan.tessera.dto.SetDepartmentParentRequest
 import com.aquinofroilan.tessera.dto.TerminateEmployeeRequest
 import com.aquinofroilan.tessera.dto.UpdateDepartmentRequest
 import com.aquinofroilan.tessera.dto.UpdateEmployeeRequest
@@ -92,6 +93,10 @@ class HrGraphqlController(
         @Argument id: String,
     ): Any = support.unwrap(departmentController.getDepartment(id))
 
+    @QueryMapping
+    @PreAuthorize("hasAuthority('hr:read')")
+    fun departmentOrgChart(): Any = support.unwrap(departmentController.getOrgChart())
+
     @MutationMapping
     @PreAuthorize("hasAuthority('hr:write')")
     fun createDepartment(
@@ -104,6 +109,16 @@ class HrGraphqlController(
         @Argument id: String,
         @Argument input: Any,
     ): Any = support.unwrap(departmentController.updateDepartment(id, support.toRequest<UpdateDepartmentRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('hr:write')")
+    fun setDepartmentParent(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<SetDepartmentParentRequest>(it) } ?: SetDepartmentParentRequest()
+        return support.unwrap(departmentController.setParent(id, request))
+    }
 
     @MutationMapping
     @PreAuthorize("hasAuthority('hr:write')")

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectBillingGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectBillingGraphqlController.kt
@@ -1,0 +1,29 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.ProjectBillingController
+import com.aquinofroilan.tessera.dto.GenerateProjectInvoiceRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for project billing, delegating to the REST controller via the
+ * shared JSON-scalar pass-through. Authorization mirrors the REST endpoint
+ * (`projects:write`).
+ */
+@Controller
+class ProjectBillingGraphqlController(
+    private val projectBillingController: ProjectBillingController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun generateProjectInvoice(
+        @Argument projectId: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<GenerateProjectInvoiceRequest>(it) }
+        return support.unwrap(projectBillingController.generateInvoice(projectId, request))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectBudgetGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectBudgetGraphqlController.kt
@@ -1,0 +1,39 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.ProjectBudgetController
+import com.aquinofroilan.tessera.dto.SetProjectBudgetRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for project budgets, delegating to the REST controller via the
+ * shared JSON-scalar pass-through. Authorization mirrors the REST endpoints
+ * (`projects:read`/`projects:write`).
+ */
+@Controller
+class ProjectBudgetGraphqlController(
+    private val projectBudgetController: ProjectBudgetController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectBudgets(
+        @Argument projectId: String,
+    ): Any = support.unwrap(projectBudgetController.listBudgets(projectId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectBudgetVsActual(
+        @Argument projectId: String,
+    ): Any = support.unwrap(projectBudgetController.budgetVsActual(projectId))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun setProjectBudget(
+        @Argument projectId: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectBudgetController.setBudget(projectId, support.toRequest<SetProjectBudgetRequest>(input)))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlController.kt
@@ -1,0 +1,71 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.ProjectController
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for the project routes, delegating to the REST controller via
+ * the shared JSON-scalar pass-through. Authorization mirrors the REST endpoints
+ * (`projects:read`/`projects:write`).
+ */
+@Controller
+class ProjectGraphqlController(
+    private val projectController: ProjectController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projects(
+        @Argument status: String?,
+        @Argument customerId: String?,
+    ): Any = support.unwrap(projectController.listProjects(status, customerId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun project(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.getProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createProject(
+        @Argument input: Any,
+    ): Any = support.unwrap(projectController.createProject(support.toRequest<CreateProjectRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateProject(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectController.updateProject(id, support.toRequest<UpdateProjectRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun activateProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.activateProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun holdProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.holdProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun closeProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.closeProject(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun cancelProject(
+        @Argument id: String,
+    ): Any = support.unwrap(projectController.cancelProject(id))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectTaskGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/ProjectTaskGraphqlController.kt
@@ -1,0 +1,67 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.ProjectTaskController
+import com.aquinofroilan.tessera.dto.CreateProjectTaskRequest
+import com.aquinofroilan.tessera.dto.SetTaskParentRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectTaskRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for project tasks (work breakdown structure), delegating to the
+ * REST controller via the shared JSON-scalar pass-through. Authorization mirrors
+ * the REST endpoints (`projects:read`/`projects:write`).
+ */
+@Controller
+class ProjectTaskGraphqlController(
+    private val projectTaskController: ProjectTaskController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectTasks(
+        @Argument projectId: String,
+    ): Any = support.unwrap(projectTaskController.listTasks(projectId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectTaskTree(
+        @Argument projectId: String,
+    ): Any = support.unwrap(projectTaskController.taskTree(projectId))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun projectTask(
+        @Argument projectId: String,
+        @Argument taskId: String,
+    ): Any = support.unwrap(projectTaskController.getTask(projectId, taskId))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createProjectTask(
+        @Argument projectId: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectTaskController.createTask(projectId, support.toRequest<CreateProjectTaskRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateProjectTask(
+        @Argument projectId: String,
+        @Argument taskId: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(projectTaskController.updateTask(projectId, taskId, support.toRequest<UpdateProjectTaskRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun setProjectTaskParent(
+        @Argument projectId: String,
+        @Argument taskId: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<SetTaskParentRequest>(it) } ?: SetTaskParentRequest()
+        return support.unwrap(projectTaskController.setParent(projectId, taskId, request))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/PurchaseRequestGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/PurchaseRequestGraphqlController.kt
@@ -1,0 +1,79 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.PurchaseRequestController
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.RejectPurchaseRequestRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for the procurement purchase-request (requisition) routes,
+ * delegating to the REST controller via the shared JSON-scalar pass-through.
+ * Authorization mirrors the REST endpoints (`procurement:read`/`:write`/`:approve`).
+ */
+@Controller
+class PurchaseRequestGraphqlController(
+    private val purchaseRequestController: PurchaseRequestController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun purchaseRequests(
+        @Argument status: String?,
+        @Argument requestedBy: String?,
+    ): Any = support.unwrap(purchaseRequestController.listPurchaseRequests(status, requestedBy))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('procurement:read')")
+    fun purchaseRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseRequestController.getPurchaseRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun createPurchaseRequest(
+        @Argument input: Any,
+    ): Any = support.unwrap(purchaseRequestController.createPurchaseRequest(support.toRequest<CreatePurchaseRequestRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun submitPurchaseRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseRequestController.submitPurchaseRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun approvePurchaseRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseRequestController.approvePurchaseRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:approve')")
+    fun rejectPurchaseRequest(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<RejectPurchaseRequestRequest>(it) }
+        return support.unwrap(purchaseRequestController.rejectPurchaseRequest(id, request))
+    }
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun cancelPurchaseRequest(
+        @Argument id: String,
+    ): Any = support.unwrap(purchaseRequestController.cancelPurchaseRequest(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('procurement:write')")
+    fun convertPurchaseRequest(
+        @Argument id: String,
+        @Argument input: Any?,
+    ): Any {
+        val request = input?.let { support.toRequest<ConvertPurchaseRequestRequest>(it) }
+        return support.unwrap(purchaseRequestController.convertPurchaseRequest(id, request))
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/SelfServiceGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/SelfServiceGraphqlController.kt
@@ -1,0 +1,53 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.SelfServiceController
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+import java.time.LocalDate
+
+/**
+ * GraphQL bridge for the employee self-service routes (`/hr/me`), delegating to
+ * the REST controller via the shared JSON-scalar pass-through. Open to any
+ * authenticated user; the controller resolves the caller's own employee record,
+ * so a user can only ever see or act on their own data.
+ */
+@Controller
+class SelfServiceGraphqlController(
+    private val selfServiceController: SelfServiceController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun me(): Any = support.unwrap(selfServiceController.myProfile())
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myLeaveRequests(): Any = support.unwrap(selfServiceController.myLeaveRequests())
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myLeaveBalance(
+        @Argument leaveTypeId: String,
+        @Argument year: Int?,
+    ): Any = support.unwrap(selfServiceController.myLeaveBalance(leaveTypeId, year))
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myCompensation(): Any = support.unwrap(selfServiceController.myCompensationHistory())
+
+    @QueryMapping
+    @PreAuthorize("isAuthenticated()")
+    fun myCurrentCompensation(
+        @Argument asOf: String?,
+    ): Any = support.unwrap(selfServiceController.myCurrentCompensation(asOf?.let(LocalDate::parse)))
+
+    @MutationMapping
+    @PreAuthorize("isAuthenticated()")
+    fun submitMyLeave(
+        @Argument input: Any,
+    ): Any = support.unwrap(selfServiceController.submitLeave(support.toRequest<SubmitSelfLeaveRequest>(input)))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/TimeEntryGraphqlController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/TimeEntryGraphqlController.kt
@@ -1,0 +1,66 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.controller.TimeEntryController
+import com.aquinofroilan.tessera.dto.CreateTimeEntryRequest
+import com.aquinofroilan.tessera.dto.UpdateTimeEntryRequest
+import org.springframework.graphql.data.method.annotation.Argument
+import org.springframework.graphql.data.method.annotation.MutationMapping
+import org.springframework.graphql.data.method.annotation.QueryMapping
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+
+/**
+ * GraphQL bridge for project time entries (timesheets), delegating to the REST
+ * controller via the shared JSON-scalar pass-through. Authorization mirrors the
+ * REST endpoints (`projects:read`/`projects:write`/`projects:approve`).
+ */
+@Controller
+class TimeEntryGraphqlController(
+    private val timeEntryController: TimeEntryController,
+    private val support: GraphqlBridgeSupport,
+) {
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun timeEntries(
+        @Argument employeeId: String?,
+        @Argument projectId: String?,
+        @Argument status: String?,
+    ): Any = support.unwrap(timeEntryController.listTimeEntries(employeeId, projectId, status))
+
+    @QueryMapping
+    @PreAuthorize("hasAuthority('projects:read')")
+    fun timeEntry(
+        @Argument id: String,
+    ): Any = support.unwrap(timeEntryController.getTimeEntry(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun createTimeEntry(
+        @Argument input: Any,
+    ): Any = support.unwrap(timeEntryController.createTimeEntry(support.toRequest<CreateTimeEntryRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun updateTimeEntry(
+        @Argument id: String,
+        @Argument input: Any,
+    ): Any = support.unwrap(timeEntryController.updateTimeEntry(id, support.toRequest<UpdateTimeEntryRequest>(input)))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:write')")
+    fun submitTimeEntry(
+        @Argument id: String,
+    ): Any = support.unwrap(timeEntryController.submitTimeEntry(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:approve')")
+    fun approveTimeEntry(
+        @Argument id: String,
+    ): Any = support.unwrap(timeEntryController.approveTimeEntry(id))
+
+    @MutationMapping
+    @PreAuthorize("hasAuthority('projects:approve')")
+    fun rejectTimeEntry(
+        @Argument id: String,
+    ): Any = support.unwrap(timeEntryController.rejectTimeEntry(id))
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/AttendanceRecord.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/AttendanceRecord.kt
@@ -1,0 +1,51 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class AttendanceStatus {
+    PRESENT,
+    ABSENT,
+    ON_LEAVE,
+}
+
+@Entity
+@Table(name = "attendance_records")
+@EntityListeners(AuditingEntityListener::class)
+data class AttendanceRecord(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "employee_id", columnDefinition = "uuid")
+    val employeeId: String,
+    @Column(name = "work_date")
+    val workDate: LocalDate,
+    @Column(name = "clock_in")
+    val clockIn: LocalDateTime? = null,
+    @Column(name = "clock_out")
+    val clockOut: LocalDateTime? = null,
+    @Column(name = "worked_minutes")
+    val workedMinutes: Int? = null,
+    @Enumerated(EnumType.STRING)
+    val status: AttendanceStatus = AttendanceStatus.PRESENT,
+    val notes: String? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Department.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Department.kt
@@ -21,6 +21,8 @@ data class Department(
     val code: String,
     val name: String,
     val description: String? = null,
+    @Column(name = "parent_id", columnDefinition = "uuid")
+    val parentId: String? = null,
     @Column(name = "organization_id", columnDefinition = "uuid")
     val organizationId: String,
     @Column(name = "is_active")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Employee.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Employee.kt
@@ -38,6 +38,8 @@ data class Employee(
     val jobTitle: String? = null,
     @Column(name = "department_id", columnDefinition = "uuid")
     val departmentId: String? = null,
+    @Column(name = "user_id", columnDefinition = "uuid")
+    val userId: String? = null,
     @Column(name = "hire_date")
     val hireDate: LocalDate,
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/LoginLinkToken.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/LoginLinkToken.kt
@@ -1,0 +1,31 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+@Entity
+@Table(name = "login_link_tokens")
+data class LoginLinkToken(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "token_hash")
+    val tokenHash: String,
+    @Column(name = "user_id", columnDefinition = "uuid")
+    val userId: String,
+    @Column(name = "expiry_at")
+    val expiryAt: LocalDateTime,
+    @Column(name = "consumed_at")
+    val consumedAt: LocalDateTime? = null,
+    @Column(name = "ip_address")
+    val ipAddress: String? = null,
+    @Column(name = "user_agent")
+    val userAgent: String? = null,
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Project.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Project.kt
@@ -1,0 +1,63 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class ProjectStatus {
+    PLANNED,
+    ACTIVE,
+    ON_HOLD,
+    CLOSED,
+    CANCELLED,
+}
+
+enum class ProjectBillingType {
+    TIME_AND_MATERIALS,
+    FIXED_PRICE,
+    MILESTONE,
+}
+
+@Entity
+@Table(name = "projects")
+@EntityListeners(AuditingEntityListener::class)
+data class Project(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "project_number")
+    val projectNumber: String,
+    val name: String,
+    val description: String? = null,
+    @Column(name = "customer_id", columnDefinition = "uuid")
+    val customerId: String? = null,
+    @Column(name = "manager_employee_id", columnDefinition = "uuid")
+    val managerEmployeeId: String? = null,
+    @Column(name = "start_date")
+    val startDate: LocalDate,
+    @Column(name = "end_date")
+    val endDate: LocalDate? = null,
+    @Enumerated(EnumType.STRING)
+    val status: ProjectStatus = ProjectStatus.PLANNED,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "billing_type")
+    val billingType: ProjectBillingType = ProjectBillingType.TIME_AND_MATERIALS,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectBudget.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectBudget.kt
@@ -1,0 +1,46 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class ProjectCostCategory {
+    LABOR,
+    MATERIAL,
+    EXPENSE,
+    OTHER,
+}
+
+@Entity
+@Table(name = "project_budgets")
+@EntityListeners(AuditingEntityListener::class)
+data class ProjectBudget(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "project_id", columnDefinition = "uuid")
+    val projectId: String,
+    @Enumerated(EnumType.STRING)
+    val category: ProjectCostCategory,
+    @Column(name = "budget_amount")
+    val budgetAmount: BigDecimal,
+    val currency: String? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectTask.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectTask.kt
@@ -1,0 +1,51 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class TaskStatus {
+    TODO,
+    IN_PROGRESS,
+    DONE,
+    CANCELLED,
+}
+
+@Entity
+@Table(name = "project_tasks")
+@EntityListeners(AuditingEntityListener::class)
+data class ProjectTask(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "project_id", columnDefinition = "uuid")
+    val projectId: String,
+    @Column(name = "parent_task_id", columnDefinition = "uuid")
+    val parentTaskId: String? = null,
+    val name: String,
+    val description: String? = null,
+    @Column(name = "assignee_employee_id", columnDefinition = "uuid")
+    val assigneeEmployeeId: String? = null,
+    @Column(name = "estimated_hours")
+    val estimatedHours: BigDecimal? = null,
+    @Enumerated(EnumType.STRING)
+    val status: TaskStatus = TaskStatus.TODO,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/PurchaseRequest.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/PurchaseRequest.kt
@@ -1,0 +1,89 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class PurchaseRequestStatus {
+    DRAFT,
+    SUBMITTED,
+    APPROVED,
+    REJECTED,
+    CONVERTED,
+    CANCELLED,
+}
+
+@Entity
+@Table(name = "purchase_request_lines")
+data class PurchaseRequestLine(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "line_number")
+    val lineNumber: Int = 0,
+    @Column(name = "product_id", columnDefinition = "uuid")
+    val productId: String,
+    @Column(name = "product_sku")
+    val productSku: String,
+    @Column(name = "product_name")
+    val productName: String,
+    val quantity: BigDecimal,
+    @Column(name = "estimated_unit_cost")
+    val estimatedUnitCost: BigDecimal? = null,
+    val description: String? = null,
+)
+
+@Entity
+@Table(name = "purchase_requests")
+@EntityListeners(AuditingEntityListener::class)
+data class PurchaseRequest(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "pr_number")
+    val prNumber: String,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @Enumerated(EnumType.STRING)
+    val status: PurchaseRequestStatus = PurchaseRequestStatus.DRAFT,
+    @Column(name = "suggested_vendor_id", columnDefinition = "uuid")
+    val suggestedVendorId: String? = null,
+    @Column(name = "warehouse_id", columnDefinition = "uuid")
+    val warehouseId: String? = null,
+    val justification: String? = null,
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "purchase_request_id")
+    @OrderBy("lineNumber ASC")
+    val lines: List<PurchaseRequestLine>,
+    @Column(name = "requested_by", columnDefinition = "uuid")
+    val requestedBy: String,
+    @Column(name = "decided_by", columnDefinition = "uuid")
+    val decidedBy: String? = null,
+    @Column(name = "decided_at")
+    val decidedAt: LocalDateTime? = null,
+    @Column(name = "decision_reason")
+    val decisionReason: String? = null,
+    @Column(name = "converted_purchase_order_id", columnDefinition = "uuid")
+    val convertedPurchaseOrderId: String? = null,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/TimeEntry.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/TimeEntry.kt
@@ -47,6 +47,9 @@ data class TimeEntry(
     val approvedBy: String? = null,
     @Column(name = "approved_at")
     val approvedAt: LocalDateTime? = null,
+    val invoiced: Boolean = false,
+    @Column(name = "invoice_id", columnDefinition = "uuid")
+    val invoiceId: String? = null,
     @Column(name = "organization_id", columnDefinition = "uuid")
     val organizationId: String,
     @CreatedDate

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/TimeEntry.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/TimeEntry.kt
@@ -1,0 +1,58 @@
+package com.aquinofroilan.tessera.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+enum class TimeEntryStatus {
+    DRAFT,
+    SUBMITTED,
+    APPROVED,
+    REJECTED,
+}
+
+@Entity
+@Table(name = "time_entries")
+@EntityListeners(AuditingEntityListener::class)
+data class TimeEntry(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: String = UUID.randomUUID().toString(),
+    @Column(name = "employee_id", columnDefinition = "uuid")
+    val employeeId: String,
+    @Column(name = "project_id", columnDefinition = "uuid")
+    val projectId: String,
+    @Column(name = "task_id", columnDefinition = "uuid")
+    val taskId: String? = null,
+    @Column(name = "entry_date")
+    val entryDate: LocalDate,
+    val hours: BigDecimal,
+    val billable: Boolean = true,
+    val rate: BigDecimal? = null,
+    @Enumerated(EnumType.STRING)
+    val status: TimeEntryStatus = TimeEntryStatus.DRAFT,
+    val notes: String? = null,
+    @Column(name = "approved_by", columnDefinition = "uuid")
+    val approvedBy: String? = null,
+    @Column(name = "approved_at")
+    val approvedAt: LocalDateTime? = null,
+    @Column(name = "organization_id", columnDefinition = "uuid")
+    val organizationId: String,
+    @CreatedDate
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime? = null,
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    val updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/AttendanceRecordRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/AttendanceRecordRepository.kt
@@ -1,0 +1,36 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.AttendanceRecord
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.util.Optional
+
+@Repository
+interface AttendanceRecordRepository : JpaRepository<AttendanceRecord, String> {
+    fun findByOrganizationId(organizationId: String): List<AttendanceRecord>
+
+    fun findByOrganizationIdAndEmployeeId(
+        organizationId: String,
+        employeeId: String,
+    ): List<AttendanceRecord>
+
+    fun findByOrganizationIdAndEmployeeIdAndWorkDate(
+        organizationId: String,
+        employeeId: String,
+        workDate: LocalDate,
+    ): Optional<AttendanceRecord>
+
+    fun findByOrganizationIdAndWorkDateBetween(
+        organizationId: String,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<AttendanceRecord>
+
+    fun findByOrganizationIdAndEmployeeIdAndWorkDateBetween(
+        organizationId: String,
+        employeeId: String,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<AttendanceRecord>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/EmployeeRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/EmployeeRepository.kt
@@ -4,10 +4,16 @@ import com.aquinofroilan.tessera.model.Employee
 import com.aquinofroilan.tessera.model.EmploymentStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 
 @Repository
 interface EmployeeRepository : JpaRepository<Employee, String> {
     fun findByOrganizationId(organizationId: String): List<Employee>
+
+    fun findByOrganizationIdAndUserId(
+        organizationId: String,
+        userId: String,
+    ): Optional<Employee>
 
     fun findByOrganizationIdAndStatus(
         organizationId: String,

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/LoginLinkTokenRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/LoginLinkTokenRepository.kt
@@ -1,0 +1,13 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.LoginLinkToken
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface LoginLinkTokenRepository : JpaRepository<LoginLinkToken, String> {
+    fun findByTokenHash(tokenHash: String): Optional<LoginLinkToken>
+
+    fun deleteByUserId(userId: String): Int
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectBudgetRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectBudgetRepository.kt
@@ -1,0 +1,21 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.ProjectBudget
+import com.aquinofroilan.tessera.model.ProjectCostCategory
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface ProjectBudgetRepository : JpaRepository<ProjectBudget, String> {
+    fun findByOrganizationIdAndProjectId(
+        organizationId: String,
+        projectId: String,
+    ): List<ProjectBudget>
+
+    fun findByOrganizationIdAndProjectIdAndCategory(
+        organizationId: String,
+        projectId: String,
+        category: ProjectCostCategory,
+    ): Optional<ProjectBudget>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectRepository.kt
@@ -1,0 +1,23 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProjectRepository : JpaRepository<Project, String> {
+    fun findByOrganizationId(organizationId: String): List<Project>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: ProjectStatus,
+    ): List<Project>
+
+    fun findByOrganizationIdAndCustomerId(
+        organizationId: String,
+        customerId: String,
+    ): List<Project>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectTaskRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/ProjectTaskRepository.kt
@@ -1,0 +1,13 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.ProjectTask
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProjectTaskRepository : JpaRepository<ProjectTask, String> {
+    fun findByOrganizationIdAndProjectId(
+        organizationId: String,
+        projectId: String,
+    ): List<ProjectTask>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/PurchaseRequestRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/PurchaseRequestRepository.kt
@@ -1,0 +1,23 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.PurchaseRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PurchaseRequestRepository : JpaRepository<PurchaseRequest, String> {
+    fun findByOrganizationId(organizationId: String): List<PurchaseRequest>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: PurchaseRequestStatus,
+    ): List<PurchaseRequest>
+
+    fun findByOrganizationIdAndRequestedBy(
+        organizationId: String,
+        requestedBy: String,
+    ): List<PurchaseRequest>
+
+    fun countByOrganizationId(organizationId: String): Long
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/TimeEntryRepository.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/TimeEntryRepository.kt
@@ -1,0 +1,32 @@
+package com.aquinofroilan.tessera.repository
+
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TimeEntryRepository : JpaRepository<TimeEntry, String> {
+    fun findByOrganizationId(organizationId: String): List<TimeEntry>
+
+    fun findByOrganizationIdAndEmployeeId(
+        organizationId: String,
+        employeeId: String,
+    ): List<TimeEntry>
+
+    fun findByOrganizationIdAndProjectId(
+        organizationId: String,
+        projectId: String,
+    ): List<TimeEntry>
+
+    fun findByOrganizationIdAndStatus(
+        organizationId: String,
+        status: TimeEntryStatus,
+    ): List<TimeEntry>
+
+    fun findByOrganizationIdAndProjectIdAndStatus(
+        organizationId: String,
+        projectId: String,
+        status: TimeEntryStatus,
+    ): List<TimeEntry>
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/security/Permissions.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/security/Permissions.kt
@@ -69,6 +69,10 @@ object Permissions {
     const val HR_WRITE = "hr:write"
     const val HR_APPROVE = "hr:approve"
 
+    const val PROJECT_READ = "projects:read"
+    const val PROJECT_WRITE = "projects:write"
+    const val PROJECT_APPROVE = "projects:approve"
+
     val ALL_PERMISSIONS =
         listOf(
             SESSION_READ,
@@ -122,5 +126,8 @@ object Permissions {
             HR_READ,
             HR_WRITE,
             HR_APPROVE,
+            PROJECT_READ,
+            PROJECT_WRITE,
+            PROJECT_APPROVE,
         )
 }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/AttendanceService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/AttendanceService.kt
@@ -1,0 +1,165 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.RecordAttendanceRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.AttendanceRecord
+import com.aquinofroilan.tessera.model.AttendanceStatus
+import com.aquinofroilan.tessera.model.EmploymentStatus
+import com.aquinofroilan.tessera.repository.AttendanceRecordRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+
+@Service
+class AttendanceService(
+    private val attendanceRecordRepository: AttendanceRecordRepository,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun clockIn(
+        employeeId: String,
+        organizationId: String,
+    ): AttendanceRecord {
+        val employee = activeEmployee(employeeId, organizationId)
+        val today = LocalDate.now(ZoneOffset.UTC)
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        val existing = attendanceRecordRepository.findByOrganizationIdAndEmployeeIdAndWorkDate(organizationId, employee.id, today)
+        if (existing.isPresent && existing.get().clockIn != null) {
+            throw BusinessRuleException("Employee has already clocked in today")
+        }
+        val record =
+            existing
+                .map { it.copy(clockIn = now, status = AttendanceStatus.PRESENT) }
+                .orElseGet {
+                    AttendanceRecord(
+                        employeeId = employee.id,
+                        workDate = today,
+                        clockIn = now,
+                        status = AttendanceStatus.PRESENT,
+                        organizationId = organizationId,
+                    )
+                }
+        return attendanceRecordRepository.save(record)
+    }
+
+    @Transactional
+    fun clockOut(
+        employeeId: String,
+        organizationId: String,
+    ): AttendanceRecord {
+        val employee = activeEmployee(employeeId, organizationId)
+        val today = LocalDate.now(ZoneOffset.UTC)
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        val record =
+            attendanceRecordRepository
+                .findByOrganizationIdAndEmployeeIdAndWorkDate(organizationId, employee.id, today)
+                .orElseThrow { BusinessRuleException("Employee has not clocked in today") }
+        val clockIn = record.clockIn ?: throw BusinessRuleException("Employee has not clocked in today")
+        if (record.clockOut != null) {
+            throw BusinessRuleException("Employee has already clocked out today")
+        }
+        return attendanceRecordRepository.save(
+            record.copy(
+                clockOut = now,
+                workedMinutes = ChronoUnit.MINUTES.between(clockIn, now).toInt(),
+            ),
+        )
+    }
+
+    /**
+     * Manually records or corrects an attendance entry for a specific day,
+     * upserting the unique (org, employee, date) record.
+     */
+    @Transactional
+    fun recordAttendance(
+        request: RecordAttendanceRequest,
+        organizationId: String,
+    ): AttendanceRecord {
+        val workDate = request.workDate ?: throw BusinessRuleException("Work date is required")
+        val employee = employeeService.getEmployee(request.employeeId, organizationId)
+        if (request.clockIn != null && request.clockOut != null && request.clockOut.isBefore(request.clockIn)) {
+            throw BusinessRuleException("Clock-out must be on or after clock-in")
+        }
+        val workedMinutes =
+            if (request.clockIn != null && request.clockOut != null) {
+                ChronoUnit.MINUTES.between(request.clockIn, request.clockOut).toInt()
+            } else {
+                null
+            }
+        val status = request.status ?: AttendanceStatus.PRESENT
+        val existing =
+            attendanceRecordRepository.findByOrganizationIdAndEmployeeIdAndWorkDate(organizationId, employee.id, workDate)
+        val record =
+            existing
+                .map {
+                    it.copy(
+                        clockIn = request.clockIn,
+                        clockOut = request.clockOut,
+                        workedMinutes = workedMinutes,
+                        status = status,
+                        notes = request.notes,
+                    )
+                }.orElseGet {
+                    AttendanceRecord(
+                        employeeId = employee.id,
+                        workDate = workDate,
+                        clockIn = request.clockIn,
+                        clockOut = request.clockOut,
+                        workedMinutes = workedMinutes,
+                        status = status,
+                        notes = request.notes,
+                        organizationId = organizationId,
+                    )
+                }
+        return attendanceRecordRepository.save(record)
+    }
+
+    fun getAttendance(
+        id: String,
+        organizationId: String,
+    ): AttendanceRecord {
+        val record =
+            attendanceRecordRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Attendance record not found")
+            }
+        if (record.organizationId != organizationId) {
+            throw ResourceNotFoundException("Attendance record not found")
+        }
+        return record
+    }
+
+    /**
+     * Returns a timesheet: attendance records for the org, optionally narrowed
+     * by employee and/or an inclusive [from]..[to] date range.
+     */
+    fun listTimesheet(
+        organizationId: String,
+        employeeId: String? = null,
+        from: LocalDate? = null,
+        to: LocalDate? = null,
+    ): List<AttendanceRecord> {
+        if (from != null && to != null && to.isBefore(from)) {
+            throw BusinessRuleException("'to' date must be on or after 'from' date")
+        }
+        return when {
+            employeeId != null && from != null && to != null ->
+                attendanceRecordRepository.findByOrganizationIdAndEmployeeIdAndWorkDateBetween(organizationId, employeeId, from, to)
+            employeeId != null -> attendanceRecordRepository.findByOrganizationIdAndEmployeeId(organizationId, employeeId)
+            from != null && to != null -> attendanceRecordRepository.findByOrganizationIdAndWorkDateBetween(organizationId, from, to)
+            else -> attendanceRecordRepository.findByOrganizationId(organizationId)
+        }
+    }
+
+    private fun activeEmployee(
+        employeeId: String,
+        organizationId: String,
+    ) = employeeService.getEmployee(employeeId, organizationId).also {
+        if (it.status == EmploymentStatus.TERMINATED) {
+            throw BusinessRuleException("Cannot record attendance for a terminated employee")
+        }
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/CsvCodec.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/CsvCodec.kt
@@ -1,0 +1,107 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+
+/**
+ * Minimal RFC 4180-ish CSV encoder/decoder. Fields containing comma, quote,
+ * or newline are double-quoted; embedded quotes are doubled. Suitable for
+ * Excel and Google Sheets round-trips for plain catalog data. For exotic
+ * cases (multi-line headers, locale-dependent number formats, etc.) the
+ * caller should pre-stringify values.
+ */
+object CsvCodec {
+    fun encode(
+        headers: List<String>,
+        rows: List<Map<String, Any?>>,
+    ): String {
+        val sb = StringBuilder()
+        sb.append(headers.joinToString(",") { escape(it) })
+        sb.append("\r\n")
+        for (row in rows) {
+            sb.append(headers.joinToString(",") { escape(row[it]?.toString() ?: "") })
+            sb.append("\r\n")
+        }
+        return sb.toString()
+    }
+
+    fun decode(csv: String): List<Map<String, String>> {
+        val all = parseRows(csv)
+        if (all.isEmpty()) return emptyList()
+        val headers = all.first().map { it.trim() }
+        val seen = mutableSetOf<String>()
+        headers.forEach {
+            if (!seen.add(it)) throw BusinessRuleException("Duplicate header in CSV: '$it'")
+        }
+        return all.drop(1).filter { it.any { cell -> cell.isNotEmpty() } }.map { row ->
+            headers.mapIndexed { idx, h -> h to (row.getOrNull(idx) ?: "") }.toMap()
+        }
+    }
+
+    private fun escape(value: String): String {
+        if (value.contains(',') || value.contains('"') || value.contains('\n') || value.contains('\r')) {
+            return "\"" + value.replace("\"", "\"\"") + "\""
+        }
+        return value
+    }
+
+    private fun parseRows(csv: String): List<List<String>> {
+        val rows = mutableListOf<List<String>>()
+        val current = StringBuilder()
+        var row = mutableListOf<String>()
+        var inQuotes = false
+        var i = 0
+        while (i < csv.length) {
+            val c = csv[i]
+            if (inQuotes) {
+                if (c == '"') {
+                    if (i + 1 < csv.length && csv[i + 1] == '"') {
+                        current.append('"')
+                        i += 2
+                        continue
+                    }
+                    inQuotes = false
+                    i++
+                    continue
+                }
+                current.append(c)
+                i++
+            } else {
+                when (c) {
+                    '"' -> {
+                        inQuotes = true
+                        i++
+                    }
+                    ',' -> {
+                        row.add(current.toString())
+                        current.setLength(0)
+                        i++
+                    }
+                    '\r' -> {
+                        if (i + 1 < csv.length && csv[i + 1] == '\n') i++
+                        row.add(current.toString())
+                        current.setLength(0)
+                        rows.add(row)
+                        row = mutableListOf()
+                        i++
+                    }
+                    '\n' -> {
+                        row.add(current.toString())
+                        current.setLength(0)
+                        rows.add(row)
+                        row = mutableListOf()
+                        i++
+                    }
+                    else -> {
+                        current.append(c)
+                        i++
+                    }
+                }
+            }
+        }
+        if (current.isNotEmpty() || row.isNotEmpty()) {
+            row.add(current.toString())
+            rows.add(row)
+        }
+        return rows
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/CsvImportExportService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/CsvImportExportService.kt
@@ -1,0 +1,155 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateCustomerRequest
+import com.aquinofroilan.tessera.dto.CreateProductRequest
+import com.aquinofroilan.tessera.dto.CsvImportResult
+import com.aquinofroilan.tessera.dto.CsvImportRowError
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+
+/**
+ * CSV export/import for the catalog entities a hobby ERP user is most likely
+ * to bulk-edit (products, customers, vendors). Designed to round-trip with
+ * Excel and Google Sheets: a CSV exported with [exportProducts] re-imports
+ * cleanly with [importProducts] (modulo duplicate-SKU rejection).
+ *
+ * Vendors/customers can also be exported but only customers + products
+ * support import in this slice -- vendor import follows when bank details
+ * land.
+ */
+@Service
+class CsvImportExportService(
+    private val productService: ProductService,
+    private val customerService: CustomerService,
+    private val vendorService: VendorService,
+) {
+    private val productHeaders =
+        listOf("sku", "name", "description", "category", "imageUrl", "listPrice", "priceCurrency", "taxGroupId")
+    private val customerHeaders =
+        listOf("name", "contactName", "contactEmail", "contactPhone", "paymentTermDays", "defaultRevenueAccountId")
+    private val vendorHeaders =
+        listOf("name", "contactName", "contactEmail", "contactPhone", "paymentTermDays")
+
+    fun exportProducts(organizationId: String): ByteArray {
+        val rows =
+            productService
+                .listProducts(organizationId)
+                .map {
+                    mapOf(
+                        "sku" to it.sku,
+                        "name" to it.name,
+                        "description" to (it.description ?: ""),
+                        "category" to (it.category ?: ""),
+                        "imageUrl" to (it.imageUrl ?: ""),
+                        "listPrice" to it.listPrice.toPlainString(),
+                        "priceCurrency" to it.priceCurrency,
+                        "taxGroupId" to (it.taxGroupId ?: ""),
+                    )
+                }
+        return CsvCodec.encode(productHeaders, rows).toByteArray()
+    }
+
+    fun exportCustomers(organizationId: String): ByteArray {
+        val rows =
+            customerService
+                .listCustomers(organizationId)
+                .map {
+                    mapOf(
+                        "name" to it.name,
+                        "contactName" to (it.contactName ?: ""),
+                        "contactEmail" to (it.contactEmail ?: ""),
+                        "contactPhone" to (it.contactPhone ?: ""),
+                        "paymentTermDays" to it.paymentTermDays.toString(),
+                        "defaultRevenueAccountId" to (it.defaultRevenueAccountId ?: ""),
+                    )
+                }
+        return CsvCodec.encode(customerHeaders, rows).toByteArray()
+    }
+
+    fun exportVendors(organizationId: String): ByteArray {
+        val rows =
+            vendorService
+                .listVendors(organizationId)
+                .map {
+                    mapOf(
+                        "name" to it.name,
+                        "contactName" to (it.contactName ?: ""),
+                        "contactEmail" to (it.contactEmail ?: ""),
+                        "contactPhone" to (it.contactPhone ?: ""),
+                        "paymentTermDays" to it.paymentTermDays.toString(),
+                    )
+                }
+        return CsvCodec.encode(vendorHeaders, rows).toByteArray()
+    }
+
+    fun importProducts(
+        bytes: ByteArray,
+        organizationId: String,
+    ): CsvImportResult {
+        val parsed = CsvCodec.decode(String(bytes))
+        val errors = mutableListOf<CsvImportRowError>()
+        var created = 0
+        parsed.forEachIndexed { idx, row ->
+            try {
+                val sku = row["sku"]?.takeIf { it.isNotBlank() } ?: throw IllegalArgumentException("sku is required")
+                val name = row["name"]?.takeIf { it.isNotBlank() } ?: throw IllegalArgumentException("name is required")
+                val listPrice =
+                    (row["listPrice"]?.takeIf { it.isNotBlank() } ?: "0").toBigDecimalOrNull()
+                        ?: throw IllegalArgumentException("listPrice must be a number")
+                productService.createProduct(
+                    CreateProductRequest(
+                        sku = sku,
+                        name = name,
+                        description = row["description"]?.ifBlank { null },
+                        category = row["category"]?.ifBlank { null },
+                        imageUrl = row["imageUrl"]?.ifBlank { null },
+                        listPrice = listPrice,
+                        priceCurrency = row["priceCurrency"]?.ifBlank { null },
+                        taxGroupId = row["taxGroupId"]?.ifBlank { null },
+                    ),
+                    organizationId,
+                )
+                created++
+            } catch (e: Exception) {
+                errors.add(CsvImportRowError(rowNumber = idx + 2, error = e.message ?: e.javaClass.simpleName))
+            }
+        }
+        return CsvImportResult(rowsParsed = parsed.size, rowsCreated = created, errors = errors)
+    }
+
+    fun importCustomers(
+        bytes: ByteArray,
+        organizationId: String,
+    ): CsvImportResult {
+        val parsed = CsvCodec.decode(String(bytes))
+        val errors = mutableListOf<CsvImportRowError>()
+        var created = 0
+        parsed.forEachIndexed { idx, row ->
+            try {
+                val name = row["name"]?.takeIf { it.isNotBlank() } ?: throw IllegalArgumentException("name is required")
+                customerService.createCustomer(
+                    CreateCustomerRequest(
+                        name = name,
+                        contactName = row["contactName"]?.ifBlank { null },
+                        contactEmail = row["contactEmail"]?.ifBlank { null },
+                        contactPhone = row["contactPhone"]?.ifBlank { null },
+                        paymentTermDays = row["paymentTermDays"]?.toIntOrNull() ?: 30,
+                        defaultRevenueAccountId = row["defaultRevenueAccountId"]?.ifBlank { null },
+                    ),
+                    organizationId,
+                )
+                created++
+            } catch (e: Exception) {
+                errors.add(CsvImportRowError(rowNumber = idx + 2, error = e.message ?: e.javaClass.simpleName))
+            }
+        }
+        return CsvImportResult(rowsParsed = parsed.size, rowsCreated = created, errors = errors)
+    }
+
+    private fun String.toBigDecimalOrNull(): BigDecimal? =
+        try {
+            BigDecimal(this)
+        } catch (_: NumberFormatException) {
+            null
+        }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/DepartmentService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/DepartmentService.kt
@@ -1,6 +1,7 @@
 package com.aquinofroilan.tessera.service
 
 import com.aquinofroilan.tessera.dto.CreateDepartmentRequest
+import com.aquinofroilan.tessera.dto.DepartmentTreeNode
 import com.aquinofroilan.tessera.dto.UpdateDepartmentRequest
 import com.aquinofroilan.tessera.exception.BusinessRuleException
 import com.aquinofroilan.tessera.exception.ResourceNotFoundException
@@ -22,11 +23,13 @@ class DepartmentService(
         if (departmentRepository.findByOrganizationIdAndCode(organizationId, code).isPresent) {
             throw BusinessRuleException("Department code '$code' already exists")
         }
+        request.parentId?.let { requireParentInOrg(it, organizationId) }
         return departmentRepository.save(
             Department(
                 code = code,
                 name = request.name.trim(),
                 description = request.description,
+                parentId = request.parentId,
                 organizationId = organizationId,
             ),
         )
@@ -81,5 +84,70 @@ class DepartmentService(
             throw BusinessRuleException("Department is already inactive")
         }
         return departmentRepository.save(department.copy(isActive = false))
+    }
+
+    /**
+     * Sets or clears a department's parent. A null [parentId] promotes the
+     * department to a root. Rejects self-parenting and any move that would
+     * introduce a cycle (i.e. making a department a child of its own descendant).
+     */
+    @Transactional
+    fun setParent(
+        id: String,
+        parentId: String?,
+        organizationId: String,
+    ): Department {
+        val department = getDepartment(id, organizationId)
+        if (parentId == null) {
+            return departmentRepository.save(department.copy(parentId = null))
+        }
+        if (parentId == id) {
+            throw BusinessRuleException("A department cannot be its own parent")
+        }
+        requireParentInOrg(parentId, organizationId)
+        if (descendantIds(id, organizationId).contains(parentId)) {
+            throw BusinessRuleException("Cannot move a department under one of its own descendants")
+        }
+        return departmentRepository.save(department.copy(parentId = parentId))
+    }
+
+    /**
+     * Builds the department org chart for an organization: root departments
+     * (those without a parent) with their descendants nested beneath them.
+     */
+    fun getOrgChart(organizationId: String): List<DepartmentTreeNode> {
+        val all = departmentRepository.findByOrganizationId(organizationId)
+        val childrenByParent = all.groupBy { it.parentId }
+
+        fun build(department: Department): DepartmentTreeNode =
+            DepartmentTreeNode.from(
+                department,
+                childrenByParent[department.id].orEmpty().sortedBy { it.code }.map(::build),
+            )
+        return childrenByParent[null].orEmpty().sortedBy { it.code }.map(::build)
+    }
+
+    private fun requireParentInOrg(
+        parentId: String,
+        organizationId: String,
+    ) {
+        // Reuses the cross-org guard: a parent in another org surfaces as "not found".
+        getDepartment(parentId, organizationId)
+    }
+
+    private fun descendantIds(
+        id: String,
+        organizationId: String,
+    ): Set<String> {
+        val childrenByParent = departmentRepository.findByOrganizationId(organizationId).groupBy { it.parentId }
+        val descendants = mutableSetOf<String>()
+        val queue = ArrayDeque(childrenByParent[id].orEmpty().map { it.id })
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (descendants.add(current)) {
+                childrenByParent[current].orEmpty().forEach { queue.addLast(it.id) }
+            }
+        }
+        return descendants
     }
 }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/EmployeeService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/EmployeeService.kt
@@ -24,6 +24,7 @@ class EmployeeService(
     ): Employee {
         val hireDate = request.hireDate ?: throw BusinessRuleException("Hire date is required")
         request.departmentId?.let { requireActiveDepartment(it, organizationId) }
+        request.userId?.let { requireUserUnlinked(it, organizationId, excludingEmployeeId = null) }
         return saveWithRetry(organizationId) { number ->
             Employee(
                 employeeNumber = number,
@@ -32,6 +33,7 @@ class EmployeeService(
                 email = request.email?.trim(),
                 jobTitle = request.jobTitle?.trim(),
                 departmentId = request.departmentId,
+                userId = request.userId,
                 hireDate = hireDate,
                 organizationId = organizationId,
             )
@@ -70,15 +72,26 @@ class EmployeeService(
         organizationId: String,
     ): Employee {
         val employee = getEmployee(id, organizationId)
+        request.userId?.let { requireUserUnlinked(it, organizationId, excludingEmployeeId = employee.id) }
         return employeeRepository.save(
             employee.copy(
                 firstName = request.firstName?.trim() ?: employee.firstName,
                 lastName = request.lastName?.trim() ?: employee.lastName,
                 email = request.email?.trim() ?: employee.email,
                 jobTitle = request.jobTitle?.trim() ?: employee.jobTitle,
+                userId = request.userId ?: employee.userId,
             ),
         )
     }
+
+    /** Resolves the employee record linked to the given login user, for self-service. */
+    fun getEmployeeByUser(
+        userId: String,
+        organizationId: String,
+    ): Employee =
+        employeeRepository.findByOrganizationIdAndUserId(organizationId, userId).orElseThrow {
+            ResourceNotFoundException("No employee record is linked to your account")
+        }
 
     @Transactional
     fun assignDepartment(
@@ -134,6 +147,17 @@ class EmployeeService(
         return employeeRepository.save(
             employee.copy(status = EmploymentStatus.TERMINATED, terminationDate = terminationDate),
         )
+    }
+
+    private fun requireUserUnlinked(
+        userId: String,
+        organizationId: String,
+        excludingEmployeeId: String?,
+    ) {
+        val existing = employeeRepository.findByOrganizationIdAndUserId(organizationId, userId)
+        if (existing.isPresent && existing.get().id != excludingEmployeeId) {
+            throw BusinessRuleException("That user is already linked to another employee")
+        }
     }
 
     private fun requireActiveDepartment(

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/LoginLinkService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/LoginLinkService.kt
@@ -1,0 +1,140 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.AuthResponse
+import com.aquinofroilan.tessera.exception.AuthenticationException
+import com.aquinofroilan.tessera.model.LoginLinkToken
+import com.aquinofroilan.tessera.model.RefreshToken
+import com.aquinofroilan.tessera.model.SessionToken
+import com.aquinofroilan.tessera.model.orgRoleNames
+import com.aquinofroilan.tessera.model.systemRoleNames
+import com.aquinofroilan.tessera.repository.LoginLinkTokenRepository
+import com.aquinofroilan.tessera.repository.RefreshTokenRepository
+import com.aquinofroilan.tessera.repository.SessionTokenRepository
+import com.aquinofroilan.tessera.repository.UserRepository
+import com.aquinofroilan.tessera.util.TokenHasher
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+/**
+ * Passwordless login via single-use, short-lived magic-link tokens.
+ *
+ * Flow:
+ * 1. `request(email)` -> if the account exists and is active, generate a raw
+ *    token, store its SHA-256 hash, and return the raw token to the caller
+ *    (the controller is expected to deliver it via email and **not** echo it
+ *    back to the client). Returns null for unknown / inactive emails so the
+ *    public response can be uniform and unenumerable.
+ * 2. `consume(rawToken, ip, ua)` -> looks the hash up, requires unconsumed +
+ *    unexpired, marks consumed, mints a session + refresh token and returns
+ *    the same AuthResponse shape as password login. Single-use: a second
+ *    consume of the same token fails.
+ *
+ * Outstanding magic-link tokens are wiped when a new one is requested, so
+ * only the most recent link mailed to a user is usable.
+ */
+@Service
+class LoginLinkService(
+    private val userRepository: UserRepository,
+    private val loginLinkTokenRepository: LoginLinkTokenRepository,
+    private val sessionTokenRepository: SessionTokenRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val tokenHasher: TokenHasher,
+    @Value("\${security.login-link.expiration-minutes:15}")
+    private val linkExpiryMinutes: Long,
+    @Value("\${security.jwt.expiration:86400000}")
+    private val tokenValidityMs: Long,
+    @Value("\${security.jwt.refresh-expiration:2592000000}")
+    private val refreshTokenValidityMs: Long,
+) {
+    @Transactional
+    fun request(email: String): String? {
+        val normalised = email.lowercase(Locale.ROOT)
+        val user = userRepository.findByEmail(normalised).orElse(null) ?: return null
+        if (!user.isActive) return null
+
+        loginLinkTokenRepository.deleteByUserId(user.uuid)
+
+        val rawToken = tokenHasher.generate(32)
+        val record =
+            LoginLinkToken(
+                tokenHash = tokenHasher.hash(rawToken),
+                userId = user.uuid,
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(linkExpiryMinutes),
+            )
+        loginLinkTokenRepository.save(record)
+        return rawToken
+    }
+
+    @Transactional
+    fun consume(
+        rawToken: String,
+        ipAddress: String? = null,
+        userAgent: String? = null,
+    ): AuthResponse {
+        val tokenHash = tokenHasher.hash(rawToken)
+        val record =
+            loginLinkTokenRepository.findByTokenHash(tokenHash).orElseThrow {
+                AuthenticationException("Invalid or expired login link")
+            }
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        if (record.consumedAt != null) {
+            throw AuthenticationException("Invalid or expired login link")
+        }
+        if (!record.expiryAt.isAfter(now)) {
+            loginLinkTokenRepository.deleteById(record.id)
+            throw AuthenticationException("Invalid or expired login link")
+        }
+
+        val user =
+            userRepository.findById(record.userId).orElseThrow {
+                AuthenticationException("Invalid or expired login link")
+            }
+        if (!user.isActive) {
+            throw AuthenticationException("User account is inactive")
+        }
+
+        loginLinkTokenRepository.save(record.copy(consumedAt = now, ipAddress = ipAddress, userAgent = userAgent))
+
+        val accessTokenStr = tokenHasher.generate(32)
+        val accessExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(tokenValidityMs, ChronoUnit.MILLIS)
+        val orgId = user.organizationId
+        val savedSession =
+            sessionTokenRepository.save(
+                SessionToken(
+                    token = accessTokenStr,
+                    expiryAt = accessExpiryAt,
+                    userId = user.uuid,
+                    organizationId = orgId,
+                    ipAddress = ipAddress,
+                    userAgent = userAgent,
+                ),
+            )
+
+        val refreshTokenStr = tokenHasher.generate(32)
+        val refreshExpiryAt = LocalDateTime.now(ZoneOffset.UTC).plus(refreshTokenValidityMs, ChronoUnit.MILLIS)
+        refreshTokenRepository.save(
+            RefreshToken(
+                tokenHash = tokenHasher.hash(refreshTokenStr),
+                userId = user.uuid,
+                sessionTokenId = savedSession.id,
+                expiryAt = refreshExpiryAt,
+            ),
+        )
+
+        val roles = (user.orgRoleNames(orgId) + user.systemRoleNames()).distinct()
+        return AuthResponse(
+            accessToken = accessTokenStr,
+            refreshToken = refreshTokenStr,
+            username = user.username,
+            roles = roles,
+            organizationId = orgId,
+            expiresAt = accessExpiryAt.toString(),
+            refreshTokenExpiresAt = refreshExpiryAt.toString(),
+        )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectBillingService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectBillingService.kt
@@ -1,0 +1,80 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateInvoiceRequest
+import com.aquinofroilan.tessera.dto.GenerateProjectInvoiceRequest
+import com.aquinofroilan.tessera.dto.InvoiceLineRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.Invoice
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+@Service
+class ProjectBillingService(
+    private val projectService: ProjectService,
+    private val customerService: CustomerService,
+    private val timeEntryRepository: TimeEntryRepository,
+    private val invoiceService: InvoiceService,
+) {
+    /**
+     * Generates a sales invoice from a project's approved, billable, un-billed
+     * time entries (time-and-materials). Each entry becomes an invoice line at
+     * hours x rate against the revenue account, and is then marked billed and
+     * linked to the invoice so it cannot be billed again.
+     */
+    @Transactional
+    fun generateInvoice(
+        projectId: String,
+        request: GenerateProjectInvoiceRequest,
+        organizationId: String,
+        createdBy: String,
+    ): Invoice {
+        val project = projectService.getProject(projectId, organizationId)
+        val customerId =
+            project.customerId ?: throw BusinessRuleException("Project has no customer to bill")
+        val customer = customerService.getCustomer(customerId, organizationId)
+        val revenueAccountId =
+            request.revenueAccountId ?: customer.defaultRevenueAccountId
+                ?: throw BusinessRuleException("No revenue account; set one on the customer or provide revenueAccountId")
+
+        val billable =
+            timeEntryRepository
+                .findByOrganizationIdAndProjectIdAndStatus(organizationId, projectId, TimeEntryStatus.APPROVED)
+                .filter { it.billable && !it.invoiced && (it.rate?.signum() ?: 0) > 0 }
+        if (billable.isEmpty()) {
+            throw BusinessRuleException("No billable time to invoice for this project")
+        }
+
+        val date = request.date ?: LocalDate.now(ZoneOffset.UTC)
+        val dueDate = request.dueDate ?: date.plusDays(customer.paymentTermDays.toLong())
+
+        val lines =
+            billable.map { entry ->
+                InvoiceLineRequest(
+                    accountId = revenueAccountId,
+                    amount = entry.hours.multiply(entry.rate!!),
+                    description = "Time ${entry.entryDate} (${entry.hours}h) on ${project.projectNumber}",
+                )
+            }
+
+        val invoice =
+            invoiceService.createInvoice(
+                CreateInvoiceRequest(
+                    customerId = customerId,
+                    date = date,
+                    dueDate = dueDate,
+                    referenceNumber = project.projectNumber,
+                    currencyCode = request.currencyCode,
+                    lines = lines,
+                ),
+                organizationId,
+                createdBy,
+            )
+
+        timeEntryRepository.saveAll(billable.map { it.copy(invoiced = true, invoiceId = invoice.id) })
+        return invoice
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectBudgetService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectBudgetService.kt
@@ -1,0 +1,105 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.BudgetVarianceLine
+import com.aquinofroilan.tessera.dto.ProjectBudgetVsActualResponse
+import com.aquinofroilan.tessera.dto.SetProjectBudgetRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.ProjectBudget
+import com.aquinofroilan.tessera.model.ProjectCostCategory
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.ProjectBudgetRepository
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@Service
+class ProjectBudgetService(
+    private val projectBudgetRepository: ProjectBudgetRepository,
+    private val projectService: ProjectService,
+    private val timeEntryRepository: TimeEntryRepository,
+) {
+    /** Upserts the budget for a single cost category on a project. */
+    @Transactional
+    fun setBudget(
+        projectId: String,
+        request: SetProjectBudgetRequest,
+        organizationId: String,
+    ): ProjectBudget {
+        projectService.getProject(projectId, organizationId)
+        val category = request.category ?: throw BusinessRuleException("Category is required")
+        val amount = request.budgetAmount ?: throw BusinessRuleException("Budget amount is required")
+        if (amount.signum() < 0) {
+            throw BusinessRuleException("Budget amount must not be negative")
+        }
+        val existing =
+            projectBudgetRepository.findByOrganizationIdAndProjectIdAndCategory(organizationId, projectId, category)
+        val budget =
+            existing
+                .map { it.copy(budgetAmount = amount, currency = request.currency ?: it.currency) }
+                .orElseGet {
+                    ProjectBudget(
+                        projectId = projectId,
+                        category = category,
+                        budgetAmount = amount,
+                        currency = request.currency,
+                        organizationId = organizationId,
+                    )
+                }
+        return projectBudgetRepository.save(budget)
+    }
+
+    fun listBudgets(
+        projectId: String,
+        organizationId: String,
+    ): List<ProjectBudget> {
+        projectService.getProject(projectId, organizationId)
+        return projectBudgetRepository.findByOrganizationIdAndProjectId(organizationId, projectId)
+    }
+
+    /**
+     * Budget vs actual for a project. Labor actuals are the sum of (hours x rate)
+     * over approved time entries. Material/expense actuals are 0 until bills and
+     * expense claims carry a project reference (Epic #166).
+     */
+    fun budgetVsActual(
+        projectId: String,
+        organizationId: String,
+    ): ProjectBudgetVsActualResponse {
+        projectService.getProject(projectId, organizationId)
+        val budgets = projectBudgetRepository.findByOrganizationIdAndProjectId(organizationId, projectId)
+
+        val laborActual =
+            timeEntryRepository
+                .findByOrganizationIdAndProjectIdAndStatus(organizationId, projectId, TimeEntryStatus.APPROVED)
+                .filter { it.rate != null }
+                .fold(BigDecimal.ZERO) { sum, entry -> sum.add(entry.hours.multiply(entry.rate)) }
+
+        val actualByCategory = mapOf(ProjectCostCategory.LABOR to laborActual)
+        val budgetByCategory = budgets.associateBy { it.category }
+        val categories =
+            (budgetByCategory.keys + actualByCategory.filterValues { it.signum() != 0 }.keys)
+                .distinct()
+                .sortedBy { it.name }
+
+        val lines =
+            categories.map { category ->
+                val budgeted = budgetByCategory[category]?.budgetAmount ?: BigDecimal.ZERO
+                val actual = actualByCategory[category] ?: BigDecimal.ZERO
+                BudgetVarianceLine(
+                    category = category,
+                    budgeted = budgeted,
+                    actual = actual,
+                    remaining = budgeted.subtract(actual),
+                )
+            }
+
+        return ProjectBudgetVsActualResponse(
+            projectId = projectId,
+            lines = lines,
+            totalBudgeted = lines.fold(BigDecimal.ZERO) { s, l -> s.add(l.budgeted) },
+            totalActual = lines.fold(BigDecimal.ZERO) { s, l -> s.add(l.actual) },
+            totalRemaining = lines.fold(BigDecimal.ZERO) { s, l -> s.add(l.remaining) },
+        )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectService.kt
@@ -1,0 +1,164 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectBillingType
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.repository.ProjectRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ProjectService(
+    private val projectRepository: ProjectRepository,
+    private val customerService: CustomerService,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun createProject(
+        request: CreateProjectRequest,
+        organizationId: String,
+    ): Project {
+        val startDate = request.startDate ?: throw BusinessRuleException("Start date is required")
+        if (request.endDate != null && request.endDate.isBefore(startDate)) {
+            throw BusinessRuleException("End date cannot be before the start date")
+        }
+        request.customerId?.let { customerService.getCustomer(it, organizationId) }
+        request.managerEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+
+        return saveWithRetry(organizationId) { number ->
+            Project(
+                projectNumber = number,
+                name = request.name.trim(),
+                description = request.description,
+                customerId = request.customerId,
+                managerEmployeeId = request.managerEmployeeId,
+                startDate = startDate,
+                endDate = request.endDate,
+                billingType = request.billingType ?: ProjectBillingType.TIME_AND_MATERIALS,
+                organizationId = organizationId,
+            )
+        }
+    }
+
+    fun getProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project =
+            projectRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Project not found")
+            }
+        if (project.organizationId != organizationId) {
+            throw ResourceNotFoundException("Project not found")
+        }
+        return project
+    }
+
+    fun listProjects(
+        organizationId: String,
+        status: ProjectStatus? = null,
+        customerId: String? = null,
+    ): List<Project> =
+        when {
+            status != null -> projectRepository.findByOrganizationIdAndStatus(organizationId, status)
+            customerId != null -> projectRepository.findByOrganizationIdAndCustomerId(organizationId, customerId)
+            else -> projectRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateProject(
+        id: String,
+        request: UpdateProjectRequest,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        request.customerId?.let { customerService.getCustomer(it, organizationId) }
+        request.managerEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+        val endDate = request.endDate ?: project.endDate
+        if (endDate != null && endDate.isBefore(project.startDate)) {
+            throw BusinessRuleException("End date cannot be before the start date")
+        }
+        return projectRepository.save(
+            project.copy(
+                name = request.name?.trim() ?: project.name,
+                description = request.description ?: project.description,
+                customerId = request.customerId ?: project.customerId,
+                managerEmployeeId = request.managerEmployeeId ?: project.managerEmployeeId,
+                endDate = endDate,
+                billingType = request.billingType ?: project.billingType,
+            ),
+        )
+    }
+
+    @Transactional
+    fun activateProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.PLANNED && project.status != ProjectStatus.ON_HOLD) {
+            throw BusinessRuleException("Only planned or on-hold projects can be activated")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.ACTIVE))
+    }
+
+    @Transactional
+    fun holdProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.ACTIVE) {
+            throw BusinessRuleException("Only active projects can be put on hold")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.ON_HOLD))
+    }
+
+    @Transactional
+    fun closeProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status != ProjectStatus.ACTIVE && project.status != ProjectStatus.ON_HOLD) {
+            throw BusinessRuleException("Only active or on-hold projects can be closed")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.CLOSED))
+    }
+
+    @Transactional
+    fun cancelProject(
+        id: String,
+        organizationId: String,
+    ): Project {
+        val project = getProject(id, organizationId)
+        if (project.status == ProjectStatus.CLOSED || project.status == ProjectStatus.CANCELLED) {
+            throw BusinessRuleException("Project is already ${project.status.name.lowercase()}")
+        }
+        return projectRepository.save(project.copy(status = ProjectStatus.CANCELLED))
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        build: (String) -> Project,
+    ): Project {
+        repeat(maxRetries) { attempt ->
+            val count = projectRepository.countByOrganizationId(organizationId)
+            val number = "PRJ-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return projectRepository.save(build(number))
+            } catch (e: DuplicateKeyException) {
+                if (attempt == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique project number: $number", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique project number")
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectTaskService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/ProjectTaskService.kt
@@ -1,0 +1,150 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectTaskRequest
+import com.aquinofroilan.tessera.dto.ProjectTaskTreeNode
+import com.aquinofroilan.tessera.dto.UpdateProjectTaskRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.ProjectTask
+import com.aquinofroilan.tessera.repository.ProjectTaskRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ProjectTaskService(
+    private val projectTaskRepository: ProjectTaskRepository,
+    private val projectService: ProjectService,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun createTask(
+        projectId: String,
+        request: CreateProjectTaskRequest,
+        organizationId: String,
+    ): ProjectTask {
+        projectService.getProject(projectId, organizationId)
+        request.assigneeEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+        request.parentTaskId?.let { requireTaskInProject(it, projectId, organizationId) }
+        return projectTaskRepository.save(
+            ProjectTask(
+                projectId = projectId,
+                parentTaskId = request.parentTaskId,
+                name = request.name.trim(),
+                description = request.description,
+                assigneeEmployeeId = request.assigneeEmployeeId,
+                estimatedHours = request.estimatedHours,
+                organizationId = organizationId,
+            ),
+        )
+    }
+
+    fun getTask(
+        projectId: String,
+        taskId: String,
+        organizationId: String,
+    ): ProjectTask {
+        val task =
+            projectTaskRepository.findById(taskId).orElseThrow {
+                ResourceNotFoundException("Task not found")
+            }
+        if (task.organizationId != organizationId || task.projectId != projectId) {
+            throw ResourceNotFoundException("Task not found")
+        }
+        return task
+    }
+
+    fun listTasks(
+        projectId: String,
+        organizationId: String,
+    ): List<ProjectTask> {
+        projectService.getProject(projectId, organizationId)
+        return projectTaskRepository.findByOrganizationIdAndProjectId(organizationId, projectId)
+    }
+
+    /** Builds the work-breakdown tree for a project: root tasks with nested children. */
+    fun getTaskTree(
+        projectId: String,
+        organizationId: String,
+    ): List<ProjectTaskTreeNode> {
+        val all = listTasks(projectId, organizationId)
+        val childrenByParent = all.groupBy { it.parentTaskId }
+
+        fun build(task: ProjectTask): ProjectTaskTreeNode =
+            ProjectTaskTreeNode.from(
+                task,
+                childrenByParent[task.id].orEmpty().sortedBy { it.name }.map(::build),
+            )
+        return childrenByParent[null].orEmpty().sortedBy { it.name }.map(::build)
+    }
+
+    @Transactional
+    fun updateTask(
+        projectId: String,
+        taskId: String,
+        request: UpdateProjectTaskRequest,
+        organizationId: String,
+    ): ProjectTask {
+        val task = getTask(projectId, taskId, organizationId)
+        request.assigneeEmployeeId?.let { employeeService.getEmployee(it, organizationId) }
+        return projectTaskRepository.save(
+            task.copy(
+                name = request.name?.trim() ?: task.name,
+                description = request.description ?: task.description,
+                assigneeEmployeeId = request.assigneeEmployeeId ?: task.assigneeEmployeeId,
+                estimatedHours = request.estimatedHours ?: task.estimatedHours,
+                status = request.status ?: task.status,
+            ),
+        )
+    }
+
+    /**
+     * Sets or clears a task's parent. A null parent promotes it to a root.
+     * Rejects self-parenting, cross-project parents, and descendant cycles.
+     */
+    @Transactional
+    fun setParent(
+        projectId: String,
+        taskId: String,
+        parentTaskId: String?,
+        organizationId: String,
+    ): ProjectTask {
+        val task = getTask(projectId, taskId, organizationId)
+        if (parentTaskId == null) {
+            return projectTaskRepository.save(task.copy(parentTaskId = null))
+        }
+        if (parentTaskId == taskId) {
+            throw BusinessRuleException("A task cannot be its own parent")
+        }
+        requireTaskInProject(parentTaskId, projectId, organizationId)
+        if (descendantIds(taskId, projectId, organizationId).contains(parentTaskId)) {
+            throw BusinessRuleException("Cannot move a task under one of its own descendants")
+        }
+        return projectTaskRepository.save(task.copy(parentTaskId = parentTaskId))
+    }
+
+    private fun requireTaskInProject(
+        taskId: String,
+        projectId: String,
+        organizationId: String,
+    ) {
+        getTask(projectId, taskId, organizationId)
+    }
+
+    private fun descendantIds(
+        taskId: String,
+        projectId: String,
+        organizationId: String,
+    ): Set<String> {
+        val childrenByParent =
+            projectTaskRepository.findByOrganizationIdAndProjectId(organizationId, projectId).groupBy { it.parentTaskId }
+        val descendants = mutableSetOf<String>()
+        val queue = ArrayDeque(childrenByParent[taskId].orEmpty().map { it.id })
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (descendants.add(current)) {
+                childrenByParent[current].orEmpty().forEach { queue.addLast(it.id) }
+            }
+        }
+        return descendants
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestService.kt
@@ -1,0 +1,247 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseOrderLineRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseOrderRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.PurchaseOrder
+import com.aquinofroilan.tessera.model.PurchaseRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestLine
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import com.aquinofroilan.tessera.repository.PurchaseRequestRepository
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Service
+class PurchaseRequestService(
+    private val purchaseRequestRepository: PurchaseRequestRepository,
+    private val productService: ProductService,
+    private val vendorService: VendorService,
+    private val warehouseService: WarehouseService,
+    private val purchaseOrderService: PurchaseOrderService,
+) {
+    @Transactional
+    fun createPurchaseRequest(
+        request: CreatePurchaseRequestRequest,
+        organizationId: String,
+        requestedBy: String,
+    ): PurchaseRequest {
+        request.suggestedVendorId?.let { vendorService.getVendor(it, organizationId) }
+        request.warehouseId?.let { warehouseService.getWarehouse(it, organizationId) }
+
+        val lines =
+            request.lines.mapIndexed { index, lineReq ->
+                val quantity = lineReq.quantity ?: throw BusinessRuleException("Quantity is required")
+                if (quantity.signum() <= 0) {
+                    throw BusinessRuleException("Line quantity must be positive")
+                }
+                if (lineReq.estimatedUnitCost != null && lineReq.estimatedUnitCost.signum() < 0) {
+                    throw BusinessRuleException("Estimated unit cost must not be negative")
+                }
+                val product = productService.getProduct(lineReq.productId, organizationId)
+                if (!product.isActive) {
+                    throw BusinessRuleException("Product '${product.sku}' is inactive")
+                }
+                PurchaseRequestLine(
+                    lineNumber = index + 1,
+                    productId = product.id,
+                    productSku = product.sku,
+                    productName = product.name,
+                    quantity = quantity,
+                    estimatedUnitCost = lineReq.estimatedUnitCost,
+                    description = lineReq.description,
+                )
+            }
+
+        return saveWithRetry(organizationId) { number ->
+            PurchaseRequest(
+                prNumber = number,
+                organizationId = organizationId,
+                suggestedVendorId = request.suggestedVendorId,
+                warehouseId = request.warehouseId,
+                justification = request.justification,
+                lines = lines,
+                requestedBy = requestedBy,
+            )
+        }
+    }
+
+    fun getPurchaseRequest(
+        id: String,
+        organizationId: String,
+    ): PurchaseRequest {
+        val pr =
+            purchaseRequestRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Purchase request not found")
+            }
+        if (pr.organizationId != organizationId) {
+            throw ResourceNotFoundException("Purchase request not found")
+        }
+        return pr
+    }
+
+    fun listPurchaseRequests(
+        organizationId: String,
+        status: PurchaseRequestStatus? = null,
+        requestedBy: String? = null,
+    ): List<PurchaseRequest> =
+        when {
+            status != null -> purchaseRequestRepository.findByOrganizationIdAndStatus(organizationId, status)
+            requestedBy != null -> purchaseRequestRepository.findByOrganizationIdAndRequestedBy(organizationId, requestedBy)
+            else -> purchaseRequestRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun submitPurchaseRequest(
+        id: String,
+        organizationId: String,
+    ): PurchaseRequest {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status != PurchaseRequestStatus.DRAFT) {
+            throw BusinessRuleException("Only draft purchase requests can be submitted")
+        }
+        return purchaseRequestRepository.save(pr.copy(status = PurchaseRequestStatus.SUBMITTED))
+    }
+
+    @Transactional
+    fun approvePurchaseRequest(
+        id: String,
+        organizationId: String,
+        decidedBy: String,
+    ): PurchaseRequest {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status != PurchaseRequestStatus.SUBMITTED) {
+            throw BusinessRuleException("Only submitted purchase requests can be approved")
+        }
+        return purchaseRequestRepository.save(
+            pr.copy(
+                status = PurchaseRequestStatus.APPROVED,
+                decidedBy = decidedBy,
+                decidedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+
+    @Transactional
+    fun rejectPurchaseRequest(
+        id: String,
+        reason: String?,
+        organizationId: String,
+        decidedBy: String,
+    ): PurchaseRequest {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status != PurchaseRequestStatus.SUBMITTED) {
+            throw BusinessRuleException("Only submitted purchase requests can be rejected")
+        }
+        return purchaseRequestRepository.save(
+            pr.copy(
+                status = PurchaseRequestStatus.REJECTED,
+                decisionReason = reason,
+                decidedBy = decidedBy,
+                decidedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+
+    @Transactional
+    fun cancelPurchaseRequest(
+        id: String,
+        organizationId: String,
+    ): PurchaseRequest {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status == PurchaseRequestStatus.CONVERTED) {
+            throw BusinessRuleException("A converted purchase request cannot be cancelled")
+        }
+        if (pr.status == PurchaseRequestStatus.CANCELLED || pr.status == PurchaseRequestStatus.REJECTED) {
+            throw BusinessRuleException("Purchase request is already ${pr.status.name.lowercase()}")
+        }
+        return purchaseRequestRepository.save(pr.copy(status = PurchaseRequestStatus.CANCELLED))
+    }
+
+    /**
+     * Converts an approved request into a purchase order. The vendor, warehouse
+     * and order date may be supplied on the request or fall back to the values
+     * captured on the requisition. Each line needs a unit cost — taken from a
+     * per-line override or the line's estimated cost. Marks the request CONVERTED
+     * and links it to the new PO.
+     */
+    @Transactional
+    fun convertToPurchaseOrder(
+        id: String,
+        request: ConvertPurchaseRequestRequest,
+        organizationId: String,
+        createdBy: String,
+    ): PurchaseOrder {
+        val pr = getPurchaseRequest(id, organizationId)
+        if (pr.status != PurchaseRequestStatus.APPROVED) {
+            throw BusinessRuleException("Only approved purchase requests can be converted")
+        }
+        val vendorId =
+            request.vendorId ?: pr.suggestedVendorId
+                ?: throw BusinessRuleException("A vendor is required to convert this request")
+        val warehouseId =
+            request.warehouseId ?: pr.warehouseId
+                ?: throw BusinessRuleException("A warehouse is required to convert this request")
+        val costOverrides = request.lineCosts.orEmpty().associate { it.lineId to it.unitCost }
+
+        val poLines =
+            pr.lines.map { line ->
+                val unitCost =
+                    costOverrides[line.id] ?: line.estimatedUnitCost
+                        ?: throw BusinessRuleException("Line '${line.productSku}' has no unit cost; provide one to convert")
+                CreatePurchaseOrderLineRequest(
+                    productId = line.productId,
+                    quantity = line.quantity,
+                    unitCost = unitCost,
+                    description = line.description,
+                )
+            }
+
+        val po =
+            purchaseOrderService.createPurchaseOrder(
+                CreatePurchaseOrderRequest(
+                    vendorId = vendorId,
+                    warehouseId = warehouseId,
+                    orderDate = request.orderDate ?: LocalDate.now(ZoneOffset.UTC),
+                    expectedDate = request.expectedDate,
+                    referenceNumber = pr.prNumber,
+                    lines = poLines,
+                ),
+                organizationId,
+                createdBy,
+            )
+
+        purchaseRequestRepository.save(
+            pr.copy(
+                status = PurchaseRequestStatus.CONVERTED,
+                convertedPurchaseOrderId = po.id,
+            ),
+        )
+        return po
+    }
+
+    private fun saveWithRetry(
+        organizationId: String,
+        maxRetries: Int = 3,
+        build: (String) -> PurchaseRequest,
+    ): PurchaseRequest {
+        repeat(maxRetries) { attempt ->
+            val count = purchaseRequestRepository.countByOrganizationId(organizationId)
+            val number = "PR-${(count + 1).toString().padStart(4, '0')}"
+            try {
+                return purchaseRequestRepository.save(build(number))
+            } catch (e: DuplicateKeyException) {
+                if (attempt == maxRetries - 1) {
+                    throw IllegalStateException("Failed to generate unique PR number: $number", e)
+                }
+            }
+        }
+        throw IllegalStateException("Failed to generate unique PR number")
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/SelfServiceService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/SelfServiceService.kt
@@ -1,0 +1,83 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateLeaveRequestRequest
+import com.aquinofroilan.tessera.dto.LeaveBalanceResponse
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import com.aquinofroilan.tessera.model.Employee
+import com.aquinofroilan.tessera.model.EmployeeCompensation
+import com.aquinofroilan.tessera.model.LeaveRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+/**
+ * Employee self-service: a self-scoped facade over the HR services. Every call
+ * resolves the caller's own employee record from their login user, so an
+ * employee can only ever see or act on their own data.
+ */
+@Service
+class SelfServiceService(
+    private val employeeService: EmployeeService,
+    private val leaveRequestService: LeaveRequestService,
+    private val employeeCompensationService: EmployeeCompensationService,
+) {
+    fun myProfile(
+        userId: String,
+        organizationId: String,
+    ): Employee = employeeService.getEmployeeByUser(userId, organizationId)
+
+    fun myLeaveRequests(
+        userId: String,
+        organizationId: String,
+    ): List<LeaveRequest> {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return leaveRequestService.listLeaveRequests(organizationId, employeeId = me.id)
+    }
+
+    @Transactional
+    fun submitLeave(
+        userId: String,
+        organizationId: String,
+        request: SubmitSelfLeaveRequest,
+    ): LeaveRequest {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return leaveRequestService.createLeaveRequest(
+            CreateLeaveRequestRequest(
+                employeeId = me.id,
+                leaveTypeId = request.leaveTypeId,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                reason = request.reason,
+            ),
+            organizationId,
+            requestedBy = userId,
+        )
+    }
+
+    fun myLeaveBalance(
+        userId: String,
+        organizationId: String,
+        leaveTypeId: String,
+        year: Int,
+    ): LeaveBalanceResponse {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return leaveRequestService.balance(me.id, leaveTypeId, year, organizationId)
+    }
+
+    fun myCompensationHistory(
+        userId: String,
+        organizationId: String,
+    ): List<EmployeeCompensation> {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return employeeCompensationService.listCompensation(me.id, organizationId)
+    }
+
+    fun myCurrentCompensation(
+        userId: String,
+        organizationId: String,
+        asOf: LocalDate,
+    ): EmployeeCompensation {
+        val me = employeeService.getEmployeeByUser(userId, organizationId)
+        return employeeCompensationService.currentCompensation(me.id, organizationId, asOf)
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/TimeEntryService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/TimeEntryService.kt
@@ -1,0 +1,156 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateTimeEntryRequest
+import com.aquinofroilan.tessera.dto.UpdateTimeEntryRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Service
+class TimeEntryService(
+    private val timeEntryRepository: TimeEntryRepository,
+    private val projectService: ProjectService,
+    private val projectTaskService: ProjectTaskService,
+    private val employeeService: EmployeeService,
+) {
+    @Transactional
+    fun createTimeEntry(
+        request: CreateTimeEntryRequest,
+        organizationId: String,
+    ): TimeEntry {
+        val hours = request.hours ?: throw BusinessRuleException("Hours are required")
+        if (hours.signum() <= 0) {
+            throw BusinessRuleException("Hours must be positive")
+        }
+        val entryDate = request.entryDate ?: throw BusinessRuleException("Entry date is required")
+        if (request.rate != null && request.rate.signum() < 0) {
+            throw BusinessRuleException("Rate must not be negative")
+        }
+        projectService.getProject(request.projectId, organizationId)
+        request.taskId?.let { projectTaskService.getTask(request.projectId, it, organizationId) }
+        employeeService.getEmployee(request.employeeId, organizationId)
+
+        return timeEntryRepository.save(
+            TimeEntry(
+                employeeId = request.employeeId,
+                projectId = request.projectId,
+                taskId = request.taskId,
+                entryDate = entryDate,
+                hours = hours,
+                billable = request.billable,
+                rate = request.rate,
+                notes = request.notes,
+                organizationId = organizationId,
+            ),
+        )
+    }
+
+    fun getTimeEntry(
+        id: String,
+        organizationId: String,
+    ): TimeEntry {
+        val entry =
+            timeEntryRepository.findById(id).orElseThrow {
+                ResourceNotFoundException("Time entry not found")
+            }
+        if (entry.organizationId != organizationId) {
+            throw ResourceNotFoundException("Time entry not found")
+        }
+        return entry
+    }
+
+    fun listTimeEntries(
+        organizationId: String,
+        employeeId: String? = null,
+        projectId: String? = null,
+        status: TimeEntryStatus? = null,
+    ): List<TimeEntry> =
+        when {
+            projectId != null && status != null ->
+                timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(organizationId, projectId, status)
+            employeeId != null -> timeEntryRepository.findByOrganizationIdAndEmployeeId(organizationId, employeeId)
+            projectId != null -> timeEntryRepository.findByOrganizationIdAndProjectId(organizationId, projectId)
+            status != null -> timeEntryRepository.findByOrganizationIdAndStatus(organizationId, status)
+            else -> timeEntryRepository.findByOrganizationId(organizationId)
+        }
+
+    @Transactional
+    fun updateTimeEntry(
+        id: String,
+        request: UpdateTimeEntryRequest,
+        organizationId: String,
+    ): TimeEntry {
+        val entry = getTimeEntry(id, organizationId)
+        if (entry.status != TimeEntryStatus.DRAFT) {
+            throw BusinessRuleException("Only draft time entries can be edited")
+        }
+        request.hours?.let { if (it.signum() <= 0) throw BusinessRuleException("Hours must be positive") }
+        request.taskId?.let { projectTaskService.getTask(entry.projectId, it, organizationId) }
+        return timeEntryRepository.save(
+            entry.copy(
+                taskId = request.taskId ?: entry.taskId,
+                entryDate = request.entryDate ?: entry.entryDate,
+                hours = request.hours ?: entry.hours,
+                billable = request.billable ?: entry.billable,
+                rate = request.rate ?: entry.rate,
+                notes = request.notes ?: entry.notes,
+            ),
+        )
+    }
+
+    @Transactional
+    fun submitTimeEntry(
+        id: String,
+        organizationId: String,
+    ): TimeEntry {
+        val entry = getTimeEntry(id, organizationId)
+        if (entry.status != TimeEntryStatus.DRAFT) {
+            throw BusinessRuleException("Only draft time entries can be submitted")
+        }
+        return timeEntryRepository.save(entry.copy(status = TimeEntryStatus.SUBMITTED))
+    }
+
+    @Transactional
+    fun approveTimeEntry(
+        id: String,
+        organizationId: String,
+        approvedBy: String,
+    ): TimeEntry {
+        val entry = getTimeEntry(id, organizationId)
+        if (entry.status != TimeEntryStatus.SUBMITTED) {
+            throw BusinessRuleException("Only submitted time entries can be approved")
+        }
+        return timeEntryRepository.save(
+            entry.copy(
+                status = TimeEntryStatus.APPROVED,
+                approvedBy = approvedBy,
+                approvedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+
+    @Transactional
+    fun rejectTimeEntry(
+        id: String,
+        organizationId: String,
+        decidedBy: String,
+    ): TimeEntry {
+        val entry = getTimeEntry(id, organizationId)
+        if (entry.status != TimeEntryStatus.SUBMITTED) {
+            throw BusinessRuleException("Only submitted time entries can be rejected")
+        }
+        return timeEntryRepository.save(
+            entry.copy(
+                status = TimeEntryStatus.REJECTED,
+                approvedBy = decidedBy,
+                approvedAt = LocalDateTime.now(ZoneOffset.UTC),
+            ),
+        )
+    }
+}

--- a/src/main/resources/db/migration/V0014__hr_department_parent.sql
+++ b/src/main/resources/db/migration/V0014__hr_department_parent.sql
@@ -1,0 +1,6 @@
+-- HR module: department org-chart hierarchy.
+-- Adds an optional self-referencing parent so departments can nest into an org chart.
+ALTER TABLE departments
+    ADD COLUMN parent_id uuid REFERENCES departments(id);
+
+CREATE INDEX departments_parent_idx ON departments(parent_id);

--- a/src/main/resources/db/migration/V0015__hr_attendance.sql
+++ b/src/main/resources/db/migration/V0015__hr_attendance.sql
@@ -1,0 +1,18 @@
+-- HR module: attendance records (clock-in / clock-out + daily timesheets).
+-- One record per employee per work date.
+CREATE TABLE attendance_records (
+    id                uuid PRIMARY KEY,
+    employee_id       uuid NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+    work_date         date NOT NULL,
+    clock_in          timestamp,
+    clock_out         timestamp,
+    worked_minutes    int,
+    status            text NOT NULL DEFAULT 'PRESENT',
+    notes             text,
+    organization_id   uuid NOT NULL REFERENCES organizations(uuid),
+    created_at        timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at        timestamp,
+    CONSTRAINT attendance_records_status_chk CHECK (status IN ('PRESENT','ABSENT','ON_LEAVE')),
+    CONSTRAINT attendance_records_unique_per_day UNIQUE (organization_id, employee_id, work_date)
+);
+CREATE INDEX attendance_records_org_employee_date_idx ON attendance_records(organization_id, employee_id, work_date);

--- a/src/main/resources/db/migration/V0016__purchase_requests.sql
+++ b/src/main/resources/db/migration/V0016__purchase_requests.sql
@@ -1,0 +1,38 @@
+-- Procurement: purchase requests (requisitions).
+-- A purchase request is the requisition stage that precedes a purchase order:
+-- draft -> submit -> approve/reject, and an approved request can be converted
+-- into a purchase order (linked via converted_purchase_order_id).
+CREATE TABLE purchase_requests (
+    id                          uuid PRIMARY KEY,
+    pr_number                   text NOT NULL,
+    organization_id             uuid NOT NULL REFERENCES organizations(uuid),
+    status                      text NOT NULL DEFAULT 'DRAFT',
+    suggested_vendor_id         uuid REFERENCES vendors(id) ON DELETE SET NULL,
+    warehouse_id                uuid REFERENCES warehouses(id) ON DELETE SET NULL,
+    justification               text,
+    requested_by                uuid NOT NULL REFERENCES users(uuid),
+    decided_by                  uuid REFERENCES users(uuid),
+    decided_at                  timestamp,
+    decision_reason             text,
+    converted_purchase_order_id uuid REFERENCES purchase_orders(id) ON DELETE SET NULL,
+    created_at                  timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at                  timestamp,
+    CONSTRAINT purchase_requests_status_chk
+        CHECK (status IN ('DRAFT','SUBMITTED','APPROVED','REJECTED','CONVERTED','CANCELLED')),
+    CONSTRAINT purchase_requests_unique_number_per_org UNIQUE (organization_id, pr_number)
+);
+CREATE INDEX purchase_requests_org_status_idx ON purchase_requests(organization_id, status);
+
+CREATE TABLE purchase_request_lines (
+    id                   uuid PRIMARY KEY,
+    purchase_request_id  uuid NOT NULL REFERENCES purchase_requests(id) ON DELETE CASCADE,
+    line_number          int NOT NULL,
+    product_id           uuid NOT NULL REFERENCES products(id) ON DELETE RESTRICT,
+    product_sku          text NOT NULL,
+    product_name         text NOT NULL,
+    quantity             numeric(18,4) NOT NULL,
+    estimated_unit_cost  numeric(18,4),
+    description          text,
+    CONSTRAINT purchase_request_lines_unique_line_per_pr UNIQUE (purchase_request_id, line_number)
+);
+CREATE INDEX purchase_request_lines_product_idx ON purchase_request_lines(product_id);

--- a/src/main/resources/db/migration/V0017__employee_user_link.sql
+++ b/src/main/resources/db/migration/V0017__employee_user_link.sql
@@ -1,0 +1,9 @@
+-- HR module: link an employee record to a login user, enabling employee
+-- self-service (an authenticated user resolving to their own employee record).
+-- At most one employee per user within an organization.
+ALTER TABLE employees
+    ADD COLUMN user_id uuid REFERENCES users(uuid) ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX employees_unique_user_per_org
+    ON employees(organization_id, user_id)
+    WHERE user_id IS NOT NULL;

--- a/src/main/resources/db/migration/V0019__projects.sql
+++ b/src/main/resources/db/migration/V0019__projects.sql
@@ -1,0 +1,24 @@
+-- Project module: projects (root entity of the project-management epic).
+-- Projects own tasks, timesheets, budgets and billing in later migrations.
+CREATE TABLE projects (
+    id                   uuid PRIMARY KEY,
+    project_number       text NOT NULL,
+    name                 text NOT NULL,
+    description          text,
+    customer_id          uuid REFERENCES customers(id) ON DELETE SET NULL,
+    manager_employee_id  uuid REFERENCES employees(id) ON DELETE SET NULL,
+    start_date           date NOT NULL,
+    end_date             date,
+    status               text NOT NULL DEFAULT 'PLANNED',
+    billing_type         text NOT NULL DEFAULT 'TIME_AND_MATERIALS',
+    organization_id      uuid NOT NULL REFERENCES organizations(uuid),
+    created_at           timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at           timestamp,
+    CONSTRAINT projects_status_chk
+        CHECK (status IN ('PLANNED','ACTIVE','ON_HOLD','CLOSED','CANCELLED')),
+    CONSTRAINT projects_billing_type_chk
+        CHECK (billing_type IN ('TIME_AND_MATERIALS','FIXED_PRICE','MILESTONE')),
+    CONSTRAINT projects_unique_number_per_org UNIQUE (organization_id, project_number)
+);
+CREATE INDEX projects_org_status_idx ON projects(organization_id, status);
+CREATE INDEX projects_org_customer_idx ON projects(organization_id, customer_id);

--- a/src/main/resources/db/migration/V0020__project_tasks.sql
+++ b/src/main/resources/db/migration/V0020__project_tasks.sql
@@ -1,0 +1,19 @@
+-- Project module: tasks / work breakdown structure.
+-- Tasks nest within a project via an optional self-referencing parent.
+CREATE TABLE project_tasks (
+    id                   uuid PRIMARY KEY,
+    project_id           uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    parent_task_id       uuid REFERENCES project_tasks(id) ON DELETE CASCADE,
+    name                 text NOT NULL,
+    description          text,
+    assignee_employee_id uuid REFERENCES employees(id) ON DELETE SET NULL,
+    estimated_hours      numeric(10,2),
+    status               text NOT NULL DEFAULT 'TODO',
+    organization_id      uuid NOT NULL REFERENCES organizations(uuid),
+    created_at           timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at           timestamp,
+    CONSTRAINT project_tasks_status_chk
+        CHECK (status IN ('TODO','IN_PROGRESS','DONE','CANCELLED'))
+);
+CREATE INDEX project_tasks_org_project_idx ON project_tasks(organization_id, project_id);
+CREATE INDEX project_tasks_parent_idx ON project_tasks(parent_task_id);

--- a/src/main/resources/db/migration/V0021__time_entries.sql
+++ b/src/main/resources/db/migration/V0021__time_entries.sql
@@ -1,0 +1,25 @@
+-- Project module: timesheets / time entries.
+-- Employees log time against a project (and optionally a task). Distinct from
+-- HR attendance. Approved billable entries feed project budgeting and billing.
+CREATE TABLE time_entries (
+    id               uuid PRIMARY KEY,
+    employee_id      uuid NOT NULL REFERENCES employees(id) ON DELETE RESTRICT,
+    project_id       uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    task_id          uuid REFERENCES project_tasks(id) ON DELETE SET NULL,
+    entry_date       date NOT NULL,
+    hours            numeric(8,2) NOT NULL,
+    billable         boolean NOT NULL DEFAULT true,
+    rate             numeric(18,4),
+    status           text NOT NULL DEFAULT 'DRAFT',
+    notes            text,
+    approved_by      uuid REFERENCES users(uuid),
+    approved_at      timestamp,
+    organization_id  uuid NOT NULL REFERENCES organizations(uuid),
+    created_at       timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at       timestamp,
+    CONSTRAINT time_entries_status_chk
+        CHECK (status IN ('DRAFT','SUBMITTED','APPROVED','REJECTED'))
+);
+CREATE INDEX time_entries_org_project_idx ON time_entries(organization_id, project_id);
+CREATE INDEX time_entries_org_employee_idx ON time_entries(organization_id, employee_id);
+CREATE INDEX time_entries_org_status_idx ON time_entries(organization_id, status);

--- a/src/main/resources/db/migration/V0022__project_budgets.sql
+++ b/src/main/resources/db/migration/V0022__project_budgets.sql
@@ -1,0 +1,18 @@
+-- Project module: budgets per project, by cost category.
+-- Actuals are computed (not stored): labor actuals come from approved time
+-- entries; material/expense actuals arrive once bills/expense claims carry a
+-- project reference (Epic #166).
+CREATE TABLE project_budgets (
+    id               uuid PRIMARY KEY,
+    project_id       uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    category         text NOT NULL,
+    budget_amount    numeric(18,4) NOT NULL,
+    currency         char(3),
+    organization_id  uuid NOT NULL REFERENCES organizations(uuid),
+    created_at       timestamp NOT NULL DEFAULT current_timestamp,
+    updated_at       timestamp,
+    CONSTRAINT project_budgets_category_chk
+        CHECK (category IN ('LABOR','MATERIAL','EXPENSE','OTHER')),
+    CONSTRAINT project_budgets_unique_category_per_project UNIQUE (project_id, category)
+);
+CREATE INDEX project_budgets_org_project_idx ON project_budgets(organization_id, project_id);

--- a/src/main/resources/db/migration/V0023__time_entry_billing.sql
+++ b/src/main/resources/db/migration/V0023__time_entry_billing.sql
@@ -1,0 +1,7 @@
+-- Project module: billing. Mark time entries as billed and link them to the
+-- generated AR invoice so the same time is never billed twice.
+ALTER TABLE time_entries
+    ADD COLUMN invoiced boolean NOT NULL DEFAULT false,
+    ADD COLUMN invoice_id uuid REFERENCES invoices(id) ON DELETE SET NULL;
+
+CREATE INDEX time_entries_invoice_idx ON time_entries(invoice_id);

--- a/src/main/resources/db/migration/V0034__login_link_tokens.sql
+++ b/src/main/resources/db/migration/V0034__login_link_tokens.sql
@@ -1,0 +1,19 @@
+-- Auth: passwordless magic-link login tokens.
+-- Single-use, short-lived tokens that authenticate an existing user via a
+-- link sent to their email. Distinct from password_reset_tokens so the two
+-- flows cannot be confused: a password-reset URL cannot mint a session,
+-- and a magic-link URL cannot change a password.
+
+CREATE TABLE login_link_tokens (
+    id          uuid PRIMARY KEY,
+    token_hash  text NOT NULL,
+    user_id     uuid NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+    expiry_at   timestamp NOT NULL,
+    consumed_at timestamp,
+    ip_address  text,
+    user_agent  text,
+    created_at  timestamp NOT NULL DEFAULT current_timestamp,
+    CONSTRAINT login_link_tokens_unique_hash UNIQUE (token_hash)
+);
+CREATE INDEX login_link_tokens_user_idx ON login_link_tokens(user_id);
+CREATE INDEX login_link_tokens_open_idx ON login_link_tokens(expiry_at) WHERE consumed_at IS NULL;

--- a/src/main/resources/graphql/attendance.graphqls
+++ b/src/main/resources/graphql/attendance.graphqls
@@ -1,0 +1,10 @@
+extend type Query {
+  attendance(employeeId: String, from: String, to: String): JSON!
+  attendanceRecord(id: ID!): JSON!
+}
+
+extend type Mutation {
+  clockIn(input: JSON!): JSON!
+  clockOut(input: JSON!): JSON!
+  recordAttendance(input: JSON!): JSON!
+}

--- a/src/main/resources/graphql/hr.graphqls
+++ b/src/main/resources/graphql/hr.graphqls
@@ -4,6 +4,7 @@ extend type Query {
 
   departments(activeOnly: Boolean = false): JSON!
   department(id: ID!): JSON!
+  departmentOrgChart: JSON!
 
   employees(status: String, departmentId: String): JSON!
   employee(id: ID!): JSON!
@@ -30,6 +31,7 @@ extend type Mutation {
 
   createDepartment(input: JSON!): JSON!
   updateDepartment(id: ID!, input: JSON!): JSON!
+  setDepartmentParent(id: ID!, input: JSON): JSON!
   deactivateDepartment(id: ID!): JSON!
 
   createEmployee(input: JSON!): JSON!

--- a/src/main/resources/graphql/me.graphqls
+++ b/src/main/resources/graphql/me.graphqls
@@ -1,0 +1,11 @@
+extend type Query {
+  me: JSON!
+  myLeaveRequests: JSON!
+  myLeaveBalance(leaveTypeId: ID!, year: Int): JSON!
+  myCompensation: JSON!
+  myCurrentCompensation(asOf: String): JSON!
+}
+
+extend type Mutation {
+  submitMyLeave(input: JSON!): JSON!
+}

--- a/src/main/resources/graphql/project-billing.graphqls
+++ b/src/main/resources/graphql/project-billing.graphqls
@@ -1,0 +1,3 @@
+extend type Mutation {
+  generateProjectInvoice(projectId: ID!, input: JSON): JSON!
+}

--- a/src/main/resources/graphql/project-budgets.graphqls
+++ b/src/main/resources/graphql/project-budgets.graphqls
@@ -1,0 +1,8 @@
+extend type Query {
+  projectBudgets(projectId: ID!): JSON!
+  projectBudgetVsActual(projectId: ID!): JSON!
+}
+
+extend type Mutation {
+  setProjectBudget(projectId: ID!, input: JSON!): JSON!
+}

--- a/src/main/resources/graphql/project-tasks.graphqls
+++ b/src/main/resources/graphql/project-tasks.graphqls
@@ -1,0 +1,11 @@
+extend type Query {
+  projectTasks(projectId: ID!): JSON!
+  projectTaskTree(projectId: ID!): JSON!
+  projectTask(projectId: ID!, taskId: ID!): JSON!
+}
+
+extend type Mutation {
+  createProjectTask(projectId: ID!, input: JSON!): JSON!
+  updateProjectTask(projectId: ID!, taskId: ID!, input: JSON!): JSON!
+  setProjectTaskParent(projectId: ID!, taskId: ID!, input: JSON): JSON!
+}

--- a/src/main/resources/graphql/projects.graphqls
+++ b/src/main/resources/graphql/projects.graphqls
@@ -1,0 +1,13 @@
+extend type Query {
+  projects(status: String, customerId: String): JSON!
+  project(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createProject(input: JSON!): JSON!
+  updateProject(id: ID!, input: JSON!): JSON!
+  activateProject(id: ID!): JSON!
+  holdProject(id: ID!): JSON!
+  closeProject(id: ID!): JSON!
+  cancelProject(id: ID!): JSON!
+}

--- a/src/main/resources/graphql/purchase-requests.graphqls
+++ b/src/main/resources/graphql/purchase-requests.graphqls
@@ -1,0 +1,13 @@
+extend type Query {
+  purchaseRequests(status: String, requestedBy: String): JSON!
+  purchaseRequest(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createPurchaseRequest(input: JSON!): JSON!
+  submitPurchaseRequest(id: ID!): JSON!
+  approvePurchaseRequest(id: ID!): JSON!
+  rejectPurchaseRequest(id: ID!, input: JSON): JSON!
+  cancelPurchaseRequest(id: ID!): JSON!
+  convertPurchaseRequest(id: ID!, input: JSON): JSON!
+}

--- a/src/main/resources/graphql/time-entries.graphqls
+++ b/src/main/resources/graphql/time-entries.graphqls
@@ -1,0 +1,12 @@
+extend type Query {
+  timeEntries(employeeId: String, projectId: String, status: String): JSON!
+  timeEntry(id: ID!): JSON!
+}
+
+extend type Mutation {
+  createTimeEntry(input: JSON!): JSON!
+  updateTimeEntry(id: ID!, input: JSON!): JSON!
+  submitTimeEntry(id: ID!): JSON!
+  approveTimeEntry(id: ID!): JSON!
+  rejectTimeEntry(id: ID!): JSON!
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/config/RoleSeederTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/config/RoleSeederTest.kt
@@ -104,6 +104,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         `when`(roleRepository.findByName(any())).thenReturn(Optional.empty())
@@ -308,6 +311,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         val admin =
@@ -361,6 +367,9 @@ class RoleSeederTest {
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
                         Permissions.HR_APPROVE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
+                        Permissions.PROJECT_APPROVE,
                     ),
             )
         val member =
@@ -393,6 +402,8 @@ class RoleSeederTest {
                         Permissions.SALES_WRITE,
                         Permissions.HR_READ,
                         Permissions.HR_WRITE,
+                        Permissions.PROJECT_READ,
+                        Permissions.PROJECT_WRITE,
                     ),
             )
         val viewer =
@@ -415,6 +426,7 @@ class RoleSeederTest {
                         Permissions.PROCUREMENT_READ,
                         Permissions.SALES_READ,
                         Permissions.HR_READ,
+                        Permissions.PROJECT_READ,
                     ),
             )
 

--- a/src/test/kotlin/com/aquinofroilan/tessera/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/controller/AuthControllerTest.kt
@@ -20,6 +20,7 @@ import com.aquinofroilan.tessera.security.SessionContext
 import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
 import com.aquinofroilan.tessera.service.ApiKeyService
 import com.aquinofroilan.tessera.service.AuthService
+import com.aquinofroilan.tessera.service.LoginLinkService
 import com.aquinofroilan.tessera.util.TokenHasher
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.times
@@ -54,6 +55,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private lateinit var authService: AuthService
+
+    @MockitoBean
+    private lateinit var loginLinkService: LoginLinkService
 
     @MockitoBean
     private lateinit var sessionTokenRepository: SessionTokenRepository

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/AttendanceGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/AttendanceGraphqlControllerTest.kt
@@ -1,0 +1,91 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.AttendanceController
+import com.aquinofroilan.tessera.dto.ClockRequest
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [AttendanceGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class AttendanceGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var attendanceController: AttendanceController
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `attendance query should return json payload`() {
+        `when`(attendanceController.listTimesheet(null, null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "a1", "status" to "PRESENT"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  attendance
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("attendance[0].id")
+            .entity(String::class.java)
+            .isEqualTo("a1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["hr:write"])
+    fun `clockIn mutation should bridge to controller`() {
+        `when`(attendanceController.clockIn(any<ClockRequest>()))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "a1", "status" to "PRESENT")))
+
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  clockIn(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("employeeId" to "e1"))
+            .execute()
+            .path("clockIn.status")
+            .entity(String::class.java)
+            .isEqualTo("PRESENT")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `clockIn mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  clockIn(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("employeeId" to "e1"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/HrGraphqlControllerTest.kt
@@ -72,6 +72,29 @@ class HrGraphqlControllerTest {
     }
 
     @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `departmentOrgChart query should return the nested tree`() {
+        `when`(departmentController.getOrgChart())
+            .thenReturn(
+                ResponseEntity.ok(
+                    listOf(mapOf("id" to "d1", "children" to listOf(mapOf("id" to "d2", "children" to emptyList<Any>())))),
+                ),
+            )
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  departmentOrgChart
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("departmentOrgChart[0].children[0].id")
+            .entity(String::class.java)
+            .isEqualTo("d2")
+    }
+
+    @Test
     @WithMockUser(authorities = ["hr:approve"])
     fun `approvePayrollRun mutation should bridge to controller`() {
         `when`(payrollRunController.approvePayrollRun("pr1"))

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectBillingGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectBillingGraphqlControllerTest.kt
@@ -1,0 +1,70 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.ProjectBillingController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [ProjectBillingGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class ProjectBillingGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var projectBillingController: ProjectBillingController
+
+    @Test
+    @WithMockUser(authorities = ["projects:write"])
+    fun `generateProjectInvoice mutation should bridge to controller`() {
+        whenever(projectBillingController.generateInvoice(eq("p1"), anyOrNull()))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "inv1", "status" to "DRAFT")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  generateProjectInvoice(projectId: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("generateProjectInvoice.id")
+            .entity(String::class.java)
+            .isEqualTo("inv1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `generateProjectInvoice mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  generateProjectInvoice(projectId: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectBudgetGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectBudgetGraphqlControllerTest.kt
@@ -1,0 +1,69 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.ProjectBudgetController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [ProjectBudgetGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class ProjectBudgetGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var projectBudgetController: ProjectBudgetController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `projectBudgets query should return json payload`() {
+        `when`(projectBudgetController.listBudgets("p1"))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("category" to "LABOR", "budgetAmount" to "1000"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  projectBudgets(projectId: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("projectBudgets[0].category")
+            .entity(String::class.java)
+            .isEqualTo("LABOR")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `setProjectBudget mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  setProjectBudget(projectId: "p1", input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("category" to "LABOR", "budgetAmount" to "1000"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectGraphqlControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.ProjectController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [ProjectGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class ProjectGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var projectController: ProjectController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `projects query should return json payload`() {
+        `when`(projectController.listProjects(null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "p1", "status" to "PLANNED"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  projects
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("projects[0].id")
+            .entity(String::class.java)
+            .isEqualTo("p1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:write"])
+    fun `activateProject mutation should bridge to controller`() {
+        `when`(projectController.activateProject("p1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "p1", "status" to "ACTIVE")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  activateProject(id: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("activateProject.status")
+            .entity(String::class.java)
+            .isEqualTo("ACTIVE")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `createProject mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createProject(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("name" to "Apollo"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectTaskGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/ProjectTaskGraphqlControllerTest.kt
@@ -1,0 +1,69 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.ProjectTaskController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [ProjectTaskGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class ProjectTaskGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var projectTaskController: ProjectTaskController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `projectTasks query should return json payload`() {
+        `when`(projectTaskController.listTasks("p1"))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "t1", "status" to "TODO"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  projectTasks(projectId: "p1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("projectTasks[0].id")
+            .entity(String::class.java)
+            .isEqualTo("t1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `createProjectTask mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createProjectTask(projectId: "p1", input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("name" to "Design"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/PurchaseRequestGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/PurchaseRequestGraphqlControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.PurchaseRequestController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [PurchaseRequestGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class PurchaseRequestGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var purchaseRequestController: PurchaseRequestController
+
+    @Test
+    @WithMockUser(authorities = ["procurement:read"])
+    fun `purchaseRequests query should return json payload`() {
+        `when`(purchaseRequestController.listPurchaseRequests(null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "pr1", "status" to "DRAFT"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  purchaseRequests
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("purchaseRequests[0].id")
+            .entity(String::class.java)
+            .isEqualTo("pr1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["procurement:approve"])
+    fun `approvePurchaseRequest mutation should bridge to controller`() {
+        `when`(purchaseRequestController.approvePurchaseRequest("pr1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "pr1", "status" to "APPROVED")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  approvePurchaseRequest(id: "pr1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("approvePurchaseRequest.status")
+            .entity(String::class.java)
+            .isEqualTo("APPROVED")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["procurement:read"])
+    fun `createPurchaseRequest mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createPurchaseRequest(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("lines" to emptyList<Any>()))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/SelfServiceGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/SelfServiceGraphqlControllerTest.kt
@@ -1,0 +1,89 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.SelfServiceController
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [SelfServiceGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class SelfServiceGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var selfServiceController: SelfServiceController
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `me query returns the caller profile`() {
+        `when`(selfServiceController.myProfile())
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "e1", "firstName" to "Ada")))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  me
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("me.id")
+            .entity(String::class.java)
+            .isEqualTo("e1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["hr:read"])
+    fun `submitMyLeave mutation bridges to controller`() {
+        `when`(selfServiceController.submitLeave(any<SubmitSelfLeaveRequest>()))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "lr1", "status" to "PENDING")))
+
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  submitMyLeave(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("leaveTypeId" to "lt1", "startDate" to "2026-05-01", "endDate" to "2026-05-03"))
+            .execute()
+            .path("submitMyLeave.status")
+            .entity(String::class.java)
+            .isEqualTo("PENDING")
+    }
+
+    @Test
+    fun `me query is denied for an unauthenticated caller`() {
+        graphQlTester
+            .document(
+                """
+                query {
+                  me
+                }
+                """.trimIndent(),
+            ).execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/graphql/TimeEntryGraphqlControllerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/graphql/TimeEntryGraphqlControllerTest.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.graphql
+
+import com.aquinofroilan.tessera.config.TestSecurityConfig
+import com.aquinofroilan.tessera.controller.TimeEntryController
+import com.aquinofroilan.tessera.security.TesseraPermissionEvaluator
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest
+import org.springframework.context.annotation.Import
+import org.springframework.graphql.test.tester.GraphQlTester
+import org.springframework.http.ResponseEntity
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@GraphQlTest(controllers = [TimeEntryGraphqlController::class])
+@Import(
+    TestSecurityConfig::class,
+    TesseraPermissionEvaluator::class,
+    GraphqlExceptionResolver::class,
+    GraphqlScalarConfig::class,
+    GraphqlBridgeSupport::class,
+)
+class TimeEntryGraphqlControllerTest {
+    @Autowired
+    private lateinit var graphQlTester: GraphQlTester
+
+    @MockitoBean
+    private lateinit var timeEntryController: TimeEntryController
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `timeEntries query should return json payload`() {
+        `when`(timeEntryController.listTimeEntries(null, null, null))
+            .thenReturn(ResponseEntity.ok(listOf(mapOf("id" to "te1", "status" to "DRAFT"))))
+
+        graphQlTester
+            .document(
+                """
+                query {
+                  timeEntries
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("timeEntries[0].id")
+            .entity(String::class.java)
+            .isEqualTo("te1")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:approve"])
+    fun `approveTimeEntry mutation should bridge to controller`() {
+        `when`(timeEntryController.approveTimeEntry("te1"))
+            .thenReturn(ResponseEntity.ok(mapOf("id" to "te1", "status" to "APPROVED")))
+
+        graphQlTester
+            .document(
+                """
+                mutation {
+                  approveTimeEntry(id: "te1")
+                }
+                """.trimIndent(),
+            ).execute()
+            .path("approveTimeEntry.status")
+            .entity(String::class.java)
+            .isEqualTo("APPROVED")
+    }
+
+    @Test
+    @WithMockUser(authorities = ["projects:read"])
+    fun `createTimeEntry mutation should be denied without write authority`() {
+        graphQlTester
+            .document(
+                """
+                mutation(${'$'}input: JSON!) {
+                  createTimeEntry(input: ${'$'}input)
+                }
+                """.trimIndent(),
+            ).variable("input", mapOf("employeeId" to "e1", "projectId" to "p1"))
+            .execute()
+            .errors()
+            .satisfy { errors ->
+                org.assertj.core.api.Assertions
+                    .assertThat(errors)
+                    .isNotEmpty()
+            }
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/AttendanceServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/AttendanceServiceTest.kt
@@ -1,0 +1,167 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.RecordAttendanceRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.AttendanceRecord
+import com.aquinofroilan.tessera.model.AttendanceStatus
+import com.aquinofroilan.tessera.model.Employee
+import com.aquinofroilan.tessera.model.EmploymentStatus
+import com.aquinofroilan.tessera.repository.AttendanceRecordRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.Optional
+
+class AttendanceServiceTest {
+    private lateinit var repository: AttendanceRecordRepository
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: AttendanceService
+
+    private val orgId = "org-1"
+    private val empId = "e1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(AttendanceRecordRepository::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.save(any<AttendanceRecord>())).thenAnswer { it.arguments[0] }
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(employee())
+        whenever(repository.findByOrganizationIdAndEmployeeIdAndWorkDate(any(), any(), any())).thenReturn(Optional.empty())
+        service = AttendanceService(repository, employeeService)
+    }
+
+    private fun employee(status: EmploymentStatus = EmploymentStatus.ACTIVE) =
+        Employee(
+            id = empId,
+            employeeNumber = "EMP-0001",
+            firstName = "Ada",
+            lastName = "Lovelace",
+            hireDate = LocalDate.of(2020, 1, 1),
+            status = status,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `clock-in creates a present record`() {
+        val record = service.clockIn(empId, orgId)
+
+        assertThat(record.clockIn).isNotNull()
+        assertThat(record.clockOut).isNull()
+        assertThat(record.status).isEqualTo(AttendanceStatus.PRESENT)
+        assertThat(record.workDate).isEqualTo(LocalDate.now(ZoneOffset.UTC))
+    }
+
+    @Test
+    fun `clock-in rejects a second clock-in the same day`() {
+        whenever(repository.findByOrganizationIdAndEmployeeIdAndWorkDate(any(), any(), any()))
+            .thenReturn(Optional.of(record(clockIn = LocalDateTime.now(ZoneOffset.UTC))))
+
+        assertThatThrownBy { service.clockIn(empId, orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `clock-in is rejected for a terminated employee`() {
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(employee(EmploymentStatus.TERMINATED))
+
+        assertThatThrownBy { service.clockIn(empId, orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `clock-out sets worked minutes`() {
+        val start = LocalDateTime.now(ZoneOffset.UTC).minusHours(8)
+        whenever(repository.findByOrganizationIdAndEmployeeIdAndWorkDate(any(), any(), any()))
+            .thenReturn(Optional.of(record(clockIn = start)))
+
+        val record = service.clockOut(empId, orgId)
+
+        assertThat(record.clockOut).isNotNull()
+        assertThat(record.workedMinutes).isGreaterThanOrEqualTo(8 * 60)
+    }
+
+    @Test
+    fun `clock-out without a clock-in is rejected`() {
+        assertThatThrownBy { service.clockOut(empId, orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `clock-out twice is rejected`() {
+        val now = LocalDateTime.now(ZoneOffset.UTC)
+        whenever(repository.findByOrganizationIdAndEmployeeIdAndWorkDate(any(), any(), any()))
+            .thenReturn(Optional.of(record(clockIn = now.minusHours(8), clockOut = now)))
+
+        assertThatThrownBy { service.clockOut(empId, orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `manual entry computes worked minutes and defaults to present`() {
+        val day = LocalDate.of(2026, 5, 1)
+        val record =
+            service.recordAttendance(
+                RecordAttendanceRequest(
+                    employeeId = empId,
+                    workDate = day,
+                    clockIn = day.atTime(9, 0),
+                    clockOut = day.atTime(17, 30),
+                ),
+                orgId,
+            )
+
+        assertThat(record.status).isEqualTo(AttendanceStatus.PRESENT)
+        assertThat(record.workedMinutes).isEqualTo(8 * 60 + 30)
+    }
+
+    @Test
+    fun `manual entry rejects clock-out before clock-in`() {
+        val day = LocalDate.of(2026, 5, 1)
+        assertThatThrownBy {
+            service.recordAttendance(
+                RecordAttendanceRequest(
+                    employeeId = empId,
+                    workDate = day,
+                    clockIn = day.atTime(17, 0),
+                    clockOut = day.atTime(9, 0),
+                ),
+                orgId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("a1"))
+            .thenReturn(Optional.of(record(clockIn = null).copy(id = "a1", organizationId = "other")))
+
+        assertThatThrownBy { service.getAttendance("a1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `timesheet rejects an inverted date range`() {
+        assertThatThrownBy {
+            service.listTimesheet(orgId, from = LocalDate.of(2026, 5, 10), to = LocalDate.of(2026, 5, 1))
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    private fun record(
+        clockIn: LocalDateTime? = null,
+        clockOut: LocalDateTime? = null,
+    ) = AttendanceRecord(
+        employeeId = empId,
+        workDate = LocalDate.now(ZoneOffset.UTC),
+        clockIn = clockIn,
+        clockOut = clockOut,
+        organizationId = orgId,
+    )
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/CsvCodecTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/CsvCodecTest.kt
@@ -1,0 +1,53 @@
+package com.aquinofroilan.tessera.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CsvCodecTest {
+    @Test
+    fun `encode round-trips simple rows`() {
+        val csv =
+            CsvCodec.encode(
+                listOf("sku", "name"),
+                listOf(
+                    mapOf("sku" to "A", "name" to "Widget"),
+                    mapOf("sku" to "B", "name" to "Gadget"),
+                ),
+            )
+        assertThat(csv).contains("sku,name").contains("A,Widget").contains("B,Gadget")
+    }
+
+    @Test
+    fun `encode quotes fields containing commas and quotes`() {
+        val csv =
+            CsvCodec.encode(
+                listOf("name"),
+                listOf(mapOf("name" to "Smith, John \"Jr.\"")),
+            )
+        assertThat(csv).contains("\"Smith, John \"\"Jr.\"\"\"")
+    }
+
+    @Test
+    fun `decode parses headers + rows including quoted commas`() {
+        val csv = "sku,name\r\nA,\"Widget, Deluxe\"\r\nB,Gadget\r\n"
+        val rows = CsvCodec.decode(csv)
+        assertThat(rows).hasSize(2)
+        assertThat(rows[0]["sku"]).isEqualTo("A")
+        assertThat(rows[0]["name"]).isEqualTo("Widget, Deluxe")
+        assertThat(rows[1]["name"]).isEqualTo("Gadget")
+    }
+
+    @Test
+    fun `decode handles escaped quotes inside quoted field`() {
+        val csv = "name\r\n\"He said \"\"hi\"\"\"\r\n"
+        val rows = CsvCodec.decode(csv)
+        assertThat(rows[0]["name"]).isEqualTo("He said \"hi\"")
+    }
+
+    @Test
+    fun `decode skips blank trailing rows`() {
+        val csv = "sku\r\nA\r\n\r\n"
+        val rows = CsvCodec.decode(csv)
+        assertThat(rows).hasSize(1)
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/DepartmentServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/DepartmentServiceTest.kt
@@ -76,4 +76,61 @@ class DepartmentServiceTest {
         assertThatThrownBy { service.deactivateDepartment("d1", orgId) }
             .isInstanceOf(BusinessRuleException::class.java)
     }
+
+    @Test
+    fun `create with a parent validates the parent belongs to the org`() {
+        whenever(repository.findById("p1")).thenReturn(Optional.empty())
+
+        assertThatThrownBy {
+            service.createDepartment(CreateDepartmentRequest(code = "ENG", name = "Eng", parentId = "p1"), orgId)
+        }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `setParent rejects self-parenting`() {
+        whenever(repository.findById("d1"))
+            .thenReturn(Optional.of(Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId)))
+
+        assertThatThrownBy { service.setParent("d1", "d1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `setParent rejects a move that would create a cycle`() {
+        val parent = Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId)
+        val child = Department(id = "d2", code = "BE", name = "Backend", organizationId = orgId, parentId = "d1")
+        whenever(repository.findById("d1")).thenReturn(Optional.of(parent))
+        whenever(repository.findById("d2")).thenReturn(Optional.of(child))
+        whenever(repository.findByOrganizationId(orgId)).thenReturn(listOf(parent, child))
+
+        // Making d1 (an ancestor) a child of d2 (its descendant) is a cycle.
+        assertThatThrownBy { service.setParent("d1", "d2", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `setParent clears the parent when null`() {
+        whenever(repository.findById("d2"))
+            .thenReturn(Optional.of(Department(id = "d2", code = "BE", name = "Backend", organizationId = orgId, parentId = "d1")))
+
+        val updated = service.setParent("d2", null, orgId)
+
+        assertThat(updated.parentId).isNull()
+    }
+
+    @Test
+    fun `org chart nests children under their roots`() {
+        val root = Department(id = "d1", code = "ENG", name = "Engineering", organizationId = orgId)
+        val child = Department(id = "d2", code = "BE", name = "Backend", organizationId = orgId, parentId = "d1")
+        val grandchild = Department(id = "d3", code = "API", name = "API", organizationId = orgId, parentId = "d2")
+        whenever(repository.findByOrganizationId(orgId)).thenReturn(listOf(child, root, grandchild))
+
+        val chart = service.getOrgChart(orgId)
+
+        assertThat(chart).hasSize(1)
+        assertThat(chart[0].id).isEqualTo("d1")
+        assertThat(chart[0].children).hasSize(1)
+        assertThat(chart[0].children[0].id).isEqualTo("d2")
+        assertThat(chart[0].children[0].children[0].id).isEqualTo("d3")
+    }
 }

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/EmployeeServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/EmployeeServiceTest.kt
@@ -2,6 +2,7 @@ package com.aquinofroilan.tessera.service
 
 import com.aquinofroilan.tessera.dto.CreateEmployeeRequest
 import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
 import com.aquinofroilan.tessera.model.Department
 import com.aquinofroilan.tessera.model.Employee
 import com.aquinofroilan.tessera.model.EmploymentStatus
@@ -100,5 +101,38 @@ class EmployeeServiceTest {
         whenever(repository.findById("e1")).thenReturn(Optional.of(employee(status = EmploymentStatus.TERMINATED)))
         assertThatThrownBy { service.assignDepartment("e1", "d1", orgId) }
             .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `create links a user`() {
+        whenever(repository.findByOrganizationIdAndUserId(orgId, "u1")).thenReturn(Optional.empty())
+        val emp =
+            service.createEmployee(
+                CreateEmployeeRequest(firstName = "Ada", lastName = "Lovelace", hireDate = hireDate, userId = "u1"),
+                orgId,
+            )
+        assertThat(emp.userId).isEqualTo("u1")
+    }
+
+    @Test
+    fun `create rejects linking a user already linked to another employee`() {
+        whenever(repository.findByOrganizationIdAndUserId(orgId, "u1"))
+            .thenReturn(Optional.of(employee(id = "other")))
+        assertThatThrownBy {
+            service.createEmployee(
+                CreateEmployeeRequest(firstName = "Ada", lastName = "Lovelace", hireDate = hireDate, userId = "u1"),
+                orgId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `getEmployeeByUser resolves the linked employee or throws`() {
+        whenever(repository.findByOrganizationIdAndUserId(orgId, "u1")).thenReturn(Optional.of(employee()))
+        assertThat(service.getEmployeeByUser("u1", orgId).id).isEqualTo("e1")
+
+        whenever(repository.findByOrganizationIdAndUserId(orgId, "u2")).thenReturn(Optional.empty())
+        assertThatThrownBy { service.getEmployeeByUser("u2", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
     }
 }

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/LoginLinkServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/LoginLinkServiceTest.kt
@@ -1,0 +1,172 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.exception.AuthenticationException
+import com.aquinofroilan.tessera.model.LoginLinkToken
+import com.aquinofroilan.tessera.model.RefreshToken
+import com.aquinofroilan.tessera.model.SessionToken
+import com.aquinofroilan.tessera.model.User
+import com.aquinofroilan.tessera.repository.LoginLinkTokenRepository
+import com.aquinofroilan.tessera.repository.RefreshTokenRepository
+import com.aquinofroilan.tessera.repository.SessionTokenRepository
+import com.aquinofroilan.tessera.repository.UserRepository
+import com.aquinofroilan.tessera.util.TokenHasher
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.Optional
+
+class LoginLinkServiceTest {
+    private lateinit var userRepository: UserRepository
+    private lateinit var loginLinkTokenRepository: LoginLinkTokenRepository
+    private lateinit var sessionTokenRepository: SessionTokenRepository
+    private lateinit var refreshTokenRepository: RefreshTokenRepository
+    private lateinit var tokenHasher: TokenHasher
+    private lateinit var service: LoginLinkService
+
+    private val email = "ada@example.com"
+    private val orgId = "org-1"
+    private val userId = "u-1"
+
+    @BeforeEach
+    fun setup() {
+        userRepository = mock(UserRepository::class.java)
+        loginLinkTokenRepository = mock(LoginLinkTokenRepository::class.java)
+        sessionTokenRepository = mock(SessionTokenRepository::class.java)
+        refreshTokenRepository = mock(RefreshTokenRepository::class.java)
+        tokenHasher = TokenHasher("SHA-256").apply { validate() }
+        whenever(loginLinkTokenRepository.save(any<LoginLinkToken>())).thenAnswer { it.arguments[0] }
+        whenever(sessionTokenRepository.save(any<SessionToken>())).thenAnswer { it.arguments[0] }
+        whenever(refreshTokenRepository.save(any<RefreshToken>())).thenAnswer { it.arguments[0] }
+        service =
+            LoginLinkService(
+                userRepository,
+                loginLinkTokenRepository,
+                sessionTokenRepository,
+                refreshTokenRepository,
+                tokenHasher,
+                linkExpiryMinutes = 15,
+                tokenValidityMs = 60_000,
+                refreshTokenValidityMs = 600_000,
+            )
+    }
+
+    @Test
+    fun `request returns null for unknown email (uniform response)`() {
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.empty())
+        assertThat(service.request(email)).isNull()
+    }
+
+    @Test
+    fun `request returns null for inactive user`() {
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user(isActive = false)))
+        assertThat(service.request(email)).isNull()
+    }
+
+    @Test
+    fun `request issues a raw token and wipes outstanding ones`() {
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user()))
+        val rawToken = service.request(email)
+        assertThat(rawToken).isNotBlank
+        org.mockito.kotlin
+            .verify(loginLinkTokenRepository)
+            .deleteByUserId(userId)
+    }
+
+    @Test
+    fun `consume rejects unknown token`() {
+        whenever(loginLinkTokenRepository.findByTokenHash(any())).thenReturn(Optional.empty())
+        assertThatThrownBy { service.consume("garbage") }
+            .isInstanceOf(AuthenticationException::class.java)
+    }
+
+    @Test
+    fun `consume rejects expired token and cleans it up`() {
+        val token = tokenHasher.generate(32)
+        val hash = tokenHasher.hash(token)
+        val expired =
+            LoginLinkToken(
+                tokenHash = hash,
+                userId = userId,
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).minusMinutes(1),
+            )
+        whenever(loginLinkTokenRepository.findByTokenHash(eq(hash))).thenReturn(Optional.of(expired))
+        assertThatThrownBy { service.consume(token) }
+            .isInstanceOf(AuthenticationException::class.java)
+    }
+
+    @Test
+    fun `consume rejects already-consumed token`() {
+        val token = tokenHasher.generate(32)
+        val hash = tokenHasher.hash(token)
+        val consumed =
+            LoginLinkToken(
+                tokenHash = hash,
+                userId = userId,
+                expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                consumedAt = LocalDateTime.now(ZoneOffset.UTC),
+            )
+        whenever(loginLinkTokenRepository.findByTokenHash(eq(hash))).thenReturn(Optional.of(consumed))
+        assertThatThrownBy { service.consume(token) }
+            .isInstanceOf(AuthenticationException::class.java)
+    }
+
+    @Test
+    fun `consume on valid token mints session + refresh tokens`() {
+        val token = tokenHasher.generate(32)
+        val hash = tokenHasher.hash(token)
+        whenever(loginLinkTokenRepository.findByTokenHash(eq(hash))).thenReturn(
+            Optional.of(
+                LoginLinkToken(
+                    tokenHash = hash,
+                    userId = userId,
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                ),
+            ),
+        )
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(user()))
+
+        val response = service.consume(token, ipAddress = "1.2.3.4", userAgent = "ua")
+
+        assertThat(response.accessToken).isNotBlank
+        assertThat(response.refreshToken).isNotBlank
+        assertThat(response.username).isEqualTo("ada")
+        assertThat(response.organizationId).isEqualTo(orgId)
+    }
+
+    @Test
+    fun `consume rejects when user has become inactive after request`() {
+        val token = tokenHasher.generate(32)
+        val hash = tokenHasher.hash(token)
+        whenever(loginLinkTokenRepository.findByTokenHash(eq(hash))).thenReturn(
+            Optional.of(
+                LoginLinkToken(
+                    tokenHash = hash,
+                    userId = userId,
+                    expiryAt = LocalDateTime.now(ZoneOffset.UTC).plusMinutes(5),
+                ),
+            ),
+        )
+        whenever(userRepository.findById(userId)).thenReturn(Optional.of(user(isActive = false)))
+        assertThatThrownBy { service.consume(token) }
+            .isInstanceOf(AuthenticationException::class.java)
+    }
+
+    private fun user(isActive: Boolean = true) =
+        User(
+            uuid = userId,
+            username = "ada",
+            email = email,
+            firstName = "Ada",
+            lastName = "Lovelace",
+            passwordHash = "ignored",
+            organizationId = orgId,
+            isActive = isActive,
+        )
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectBillingServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectBillingServiceTest.kt
@@ -1,0 +1,129 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateInvoiceRequest
+import com.aquinofroilan.tessera.dto.GenerateProjectInvoiceRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.model.Customer
+import com.aquinofroilan.tessera.model.Invoice
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+class ProjectBillingServiceTest {
+    private lateinit var projectService: ProjectService
+    private lateinit var customerService: CustomerService
+    private lateinit var timeEntryRepository: TimeEntryRepository
+    private lateinit var invoiceService: InvoiceService
+    private lateinit var service: ProjectBillingService
+
+    private val orgId = "org-1"
+    private val projectId = "p-1"
+    private val userId = "u-1"
+    private val day = LocalDate.of(2026, 5, 1)
+
+    @BeforeEach
+    fun setup() {
+        projectService = mock(ProjectService::class.java)
+        customerService = mock(CustomerService::class.java)
+        timeEntryRepository = mock(TimeEntryRepository::class.java)
+        invoiceService = mock(InvoiceService::class.java)
+        whenever(projectService.getProject(projectId, orgId)).thenReturn(project(customerId = "c-1"))
+        whenever(customerService.getCustomer("c-1", orgId)).thenReturn(
+            Customer(id = "c-1", name = "Globex", paymentTermDays = 30, defaultRevenueAccountId = "acc-1", organizationId = orgId),
+        )
+        val invoice = mock(Invoice::class.java)
+        whenever(invoice.id).thenReturn("inv-1")
+        whenever(invoiceService.createInvoice(any(), eq(orgId), eq(userId))).thenReturn(invoice)
+        service = ProjectBillingService(projectService, customerService, timeEntryRepository, invoiceService)
+    }
+
+    private fun project(customerId: String?) =
+        Project(
+            id = projectId,
+            projectNumber = "PRJ-0001",
+            name = "Apollo",
+            startDate = day,
+            customerId = customerId,
+            organizationId = orgId,
+        )
+
+    private fun entry(
+        rate: String?,
+        billable: Boolean = true,
+        invoiced: Boolean = false,
+    ) = TimeEntry(
+        id = UUID.randomUUID().toString(),
+        employeeId = "e-1",
+        projectId = projectId,
+        entryDate = day,
+        hours = BigDecimal("4"),
+        billable = billable,
+        rate = rate?.let { BigDecimal(it) },
+        status = TimeEntryStatus.APPROVED,
+        invoiced = invoiced,
+        organizationId = orgId,
+    )
+
+    @Test
+    fun `generate invoice bills approved billable time and marks it invoiced`() {
+        whenever(timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(orgId, projectId, TimeEntryStatus.APPROVED))
+            .thenReturn(listOf(entry("50"), entry("50"), entry(null), entry("50", billable = false), entry("50", invoiced = true)))
+
+        val invoice = service.generateInvoice(projectId, GenerateProjectInvoiceRequest(), orgId, userId)
+
+        assertThat(invoice.id).isEqualTo("inv-1")
+        val captor = argumentCaptor<CreateInvoiceRequest>()
+        verify(invoiceService).createInvoice(captor.capture(), eq(orgId), eq(userId))
+        // Only the two billable, un-invoiced, rated entries are billed.
+        assertThat(captor.firstValue.lines).hasSize(2)
+        assertThat(captor.firstValue.lines[0].accountId).isEqualTo("acc-1")
+        assertThat(captor.firstValue.lines[0].amount).isEqualByComparingTo("200")
+        assertThat(captor.firstValue.customerId).isEqualTo("c-1")
+
+        val saved = argumentCaptor<List<TimeEntry>>()
+        verify(timeEntryRepository).saveAll(saved.capture())
+        assertThat(saved.firstValue).hasSize(2)
+        assertThat(saved.firstValue).allMatch { it.invoiced && it.invoiceId == "inv-1" }
+    }
+
+    @Test
+    fun `generate invoice fails when the project has no customer`() {
+        whenever(projectService.getProject(projectId, orgId)).thenReturn(project(customerId = null))
+        assertThatThrownBy { service.generateInvoice(projectId, GenerateProjectInvoiceRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `generate invoice fails when no revenue account can be resolved`() {
+        whenever(customerService.getCustomer("c-1", orgId))
+            .thenReturn(Customer(id = "c-1", name = "Globex", defaultRevenueAccountId = null, organizationId = orgId))
+        whenever(timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(orgId, projectId, TimeEntryStatus.APPROVED))
+            .thenReturn(listOf(entry("50")))
+
+        assertThatThrownBy { service.generateInvoice(projectId, GenerateProjectInvoiceRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `generate invoice fails when there is no billable time`() {
+        whenever(timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(orgId, projectId, TimeEntryStatus.APPROVED))
+            .thenReturn(listOf(entry(null), entry("50", invoiced = true)))
+
+        assertThatThrownBy { service.generateInvoice(projectId, GenerateProjectInvoiceRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectBudgetServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectBudgetServiceTest.kt
@@ -1,0 +1,107 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.SetProjectBudgetRequest
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectBudget
+import com.aquinofroilan.tessera.model.ProjectCostCategory
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.ProjectBudgetRepository
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class ProjectBudgetServiceTest {
+    private lateinit var repository: ProjectBudgetRepository
+    private lateinit var projectService: ProjectService
+    private lateinit var timeEntryRepository: TimeEntryRepository
+    private lateinit var service: ProjectBudgetService
+
+    private val orgId = "org-1"
+    private val projectId = "p-1"
+    private val day = LocalDate.of(2026, 5, 1)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(ProjectBudgetRepository::class.java)
+        projectService = mock(ProjectService::class.java)
+        timeEntryRepository = mock(TimeEntryRepository::class.java)
+        whenever(repository.save(any<ProjectBudget>())).thenAnswer { it.arguments[0] }
+        whenever(projectService.getProject(projectId, orgId)).thenReturn(
+            Project(id = projectId, projectNumber = "PRJ-0001", name = "Apollo", startDate = day, organizationId = orgId),
+        )
+        whenever(repository.findByOrganizationIdAndProjectIdAndCategory(any(), any(), any())).thenReturn(Optional.empty())
+        whenever(timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(any(), any(), any())).thenReturn(emptyList())
+        service = ProjectBudgetService(repository, projectService, timeEntryRepository)
+    }
+
+    private fun entry(
+        hours: String,
+        rate: String?,
+    ) = TimeEntry(
+        employeeId = "e-1",
+        projectId = projectId,
+        entryDate = day,
+        hours = BigDecimal(hours),
+        rate = rate?.let { BigDecimal(it) },
+        status = TimeEntryStatus.APPROVED,
+        organizationId = orgId,
+    )
+
+    @Test
+    fun `set budget creates a new category budget`() {
+        val b = service.setBudget(projectId, SetProjectBudgetRequest(ProjectCostCategory.LABOR, BigDecimal("1000")), orgId)
+        assertThat(b.category).isEqualTo(ProjectCostCategory.LABOR)
+        assertThat(b.budgetAmount).isEqualByComparingTo("1000")
+    }
+
+    @Test
+    fun `set budget updates an existing category budget`() {
+        whenever(repository.findByOrganizationIdAndProjectIdAndCategory(orgId, projectId, ProjectCostCategory.LABOR))
+            .thenReturn(
+                Optional.of(
+                    ProjectBudget(
+                        id = "b-1",
+                        projectId = projectId,
+                        category = ProjectCostCategory.LABOR,
+                        budgetAmount = BigDecimal("500"),
+                        organizationId = orgId,
+                    ),
+                ),
+            )
+        val b = service.setBudget(projectId, SetProjectBudgetRequest(ProjectCostCategory.LABOR, BigDecimal("1500")), orgId)
+        assertThat(b.id).isEqualTo("b-1")
+        assertThat(b.budgetAmount).isEqualByComparingTo("1500")
+    }
+
+    @Test
+    fun `budget vs actual computes labor actual from approved time entries`() {
+        whenever(repository.findByOrganizationIdAndProjectId(orgId, projectId)).thenReturn(
+            listOf(
+                ProjectBudget(
+                    projectId = projectId,
+                    category = ProjectCostCategory.LABOR,
+                    budgetAmount = BigDecimal("1000"),
+                    organizationId = orgId,
+                ),
+            ),
+        )
+        whenever(timeEntryRepository.findByOrganizationIdAndProjectIdAndStatus(orgId, projectId, TimeEntryStatus.APPROVED))
+            .thenReturn(listOf(entry("4", "50"), entry("4", "50"), entry("2", null)))
+
+        val report = service.budgetVsActual(projectId, orgId)
+
+        val labor = report.lines.first { it.category == ProjectCostCategory.LABOR }
+        assertThat(labor.budgeted).isEqualByComparingTo("1000")
+        assertThat(labor.actual).isEqualByComparingTo("400") // 4*50 + 4*50; the null-rate entry is excluded
+        assertThat(labor.remaining).isEqualByComparingTo("600")
+        assertThat(report.totalActual).isEqualByComparingTo("400")
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectServiceTest.kt
@@ -1,0 +1,113 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Customer
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectStatus
+import com.aquinofroilan.tessera.repository.ProjectRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.util.Optional
+
+class ProjectServiceTest {
+    private lateinit var repository: ProjectRepository
+    private lateinit var customerService: CustomerService
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: ProjectService
+
+    private val orgId = "org-1"
+    private val start = LocalDate.of(2026, 1, 1)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(ProjectRepository::class.java)
+        customerService = mock(CustomerService::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
+        whenever(repository.save(any<Project>())).thenAnswer { it.arguments[0] }
+        whenever(customerService.getCustomer("c-1", orgId)).thenReturn(Customer(id = "c-1", name = "Globex", organizationId = orgId))
+        service = ProjectService(repository, customerService, employeeService)
+    }
+
+    private fun project(status: ProjectStatus = ProjectStatus.PLANNED) =
+        Project(
+            id = "p-1",
+            projectNumber = "PRJ-0001",
+            name = "Apollo",
+            startDate = start,
+            status = status,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `create persists a planned project with a generated number`() {
+        val p = service.createProject(CreateProjectRequest(name = " Apollo ", startDate = start), orgId)
+
+        assertThat(p.status).isEqualTo(ProjectStatus.PLANNED)
+        assertThat(p.projectNumber).isEqualTo("PRJ-0001")
+        assertThat(p.name).isEqualTo("Apollo")
+    }
+
+    @Test
+    fun `create rejects an end date before the start date`() {
+        assertThatThrownBy {
+            service.createProject(CreateProjectRequest(name = "Apollo", startDate = start, endDate = start.minusDays(1)), orgId)
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `create validates the customer belongs to the org`() {
+        whenever(customerService.getCustomer("missing", orgId)).thenThrow(ResourceNotFoundException("Customer not found"))
+        assertThatThrownBy {
+            service.createProject(CreateProjectRequest(name = "Apollo", startDate = start, customerId = "missing"), orgId)
+        }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `activate moves planned to active and rejects from other states`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.PLANNED)))
+        assertThat(service.activateProject("p-1", orgId).status).isEqualTo(ProjectStatus.ACTIVE)
+
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.CLOSED)))
+        assertThatThrownBy { service.activateProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `hold requires an active project`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.PLANNED)))
+        assertThatThrownBy { service.holdProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `cancel rejects an already-closed project`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project(ProjectStatus.CLOSED)))
+        assertThatThrownBy { service.cancelProject("p-1", orgId) }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `update changes fields and validates end date`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project()))
+        val updated = service.updateProject("p-1", UpdateProjectRequest(name = "Apollo II"), orgId)
+        assertThat(updated.name).isEqualTo("Apollo II")
+
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project()))
+        assertThatThrownBy {
+            service.updateProject("p-1", UpdateProjectRequest(endDate = start.minusDays(5)), orgId)
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("p-1")).thenReturn(Optional.of(project().copy(organizationId = "other")))
+        assertThatThrownBy { service.getProject("p-1", orgId) }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectTaskServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectTaskServiceTest.kt
@@ -1,0 +1,124 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateProjectTaskRequest
+import com.aquinofroilan.tessera.dto.UpdateProjectTaskRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.ProjectTask
+import com.aquinofroilan.tessera.model.TaskStatus
+import com.aquinofroilan.tessera.repository.ProjectTaskRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+import java.util.Optional
+
+class ProjectTaskServiceTest {
+    private lateinit var repository: ProjectTaskRepository
+    private lateinit var projectService: ProjectService
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: ProjectTaskService
+
+    private val orgId = "org-1"
+    private val projectId = "p-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(ProjectTaskRepository::class.java)
+        projectService = mock(ProjectService::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.save(any<ProjectTask>())).thenAnswer { it.arguments[0] }
+        whenever(projectService.getProject(projectId, orgId)).thenReturn(
+            Project(
+                id = projectId,
+                projectNumber = "PRJ-0001",
+                name = "Apollo",
+                startDate = LocalDate.of(2026, 1, 1),
+                organizationId = orgId,
+            ),
+        )
+        service = ProjectTaskService(repository, projectService, employeeService)
+    }
+
+    private fun task(
+        id: String,
+        parent: String? = null,
+        org: String = orgId,
+        project: String = projectId,
+    ) = ProjectTask(id = id, projectId = project, parentTaskId = parent, name = id, organizationId = org)
+
+    @Test
+    fun `create persists a task under a validated project`() {
+        val t = service.createTask(projectId, CreateProjectTaskRequest(name = " Design "), orgId)
+        assertThat(t.name).isEqualTo("Design")
+        assertThat(t.projectId).isEqualTo(projectId)
+        assertThat(t.status).isEqualTo(TaskStatus.TODO)
+    }
+
+    @Test
+    fun `create with a parent validates the parent is in the same project`() {
+        whenever(repository.findById("missing")).thenReturn(Optional.empty())
+        assertThatThrownBy {
+            service.createTask(projectId, CreateProjectTaskRequest(name = "Sub", parentTaskId = "missing"), orgId)
+        }.isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `setParent rejects self-parenting`() {
+        whenever(repository.findById("t1")).thenReturn(Optional.of(task("t1")))
+        assertThatThrownBy { service.setParent(projectId, "t1", "t1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `setParent rejects a descendant cycle`() {
+        val t1 = task("t1")
+        val t2 = task("t2", parent = "t1")
+        whenever(repository.findById("t1")).thenReturn(Optional.of(t1))
+        whenever(repository.findById("t2")).thenReturn(Optional.of(t2))
+        whenever(repository.findByOrganizationIdAndProjectId(orgId, projectId)).thenReturn(listOf(t1, t2))
+
+        assertThatThrownBy { service.setParent(projectId, "t1", "t2", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `setParent clears the parent when null`() {
+        whenever(repository.findById("t2")).thenReturn(Optional.of(task("t2", parent = "t1")))
+        assertThat(service.setParent(projectId, "t2", null, orgId).parentTaskId).isNull()
+    }
+
+    @Test
+    fun `task tree nests children under roots`() {
+        val root = task("t1")
+        val child = task("t2", parent = "t1")
+        val grandchild = task("t3", parent = "t2")
+        whenever(repository.findByOrganizationIdAndProjectId(orgId, projectId)).thenReturn(listOf(child, root, grandchild))
+
+        val tree = service.getTaskTree(projectId, orgId)
+
+        assertThat(tree).hasSize(1)
+        assertThat(tree[0].id).isEqualTo("t1")
+        assertThat(tree[0].children[0].id).isEqualTo("t2")
+        assertThat(tree[0].children[0].children[0].id).isEqualTo("t3")
+    }
+
+    @Test
+    fun `get rejects a task from another project`() {
+        whenever(repository.findById("t1")).thenReturn(Optional.of(task("t1", project = "other")))
+        assertThatThrownBy { service.getTask(projectId, "t1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `update changes status`() {
+        whenever(repository.findById("t1")).thenReturn(Optional.of(task("t1")))
+        val updated = service.updateTask(projectId, "t1", UpdateProjectTaskRequest(status = TaskStatus.DONE), orgId)
+        assertThat(updated.status).isEqualTo(TaskStatus.DONE)
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestServiceTest.kt
@@ -1,0 +1,255 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestLineCost
+import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseOrderRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestLineRequest
+import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Product
+import com.aquinofroilan.tessera.model.PurchaseOrder
+import com.aquinofroilan.tessera.model.PurchaseRequest
+import com.aquinofroilan.tessera.model.PurchaseRequestLine
+import com.aquinofroilan.tessera.model.PurchaseRequestStatus
+import com.aquinofroilan.tessera.model.Vendor
+import com.aquinofroilan.tessera.model.Warehouse
+import com.aquinofroilan.tessera.repository.PurchaseRequestRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class PurchaseRequestServiceTest {
+    private lateinit var repository: PurchaseRequestRepository
+    private lateinit var productService: ProductService
+    private lateinit var vendorService: VendorService
+    private lateinit var warehouseService: WarehouseService
+    private lateinit var purchaseOrderService: PurchaseOrderService
+    private lateinit var service: PurchaseRequestService
+
+    private val orgId = "org-1"
+    private val userId = "user-1"
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(PurchaseRequestRepository::class.java)
+        productService = mock(ProductService::class.java)
+        vendorService = mock(VendorService::class.java)
+        warehouseService = mock(WarehouseService::class.java)
+        purchaseOrderService = mock(PurchaseOrderService::class.java)
+        whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
+        whenever(repository.save(any<PurchaseRequest>())).thenAnswer { it.arguments[0] }
+        whenever(productService.getProduct("p-1", orgId)).thenReturn(
+            Product(id = "p-1", sku = "SKU-1", name = "Widget", listPrice = BigDecimal("9"), priceCurrency = "USD", organizationId = orgId),
+        )
+        whenever(vendorService.getVendor("v-1", orgId)).thenReturn(Vendor(id = "v-1", name = "Acme", organizationId = orgId))
+        whenever(warehouseService.getWarehouse("wh-1", orgId))
+            .thenReturn(Warehouse(id = "wh-1", code = "MAIN", name = "Main", organizationId = orgId))
+        service = PurchaseRequestService(repository, productService, vendorService, warehouseService, purchaseOrderService)
+    }
+
+    private fun lineReq(estimatedUnitCost: BigDecimal? = BigDecimal("5")) =
+        CreatePurchaseRequestLineRequest(productId = "p-1", quantity = BigDecimal("3"), estimatedUnitCost = estimatedUnitCost)
+
+    private fun approvedRequest(
+        lines: List<PurchaseRequestLine> =
+            listOf(
+                PurchaseRequestLine(
+                    id = "prl-1",
+                    lineNumber = 1,
+                    productId = "p-1",
+                    productSku = "SKU-1",
+                    productName = "Widget",
+                    quantity = BigDecimal("3"),
+                    estimatedUnitCost = BigDecimal("5"),
+                ),
+            ),
+        suggestedVendorId: String? = "v-1",
+        warehouseId: String? = "wh-1",
+    ) = PurchaseRequest(
+        id = "pr-1",
+        prNumber = "PR-0001",
+        organizationId = orgId,
+        status = PurchaseRequestStatus.APPROVED,
+        suggestedVendorId = suggestedVendorId,
+        warehouseId = warehouseId,
+        lines = lines,
+        requestedBy = userId,
+    )
+
+    @Test
+    fun `create persists a draft with a generated number`() {
+        val pr =
+            service.createPurchaseRequest(
+                CreatePurchaseRequestRequest(suggestedVendorId = "v-1", warehouseId = "wh-1", lines = listOf(lineReq())),
+                orgId,
+                userId,
+            )
+
+        assertThat(pr.status).isEqualTo(PurchaseRequestStatus.DRAFT)
+        assertThat(pr.prNumber).isEqualTo("PR-0001")
+        assertThat(pr.lines).hasSize(1)
+        assertThat(pr.lines[0].productSku).isEqualTo("SKU-1")
+    }
+
+    @Test
+    fun `create rejects a non-positive quantity`() {
+        assertThatThrownBy {
+            service.createPurchaseRequest(
+                CreatePurchaseRequestRequest(lines = listOf(lineReq().copy(quantity = BigDecimal.ZERO))),
+                orgId,
+                userId,
+            )
+        }.isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `submit moves a draft to submitted`() {
+        whenever(repository.findById("pr-1"))
+            .thenReturn(Optional.of(approvedRequest().copy(status = PurchaseRequestStatus.DRAFT)))
+
+        assertThat(service.submitPurchaseRequest("pr-1", orgId).status).isEqualTo(PurchaseRequestStatus.SUBMITTED)
+    }
+
+    @Test
+    fun `approve rejects a request that is not submitted`() {
+        whenever(repository.findById("pr-1")).thenReturn(Optional.of(approvedRequest()))
+
+        assertThatThrownBy { service.approvePurchaseRequest("pr-1", orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `cancel rejects a converted request`() {
+        whenever(repository.findById("pr-1"))
+            .thenReturn(Optional.of(approvedRequest().copy(status = PurchaseRequestStatus.CONVERTED)))
+
+        assertThatThrownBy { service.cancelPurchaseRequest("pr-1", orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `convert requires an approved request`() {
+        whenever(repository.findById("pr-1"))
+            .thenReturn(Optional.of(approvedRequest().copy(status = PurchaseRequestStatus.SUBMITTED)))
+
+        assertThatThrownBy { service.convertToPurchaseOrder("pr-1", ConvertPurchaseRequestRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `convert builds a PO from estimated costs and marks the request converted`() {
+        whenever(repository.findById("pr-1")).thenReturn(Optional.of(approvedRequest()))
+        val createdPo =
+            PurchaseOrder(
+                id = "po-9",
+                poNumber = "PO-0001",
+                vendorId = "v-1",
+                vendorName = "Acme",
+                warehouseId = "wh-1",
+                orderDate = LocalDate.of(2026, 5, 1),
+                organizationId = orgId,
+                lines = emptyList(),
+                totalAmount = BigDecimal("15"),
+                createdBy = userId,
+            )
+        whenever(purchaseOrderService.createPurchaseOrder(any(), eq(orgId), eq(userId))).thenReturn(createdPo)
+
+        val po = service.convertToPurchaseOrder("pr-1", ConvertPurchaseRequestRequest(), orgId, userId)
+
+        assertThat(po.id).isEqualTo("po-9")
+        val captor = argumentCaptor<CreatePurchaseOrderRequest>()
+        org.mockito.kotlin
+            .verify(purchaseOrderService)
+            .createPurchaseOrder(captor.capture(), eq(orgId), eq(userId))
+        assertThat(captor.firstValue.vendorId).isEqualTo("v-1")
+        assertThat(captor.firstValue.warehouseId).isEqualTo("wh-1")
+        assertThat(captor.firstValue.lines[0].unitCost).isEqualByComparingTo("5")
+
+        val saved = argumentCaptor<PurchaseRequest>()
+        org.mockito.kotlin
+            .verify(repository)
+            .save(saved.capture())
+        assertThat(saved.firstValue.status).isEqualTo(PurchaseRequestStatus.CONVERTED)
+        assertThat(saved.firstValue.convertedPurchaseOrderId).isEqualTo("po-9")
+    }
+
+    @Test
+    fun `convert fails when a line has no cost and no override`() {
+        val noCostLine =
+            PurchaseRequestLine(
+                id = "prl-1",
+                lineNumber = 1,
+                productId = "p-1",
+                productSku = "SKU-1",
+                productName = "Widget",
+                quantity = BigDecimal("3"),
+                estimatedUnitCost = null,
+            )
+        whenever(repository.findById("pr-1")).thenReturn(Optional.of(approvedRequest(lines = listOf(noCostLine))))
+
+        assertThatThrownBy { service.convertToPurchaseOrder("pr-1", ConvertPurchaseRequestRequest(), orgId, userId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `convert uses a per-line cost override`() {
+        val noCostLine =
+            PurchaseRequestLine(
+                id = "prl-1",
+                lineNumber = 1,
+                productId = "p-1",
+                productSku = "SKU-1",
+                productName = "Widget",
+                quantity = BigDecimal("3"),
+                estimatedUnitCost = null,
+            )
+        whenever(repository.findById("pr-1")).thenReturn(Optional.of(approvedRequest(lines = listOf(noCostLine))))
+        whenever(purchaseOrderService.createPurchaseOrder(any(), eq(orgId), eq(userId))).thenAnswer {
+            val req = it.arguments[0] as CreatePurchaseOrderRequest
+            PurchaseOrder(
+                id = "po-9",
+                poNumber = "PO-0001",
+                vendorId = "v-1",
+                vendorName = "Acme",
+                warehouseId = "wh-1",
+                orderDate = LocalDate.of(2026, 5, 1),
+                organizationId = orgId,
+                lines = emptyList(),
+                totalAmount = req.lines[0].unitCost!!.multiply(req.lines[0].quantity),
+                createdBy = userId,
+            )
+        }
+
+        service.convertToPurchaseOrder(
+            "pr-1",
+            ConvertPurchaseRequestRequest(lineCosts = listOf(ConvertPurchaseRequestLineCost(lineId = "prl-1", unitCost = BigDecimal("7")))),
+            orgId,
+            userId,
+        )
+
+        val captor = argumentCaptor<CreatePurchaseOrderRequest>()
+        org.mockito.kotlin
+            .verify(purchaseOrderService)
+            .createPurchaseOrder(captor.capture(), eq(orgId), eq(userId))
+        assertThat(captor.firstValue.lines[0].unitCost).isEqualByComparingTo("7")
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("pr-1"))
+            .thenReturn(Optional.of(approvedRequest().copy(organizationId = "other")))
+
+        assertThatThrownBy { service.getPurchaseRequest("pr-1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/SelfServiceServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/SelfServiceServiceTest.kt
@@ -1,0 +1,93 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateLeaveRequestRequest
+import com.aquinofroilan.tessera.dto.SubmitSelfLeaveRequest
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Employee
+import com.aquinofroilan.tessera.model.EmploymentStatus
+import com.aquinofroilan.tessera.model.LeaveRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+
+class SelfServiceServiceTest {
+    private lateinit var employeeService: EmployeeService
+    private lateinit var leaveRequestService: LeaveRequestService
+    private lateinit var employeeCompensationService: EmployeeCompensationService
+    private lateinit var service: SelfServiceService
+
+    private val orgId = "org-1"
+    private val userId = "u1"
+
+    @BeforeEach
+    fun setup() {
+        employeeService = mock(EmployeeService::class.java)
+        leaveRequestService = mock(LeaveRequestService::class.java)
+        employeeCompensationService = mock(EmployeeCompensationService::class.java)
+        whenever(employeeService.getEmployeeByUser(userId, orgId)).thenReturn(me())
+        service = SelfServiceService(employeeService, leaveRequestService, employeeCompensationService)
+    }
+
+    private fun me() =
+        Employee(
+            id = "e1",
+            employeeNumber = "EMP-0001",
+            firstName = "Ada",
+            lastName = "Lovelace",
+            hireDate = LocalDate.of(2020, 1, 1),
+            status = EmploymentStatus.ACTIVE,
+            userId = userId,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `my profile resolves the linked employee`() {
+        assertThat(service.myProfile(userId, orgId).id).isEqualTo("e1")
+    }
+
+    @Test
+    fun `my profile surfaces not-found when the user has no employee record`() {
+        whenever(employeeService.getEmployeeByUser("u2", orgId))
+            .thenThrow(ResourceNotFoundException("No employee record is linked to your account"))
+
+        assertThatThrownBy { service.myProfile("u2", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+
+    @Test
+    fun `submit leave forces the caller's own employee id`() {
+        whenever(leaveRequestService.createLeaveRequest(any(), eq(orgId), eq(userId)))
+            .thenReturn(mock(LeaveRequest::class.java))
+
+        service.submitLeave(
+            userId,
+            orgId,
+            SubmitSelfLeaveRequest(leaveTypeId = "lt1", startDate = LocalDate.of(2026, 5, 1), endDate = LocalDate.of(2026, 5, 3)),
+        )
+
+        val captor = argumentCaptor<CreateLeaveRequestRequest>()
+        verify(leaveRequestService).createLeaveRequest(captor.capture(), eq(orgId), eq(userId))
+        assertThat(captor.firstValue.employeeId).isEqualTo("e1")
+        assertThat(captor.firstValue.leaveTypeId).isEqualTo("lt1")
+    }
+
+    @Test
+    fun `leave balance delegates with the caller's own employee id`() {
+        service.myLeaveBalance(userId, orgId, "lt1", 2026)
+        verify(leaveRequestService).balance(eq("e1"), eq("lt1"), eq(2026), eq(orgId))
+    }
+
+    @Test
+    fun `compensation history delegates with the caller's own employee id`() {
+        service.myCompensationHistory(userId, orgId)
+        verify(employeeCompensationService).listCompensation(eq("e1"), eq(orgId))
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/TimeEntryServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/TimeEntryServiceTest.kt
@@ -1,0 +1,116 @@
+package com.aquinofroilan.tessera.service
+
+import com.aquinofroilan.tessera.dto.CreateTimeEntryRequest
+import com.aquinofroilan.tessera.dto.UpdateTimeEntryRequest
+import com.aquinofroilan.tessera.exception.BusinessRuleException
+import com.aquinofroilan.tessera.exception.ResourceNotFoundException
+import com.aquinofroilan.tessera.model.Employee
+import com.aquinofroilan.tessera.model.Project
+import com.aquinofroilan.tessera.model.TimeEntry
+import com.aquinofroilan.tessera.model.TimeEntryStatus
+import com.aquinofroilan.tessera.repository.TimeEntryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+class TimeEntryServiceTest {
+    private lateinit var repository: TimeEntryRepository
+    private lateinit var projectService: ProjectService
+    private lateinit var projectTaskService: ProjectTaskService
+    private lateinit var employeeService: EmployeeService
+    private lateinit var service: TimeEntryService
+
+    private val orgId = "org-1"
+    private val projectId = "p-1"
+    private val empId = "e-1"
+    private val day = LocalDate.of(2026, 5, 1)
+
+    @BeforeEach
+    fun setup() {
+        repository = mock(TimeEntryRepository::class.java)
+        projectService = mock(ProjectService::class.java)
+        projectTaskService = mock(ProjectTaskService::class.java)
+        employeeService = mock(EmployeeService::class.java)
+        whenever(repository.save(any<TimeEntry>())).thenAnswer { it.arguments[0] }
+        whenever(projectService.getProject(projectId, orgId)).thenReturn(
+            Project(id = projectId, projectNumber = "PRJ-0001", name = "Apollo", startDate = day, organizationId = orgId),
+        )
+        whenever(employeeService.getEmployee(empId, orgId)).thenReturn(
+            Employee(
+                id = empId,
+                employeeNumber = "EMP-0001",
+                firstName = "Ada",
+                lastName = "Lovelace",
+                hireDate = day,
+                organizationId = orgId,
+            ),
+        )
+        service = TimeEntryService(repository, projectService, projectTaskService, employeeService)
+    }
+
+    private fun req(hours: BigDecimal = BigDecimal("4")) =
+        CreateTimeEntryRequest(employeeId = empId, projectId = projectId, entryDate = day, hours = hours)
+
+    private fun entry(status: TimeEntryStatus = TimeEntryStatus.DRAFT) =
+        TimeEntry(
+            id = "te-1",
+            employeeId = empId,
+            projectId = projectId,
+            entryDate = day,
+            hours = BigDecimal("4"),
+            status = status,
+            organizationId = orgId,
+        )
+
+    @Test
+    fun `create persists a draft entry`() {
+        val e = service.createTimeEntry(req(), orgId)
+        assertThat(e.status).isEqualTo(TimeEntryStatus.DRAFT)
+        assertThat(e.hours).isEqualByComparingTo("4")
+    }
+
+    @Test
+    fun `create rejects non-positive hours`() {
+        assertThatThrownBy { service.createTimeEntry(req(hours = BigDecimal.ZERO), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `submit moves draft to submitted then approval is gated`() {
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry(TimeEntryStatus.DRAFT)))
+        assertThat(service.submitTimeEntry("te-1", orgId).status).isEqualTo(TimeEntryStatus.SUBMITTED)
+
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry(TimeEntryStatus.DRAFT)))
+        assertThatThrownBy { service.approveTimeEntry("te-1", orgId, "u1") }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `approve sets approver on a submitted entry`() {
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry(TimeEntryStatus.SUBMITTED)))
+        val approved = service.approveTimeEntry("te-1", orgId, "u1")
+        assertThat(approved.status).isEqualTo(TimeEntryStatus.APPROVED)
+        assertThat(approved.approvedBy).isEqualTo("u1")
+    }
+
+    @Test
+    fun `update is rejected once not draft`() {
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry(TimeEntryStatus.APPROVED)))
+        assertThatThrownBy { service.updateTimeEntry("te-1", UpdateTimeEntryRequest(hours = BigDecimal("2")), orgId) }
+            .isInstanceOf(BusinessRuleException::class.java)
+    }
+
+    @Test
+    fun `get rejects cross-org access`() {
+        whenever(repository.findById("te-1")).thenReturn(Optional.of(entry().copy(organizationId = "other")))
+        assertThatThrownBy { service.getTimeEntry("te-1", orgId) }
+            .isInstanceOf(ResourceNotFoundException::class.java)
+    }
+}


### PR DESCRIPTION
Promotes the v0.11.0 development cycle from `staging` to `production`.

## Highlights
- **Projects module** — full vertical: project entity & lifecycle (#180), tasks / WBS hierarchy (#181), timesheets with approval (#182), budgeting & cost capture (#183), and T&M billing that turns time entries into invoices (#184).
- **HR org & people ops** — department org-chart hierarchy (#33), attendance tracking with clock-in/out & timesheets (#35), and the employee self-service surface at `/hr/me` (#37).
- **Procurement** — purchase requests / requisitions ahead of the PO flow (#45).
- **GraphQL** — bridge surface for org-chart, attendance, purchase requests, and self-service (#162).
- **Auth** — passwordless magic-link login (#239-followup).
- **Integrations** — CSV import & export for products, customers, and vendors (#73).

## Migrations
Flyway adds **V0014–V0017**, **V0019–V0023**, and **V0034** on top of v0.10.0's V0001–V0013:
- HR: department parent (V0014), attendance (V0015), employee↔user link (V0017)
- Procurement: purchase requests (V0016)
- Projects: project entity (V0019), tasks (V0020), time entries (V0021), budgets (V0022), time-entry billing (V0023)
- Auth: login-link tokens (V0034)

V0018 is intentionally unclaimed in this release — reserved for in-flight feature stacks rebasing onto the post-release staging.

## Notes
- Version bumped to `0.11.0` in `ee8b880` at the start of the cycle.
- 19 open feature PRs remain on feature branches (Manufacturing, CRM, HR ATS, Inventory count, UoM, Attachments, Bank & Cash, Sales quotations) and will rebase onto post-release staging.