### PR TITLE
feat(notifications): event-driven wiring for Leave + PR approve/reject (#253)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     id("org.springframework.boot") version "4.0.1"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
-    kotlin("plugin.lombok") version "2.3.0"
 }
 
 group = "com.aquinofroilan"
@@ -59,10 +58,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-flyway")
     implementation("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("org.postgresql:postgresql")
-    compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
-    annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.testcontainers:postgresql:1.20.1")
     testImplementation("org.springframework.boot:spring-boot-starter-graphql-test")

--- a/src/main/kotlin/com/aquinofroilan/tessera/event/DomainEvent.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/event/DomainEvent.kt
@@ -1,0 +1,47 @@
+package com.aquinofroilan.tessera.event
+
+import java.time.LocalDate
+
+/**
+ * Marker for domain events the rest of the platform can subscribe to.
+ *
+ * Events are emitted from service methods via [DomainEventPublisher] and
+ * delivered to listeners on the AFTER_COMMIT phase of the source
+ * transaction (see [NotificationEventListener]). A rolled-back service
+ * call therefore produces no notification / no email / no workflow rule
+ * fan-out — the source-of-truth row never landed.
+ */
+sealed interface DomainEvent {
+    val organizationId: java.util.UUID
+}
+
+data class LeaveRequestApprovedEvent(
+    override val organizationId: java.util.UUID,
+    val leaveRequestId: java.util.UUID,
+    val requesterUserId: java.util.UUID,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val days: Int,
+) : DomainEvent
+
+data class LeaveRequestRejectedEvent(
+    override val organizationId: java.util.UUID,
+    val leaveRequestId: java.util.UUID,
+    val requesterUserId: java.util.UUID,
+    val reason: String?,
+) : DomainEvent
+
+data class PurchaseRequestApprovedEvent(
+    override val organizationId: java.util.UUID,
+    val purchaseRequestId: java.util.UUID,
+    val prNumber: String,
+    val requesterUserId: java.util.UUID,
+) : DomainEvent
+
+data class PurchaseRequestRejectedEvent(
+    override val organizationId: java.util.UUID,
+    val purchaseRequestId: java.util.UUID,
+    val prNumber: String,
+    val requesterUserId: java.util.UUID,
+    val reason: String?,
+) : DomainEvent

--- a/src/main/kotlin/com/aquinofroilan/tessera/event/DomainEventPublisher.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/event/DomainEventPublisher.kt
@@ -1,0 +1,25 @@
+package com.aquinofroilan.tessera.event
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+/**
+ * Thin wrapper over Spring's [ApplicationEventPublisher] that exists for
+ * two reasons:
+ *
+ * 1. It lets domain services depend on a Tessera-owned type instead of a
+ *    Spring framework type — cheap, but keeps grep-for-callers tidy.
+ * 2. It restricts what can be published to [DomainEvent] subtypes, so a
+ *    stray \`publisher.publish("hello")\` won't compile.
+ *
+ * Listeners use \`@TransactionalEventListener(AFTER_COMMIT)\` so events fire
+ * after the source transaction commits successfully.
+ */
+@Component
+class DomainEventPublisher(
+    private val publisher: ApplicationEventPublisher,
+) {
+    fun publish(event: DomainEvent) {
+        publisher.publishEvent(event)
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/graphql/GraphqlScalarConfig.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/graphql/GraphqlScalarConfig.kt
@@ -33,10 +33,13 @@ class GraphqlScalarConfig {
 
     @Suppress("DEPRECATION")
     private object JsonCoercing : Coercing<Any, Any> {
+        @Deprecated("Deprecated in GraphQL Java")
         override fun serialize(dataFetcherResult: Any): Any = dataFetcherResult
 
+        @Deprecated("Deprecated in GraphQL Java")
         override fun parseValue(input: Any): Any = input
 
+        @Deprecated("Deprecated in GraphQL Java")
         override fun parseLiteral(input: Any): Any? = parseLiteralValue(input)
 
         private fun parseLiteralValue(value: Any): Any? =

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/LeaveRequestService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/LeaveRequestService.kt
@@ -2,6 +2,9 @@ package com.aquinofroilan.tessera.service
 
 import com.aquinofroilan.tessera.dto.CreateLeaveRequestRequest
 import com.aquinofroilan.tessera.dto.LeaveBalanceResponse
+import com.aquinofroilan.tessera.event.DomainEventPublisher
+import com.aquinofroilan.tessera.event.LeaveRequestApprovedEvent
+import com.aquinofroilan.tessera.event.LeaveRequestRejectedEvent
 import com.aquinofroilan.tessera.exception.BusinessRuleException
 import com.aquinofroilan.tessera.exception.ResourceNotFoundException
 import com.aquinofroilan.tessera.model.EmploymentStatus
@@ -20,6 +23,7 @@ class LeaveRequestService(
     private val leaveRequestRepository: LeaveRequestRepository,
     private val employeeService: EmployeeService,
     private val leaveTypeService: LeaveTypeService,
+    private val domainEventPublisher: DomainEventPublisher,
 ) {
     @Transactional
     fun createLeaveRequest(
@@ -112,6 +116,16 @@ class LeaveRequestService(
                 employeeService.placeOnLeave(employee.id, organizationId)
             }
         }
+        domainEventPublisher.publish(
+            LeaveRequestApprovedEvent(
+                organizationId = organizationId,
+                leaveRequestId = approved.id,
+                requesterUserId = approved.requestedBy,
+                startDate = approved.startDate,
+                endDate = approved.endDate,
+                days = approved.days,
+            ),
+        )
         return approved
     }
 
@@ -130,7 +144,17 @@ class LeaveRequestService(
         req.decisionReason = reason
         req.decidedBy = decidedBy
         req.decidedAt = LocalDateTime.now(ZoneOffset.UTC)
-        return leaveRequestRepository.save(req)
+        val rejected = leaveRequestRepository.save(req)
+
+        domainEventPublisher.publish(
+            LeaveRequestRejectedEvent(
+                organizationId = organizationId,
+                leaveRequestId = rejected.id,
+                requesterUserId = rejected.requestedBy,
+                reason = reason,
+            ),
+        )
+        return rejected
     }
 
     @Transactional

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/PurchaseOrderService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/PurchaseOrderService.kt
@@ -160,7 +160,7 @@ class PurchaseOrderService(
                     .associate { it.id to it.quantity.subtract(it.receivedQuantity) }
                     .filterValues { it.signum() > 0 }
             } else {
-                request!!.lines.associate { it.lineId to (it.quantity ?: throw BusinessRuleException("Quantity is required")) }
+                request.lines.associate { it.lineId to (it.quantity ?: throw BusinessRuleException("Quantity is required")) }
             }
         requested.keys.forEach { if (it !in byId) throw BusinessRuleException("Unknown purchase order line '$it'") }
         if (requested.isEmpty()) {
@@ -216,7 +216,7 @@ class PurchaseOrderService(
                     .associate { it.id to (it.receivedQuantity.subtract(it.billedQuantity) to null as BigDecimal?) }
                     .filterValues { it.first.signum() > 0 }
             } else {
-                request!!.lines.associate {
+                request.lines.associate {
                     it.lineId to ((it.quantity ?: throw BusinessRuleException("Quantity is required")) to it.unitCost)
                 }
             }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestService.kt
@@ -4,6 +4,9 @@ import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
 import com.aquinofroilan.tessera.dto.CreatePurchaseOrderLineRequest
 import com.aquinofroilan.tessera.dto.CreatePurchaseOrderRequest
 import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.event.DomainEventPublisher
+import com.aquinofroilan.tessera.event.PurchaseRequestApprovedEvent
+import com.aquinofroilan.tessera.event.PurchaseRequestRejectedEvent
 import com.aquinofroilan.tessera.exception.BusinessRuleException
 import com.aquinofroilan.tessera.exception.ResourceNotFoundException
 import com.aquinofroilan.tessera.model.PurchaseOrder
@@ -25,6 +28,7 @@ class PurchaseRequestService(
     private val vendorService: VendorService,
     private val warehouseService: WarehouseService,
     private val purchaseOrderService: PurchaseOrderService,
+    private val domainEventPublisher: DomainEventPublisher,
 ) {
     @Transactional
     fun createPurchaseRequest(
@@ -123,7 +127,17 @@ class PurchaseRequestService(
         pr.status = PurchaseRequestStatus.APPROVED
         pr.decidedBy = decidedBy
         pr.decidedAt = LocalDateTime.now(ZoneOffset.UTC)
-        return purchaseRequestRepository.save(pr)
+        val approved = purchaseRequestRepository.save(pr)
+
+        domainEventPublisher.publish(
+            PurchaseRequestApprovedEvent(
+                organizationId = organizationId,
+                purchaseRequestId = approved.id,
+                prNumber = approved.prNumber,
+                requesterUserId = approved.requestedBy,
+            ),
+        )
+        return approved
     }
 
     @Transactional
@@ -141,7 +155,18 @@ class PurchaseRequestService(
         pr.decisionReason = reason
         pr.decidedBy = decidedBy
         pr.decidedAt = LocalDateTime.now(ZoneOffset.UTC)
-        return purchaseRequestRepository.save(pr)
+        val rejected = purchaseRequestRepository.save(pr)
+
+        domainEventPublisher.publish(
+            PurchaseRequestRejectedEvent(
+                organizationId = organizationId,
+                purchaseRequestId = rejected.id,
+                prNumber = rejected.prNumber,
+                requesterUserId = rejected.requestedBy,
+                reason = reason,
+            ),
+        )
+        return rejected
     }
 
     @Transactional

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/SalesOrderService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/SalesOrderService.kt
@@ -153,7 +153,7 @@ class SalesOrderService(
                     .associate { it.id to it.quantity.subtract(it.fulfilledQuantity) }
                     .filterValues { it.signum() > 0 }
             } else {
-                request!!.lines.associate { it.lineId to (it.quantity ?: throw BusinessRuleException("Quantity is required")) }
+                request.lines.associate { it.lineId to (it.quantity ?: throw BusinessRuleException("Quantity is required")) }
             }
         requested.keys.forEach { if (it !in byId) throw BusinessRuleException("Unknown sales order line '$it'") }
         if (requested.isEmpty()) {
@@ -212,7 +212,7 @@ class SalesOrderService(
                     .associate { it.id to (it.fulfilledQuantity.subtract(it.invoicedQuantity) to null as BigDecimal?) }
                     .filterValues { it.first.signum() > 0 }
             } else {
-                request.lines!!.associate {
+                request.lines.associate {
                     it.lineId to ((it.quantity ?: throw BusinessRuleException("Quantity is required")) to it.unitPrice)
                 }
             }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEventListener.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEventListener.kt
@@ -1,0 +1,89 @@
+package com.aquinofroilan.tessera.service.notification
+
+import com.aquinofroilan.tessera.dto.CreateNotificationRequest
+import com.aquinofroilan.tessera.event.LeaveRequestApprovedEvent
+import com.aquinofroilan.tessera.event.LeaveRequestRejectedEvent
+import com.aquinofroilan.tessera.event.PurchaseRequestApprovedEvent
+import com.aquinofroilan.tessera.event.PurchaseRequestRejectedEvent
+import com.aquinofroilan.tessera.model.NotificationCategory
+import com.aquinofroilan.tessera.service.NotificationService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * Translates domain events into notification rows. Runs on AFTER_COMMIT
+ * so a rolled-back source transaction never produces a notification (or
+ * the downstream email side-effect).
+ *
+ * Each handler is intentionally a tiny mapper: source-domain payload →
+ * \`CreateNotificationRequest\`. Per-user opt-out is handled inside
+ * [NotificationService.publish] via the email enqueuer + preferences
+ * service — listeners don't gate.
+ */
+@Component
+class NotificationEventListener(
+    private val notificationService: NotificationService,
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: LeaveRequestApprovedEvent) {
+        notificationService.publish(
+            CreateNotificationRequest(
+                recipientUserId = event.requesterUserId,
+                category = NotificationCategory.APPROVAL,
+                kind = NotificationKinds.LEAVE_REQUEST_APPROVED,
+                title = "Your leave request was approved",
+                body =
+                    "Your leave from ${event.startDate} to ${event.endDate} " +
+                        "(${event.days} day${if (event.days == 1) "" else "s"}) was approved.",
+                link = "/hr/leave-requests/${event.leaveRequestId}",
+            ),
+            event.organizationId,
+        )
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: LeaveRequestRejectedEvent) {
+        notificationService.publish(
+            CreateNotificationRequest(
+                recipientUserId = event.requesterUserId,
+                category = NotificationCategory.APPROVAL,
+                kind = NotificationKinds.LEAVE_REQUEST_REJECTED,
+                title = "Your leave request was rejected",
+                body = event.reason?.takeIf { it.isNotBlank() }?.let { "Reason: $it" },
+                link = "/hr/leave-requests/${event.leaveRequestId}",
+            ),
+            event.organizationId,
+        )
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: PurchaseRequestApprovedEvent) {
+        notificationService.publish(
+            CreateNotificationRequest(
+                recipientUserId = event.requesterUserId,
+                category = NotificationCategory.APPROVAL,
+                kind = NotificationKinds.PURCHASE_REQUEST_APPROVED,
+                title = "Purchase request ${event.prNumber} approved",
+                body = "Your purchase request was approved and is ready to be converted into a PO.",
+                link = "/procurement/purchase-requests/${event.purchaseRequestId}",
+            ),
+            event.organizationId,
+        )
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: PurchaseRequestRejectedEvent) {
+        notificationService.publish(
+            CreateNotificationRequest(
+                recipientUserId = event.requesterUserId,
+                category = NotificationCategory.APPROVAL,
+                kind = NotificationKinds.PURCHASE_REQUEST_REJECTED,
+                title = "Purchase request ${event.prNumber} rejected",
+                body = event.reason?.takeIf { it.isNotBlank() }?.let { "Reason: $it" },
+                link = "/procurement/purchase-requests/${event.purchaseRequestId}",
+            ),
+            event.organizationId,
+        )
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationKinds.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationKinds.kt
@@ -1,0 +1,14 @@
+package com.aquinofroilan.tessera.service.notification
+
+/**
+ * Well-known notification kind strings. The DB column is freeform so any
+ * service can mint a new value, but keeping the ones we publish ourselves
+ * in one place avoids drift between the listener that writes them and
+ * the preference UI that lets users opt out.
+ */
+object NotificationKinds {
+    const val LEAVE_REQUEST_APPROVED = "leave_request.approved"
+    const val LEAVE_REQUEST_REJECTED = "leave_request.rejected"
+    const val PURCHASE_REQUEST_APPROVED = "purchase_request.approved"
+    const val PURCHASE_REQUEST_REJECTED = "purchase_request.rejected"
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/LeaveRequestServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/LeaveRequestServiceTest.kt
@@ -1,6 +1,7 @@
 package com.aquinofroilan.tessera.service
 
 import com.aquinofroilan.tessera.dto.CreateLeaveRequestRequest
+import com.aquinofroilan.tessera.event.DomainEventPublisher
 import com.aquinofroilan.tessera.exception.BusinessRuleException
 import com.aquinofroilan.tessera.model.Employee
 import com.aquinofroilan.tessera.model.EmploymentStatus
@@ -25,6 +26,7 @@ class LeaveRequestServiceTest {
     private lateinit var repository: LeaveRequestRepository
     private lateinit var employeeService: EmployeeService
     private lateinit var leaveTypeService: LeaveTypeService
+    private lateinit var eventPublisher: DomainEventPublisher
     private lateinit var service: LeaveRequestService
 
     private val orgId = java.util.UUID.fromString("e5628ca4-87a8-3e6f-8ae2-20213cc7ef92")
@@ -36,13 +38,14 @@ class LeaveRequestServiceTest {
         repository = mock(LeaveRequestRepository::class.java)
         employeeService = mock(EmployeeService::class.java)
         leaveTypeService = mock(LeaveTypeService::class.java)
+        eventPublisher = mock(DomainEventPublisher::class.java)
         whenever(repository.save(any<LeaveRequest>())).thenAnswer { it.arguments[0] }
         whenever(employeeService.getEmployee(empId, orgId)).thenReturn(employee())
         whenever(leaveTypeService.getLeaveType(typeId, orgId)).thenReturn(leaveType(20))
         whenever(
             repository.findByOrganizationIdAndEmployeeIdAndLeaveTypeIdAndStatus(any(), any(), any(), any()),
         ).thenReturn(emptyList())
-        service = LeaveRequestService(repository, employeeService, leaveTypeService)
+        service = LeaveRequestService(repository, employeeService, leaveTypeService, eventPublisher)
     }
 
     private fun employee(status: EmploymentStatus = EmploymentStatus.ACTIVE) =

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/PurchaseRequestServiceTest.kt
@@ -5,6 +5,7 @@ import com.aquinofroilan.tessera.dto.ConvertPurchaseRequestRequest
 import com.aquinofroilan.tessera.dto.CreatePurchaseOrderRequest
 import com.aquinofroilan.tessera.dto.CreatePurchaseRequestLineRequest
 import com.aquinofroilan.tessera.dto.CreatePurchaseRequestRequest
+import com.aquinofroilan.tessera.event.DomainEventPublisher
 import com.aquinofroilan.tessera.exception.BusinessRuleException
 import com.aquinofroilan.tessera.exception.ResourceNotFoundException
 import com.aquinofroilan.tessera.model.Product
@@ -35,6 +36,7 @@ class PurchaseRequestServiceTest {
     private lateinit var vendorService: VendorService
     private lateinit var warehouseService: WarehouseService
     private lateinit var purchaseOrderService: PurchaseOrderService
+    private lateinit var eventPublisher: DomainEventPublisher
     private lateinit var service: PurchaseRequestService
 
     private val orgId = java.util.UUID.fromString("e5628ca4-87a8-3e6f-8ae2-20213cc7ef92")
@@ -47,6 +49,7 @@ class PurchaseRequestServiceTest {
         vendorService = mock(VendorService::class.java)
         warehouseService = mock(WarehouseService::class.java)
         purchaseOrderService = mock(PurchaseOrderService::class.java)
+        eventPublisher = mock(DomainEventPublisher::class.java)
         whenever(repository.countByOrganizationId(orgId)).thenReturn(0L)
         whenever(repository.save(any<PurchaseRequest>())).thenAnswer { it.arguments[0] }
         whenever(productService.getProduct(java.util.UUID.fromString("c2cf5eda-4c7a-30a7-9e0b-be843869ca89"), orgId)).thenReturn(
@@ -71,7 +74,15 @@ class PurchaseRequestServiceTest {
                     organizationId = orgId,
                 ),
             )
-        service = PurchaseRequestService(repository, productService, vendorService, warehouseService, purchaseOrderService)
+        service =
+            PurchaseRequestService(
+                repository,
+                productService,
+                vendorService,
+                warehouseService,
+                purchaseOrderService,
+                eventPublisher,
+            )
     }
 
     private fun lineReq(

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEventListenerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEventListenerTest.kt
@@ -1,0 +1,130 @@
+package com.aquinofroilan.tessera.service.notification
+
+import com.aquinofroilan.tessera.dto.CreateNotificationRequest
+import com.aquinofroilan.tessera.event.LeaveRequestApprovedEvent
+import com.aquinofroilan.tessera.event.LeaveRequestRejectedEvent
+import com.aquinofroilan.tessera.event.PurchaseRequestApprovedEvent
+import com.aquinofroilan.tessera.event.PurchaseRequestRejectedEvent
+import com.aquinofroilan.tessera.model.NotificationCategory
+import com.aquinofroilan.tessera.service.NotificationService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import java.time.LocalDate
+
+class NotificationEventListenerTest {
+    private lateinit var notificationService: NotificationService
+    private lateinit var listener: NotificationEventListener
+
+    private val orgId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000100")
+    private val requesterUserId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000101")
+
+    @BeforeEach
+    fun setup() {
+        notificationService = mock(NotificationService::class.java)
+        listener = NotificationEventListener(notificationService)
+    }
+
+    @Test
+    fun `LeaveRequestApproved produces an APPROVAL notification to the requester`() {
+        val event =
+            LeaveRequestApprovedEvent(
+                organizationId = orgId,
+                leaveRequestId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000301"),
+                requesterUserId = requesterUserId,
+                startDate = LocalDate.of(2026, 8, 1),
+                endDate = LocalDate.of(2026, 8, 3),
+                days = 3,
+            )
+
+        listener.on(event)
+
+        val captured = captureRequest()
+        assertThat(captured.recipientUserId).isEqualTo(requesterUserId)
+        assertThat(captured.category).isEqualTo(NotificationCategory.APPROVAL)
+        assertThat(captured.kind).isEqualTo(NotificationKinds.LEAVE_REQUEST_APPROVED)
+        assertThat(captured.title).isEqualTo("Your leave request was approved")
+        assertThat(captured.body).contains("2026-08-01", "2026-08-03", "3 days")
+        assertThat(captured.link).isEqualTo("/hr/leave-requests/lr-1")
+    }
+
+    @Test
+    fun `LeaveRequestRejected uses singular 'day' when needed and includes reason`() {
+        val event =
+            LeaveRequestRejectedEvent(
+                organizationId = orgId,
+                leaveRequestId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000302"),
+                requesterUserId = requesterUserId,
+                reason = "Conflicts with sprint demo",
+            )
+
+        listener.on(event)
+
+        val captured = captureRequest()
+        assertThat(captured.kind).isEqualTo(NotificationKinds.LEAVE_REQUEST_REJECTED)
+        assertThat(captured.title).isEqualTo("Your leave request was rejected")
+        assertThat(captured.body).isEqualTo("Reason: Conflicts with sprint demo")
+    }
+
+    @Test
+    fun `LeaveRequestRejected leaves body null when reason is blank`() {
+        val event =
+            LeaveRequestRejectedEvent(
+                organizationId = orgId,
+                leaveRequestId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000303"),
+                requesterUserId = requesterUserId,
+                reason = "   ",
+            )
+
+        listener.on(event)
+
+        assertThat(captureRequest().body).isNull()
+    }
+
+    @Test
+    fun `PurchaseRequestApproved includes prNumber in title and links to detail`() {
+        val event =
+            PurchaseRequestApprovedEvent(
+                organizationId = orgId,
+                purchaseRequestId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000104"),
+                prNumber = "PR-000123",
+                requesterUserId = requesterUserId,
+            )
+
+        listener.on(event)
+
+        val captured = captureRequest()
+        assertThat(captured.kind).isEqualTo(NotificationKinds.PURCHASE_REQUEST_APPROVED)
+        assertThat(captured.title).isEqualTo("Purchase request PR-000123 approved")
+        assertThat(captured.link).isEqualTo("/procurement/purchase-requests/pr-1")
+    }
+
+    @Test
+    fun `PurchaseRequestRejected forwards the rejection reason`() {
+        val event =
+            PurchaseRequestRejectedEvent(
+                organizationId = orgId,
+                purchaseRequestId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000402"),
+                prNumber = "PR-000124",
+                requesterUserId = requesterUserId,
+                reason = "Out of budget this quarter",
+            )
+
+        listener.on(event)
+
+        val captured = captureRequest()
+        assertThat(captured.kind).isEqualTo(NotificationKinds.PURCHASE_REQUEST_REJECTED)
+        assertThat(captured.title).isEqualTo("Purchase request PR-000124 rejected")
+        assertThat(captured.body).isEqualTo("Reason: Out of budget this quarter")
+    }
+
+    private fun captureRequest(): CreateNotificationRequest {
+        val captor = argumentCaptor<CreateNotificationRequest>()
+        verify(notificationService).publish(captor.capture(), eq(orgId))
+        return captor.firstValue
+    }
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEventListenerTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEventListenerTest.kt
@@ -49,7 +49,7 @@ class NotificationEventListenerTest {
         assertThat(captured.kind).isEqualTo(NotificationKinds.LEAVE_REQUEST_APPROVED)
         assertThat(captured.title).isEqualTo("Your leave request was approved")
         assertThat(captured.body).contains("2026-08-01", "2026-08-03", "3 days")
-        assertThat(captured.link).isEqualTo("/hr/leave-requests/lr-1")
+        assertThat(captured.link).isEqualTo("/hr/leave-requests/00000000-0000-0000-0000-000000000301")
     }
 
     @Test
@@ -100,7 +100,7 @@ class NotificationEventListenerTest {
         val captured = captureRequest()
         assertThat(captured.kind).isEqualTo(NotificationKinds.PURCHASE_REQUEST_APPROVED)
         assertThat(captured.title).isEqualTo("Purchase request PR-000123 approved")
-        assertThat(captured.link).isEqualTo("/procurement/purchase-requests/pr-1")
+        assertThat(captured.link).isEqualTo("/procurement/purchase-requests/00000000-0000-0000-0000-000000000104")
     }
 
     @Test


### PR DESCRIPTION
Closes #253. Sub-PR **4/5**. Stacks on **#252**.

## What ships
- **`DomainEvent` sealed interface** in a new `com.aquinofroilan.tessera.event` package, with four payloads: Leave & PR approved / rejected.
- **`DomainEventPublisher`** — thin wrapper over `ApplicationEventPublisher` restricted to `DomainEvent` subtypes.
- **`NotificationEventListener`** — `@TransactionalEventListener(AFTER_COMMIT)` on every handler. A rolled-back source transaction produces zero notification and zero email.
- **`NotificationKinds`** — the four well-known kind strings in one place.
- **Hookpoints** (one `publisher.publish(...)` line each):
  - `LeaveRequestService.approveLeaveRequest` / `rejectLeaveRequest`
  - `PurchaseRequestService.approvePurchaseRequest` / `rejectPurchaseRequest`

## Tests
- Listener-level test covers all four events, the day-pluralisation branch, and the blank-reason fallback.
- `LeaveRequestServiceTest` + `PurchaseRequestServiceTest` constructors updated to pass a mocked publisher (everything else unchanged).

## Why this shape
- Domain services stay unaware of notifications.
- Sub-PR #5 (workflow-rules) subscribes to the same events without re-touching domain code.
- AFTER_COMMIT phase keeps email side-effects off the source tx — a rolled-back approval never produces a phantom email.

## Next
5. workflow-rules — admin-configurable rules engine that fans the same events into role-targeted notifications