### PR TITLE
feat(notifications): HTML email rendering with plain-text fallback (#257)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/config/NotificationEmailProperties.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/config/NotificationEmailProperties.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("tessera.notifications.email")
 data class NotificationEmailProperties(
     val enabled: Boolean = true,
+    val html: Boolean = true,
     val from: String = "noreply@tessera.local",
     val senderName: String = "Tessera",
     val dispatcher: Dispatcher = Dispatcher(),

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/EmailContent.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/EmailContent.kt
@@ -1,0 +1,13 @@
+package com.aquinofroilan.tessera.service.notification
+
+/**
+ * Wire shape an [EmailSender] hands off to its transport. Carries both the
+ * plain-text body (required) and an optional HTML body — when present the
+ * SMTP sender ships a multipart/alternative message and the receiving
+ * client picks whichever it supports.
+ */
+data class EmailContent(
+    val subject: String,
+    val plainText: String,
+    val html: String? = null,
+)

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/EmailSender.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/EmailSender.kt
@@ -17,7 +17,6 @@ interface EmailSender {
      */
     fun send(
         to: String,
-        subject: String,
-        textBody: String,
+        content: EmailContent,
     ): Boolean
 }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NoOpEmailSender.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NoOpEmailSender.kt
@@ -18,14 +18,14 @@ class NoOpEmailSender : EmailSender {
 
     override fun send(
         to: String,
-        subject: String,
-        textBody: String,
+        content: EmailContent,
     ): Boolean {
         log.info(
-            "Skipping notification email to {} (subject='{}') — no JavaMailSender bean. " +
+            "Skipping notification email to {} (subject='{}', html={}) — no JavaMailSender bean. " +
                 "Configure spring.mail.* to enable SMTP delivery.",
             to,
-            subject,
+            content.subject,
+            content.html != null,
         )
         return false
     }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailDispatcher.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailDispatcher.kt
@@ -38,6 +38,7 @@ class NotificationEmailDispatcher(
     private val outboxRepository: NotificationEmailOutboxRepository,
     private val notificationRepository: NotificationRepository,
     private val emailSender: EmailSender,
+    private val renderer: NotificationEmailRenderer,
     private val properties: NotificationEmailProperties,
 ) {
     private val log = LoggerFactory.getLogger(NotificationEmailDispatcher::class.java)
@@ -73,7 +74,7 @@ class NotificationEmailDispatcher(
                 }
 
         try {
-            val delivered = emailSender.send(row.recipientEmail, notification.title, renderBody(notification))
+            val delivered = emailSender.send(row.recipientEmail, renderer.render(notification))
             if (delivered) {
                 outboxRepository.save(
                     row.copy(
@@ -117,14 +118,6 @@ class NotificationEmailDispatcher(
                 e.message,
             )
         }
-    }
-
-    private fun renderBody(notification: com.aquinofroilan.tessera.model.Notification): String {
-        val sb = StringBuilder()
-        notification.body?.let { sb.append(it).append("\n\n") }
-        notification.link?.let { sb.append("Open: ").append(it).append('\n') }
-        if (sb.isEmpty()) sb.append(notification.title)
-        return sb.toString().trimEnd()
     }
 
     companion object {

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailRenderer.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailRenderer.kt
@@ -1,0 +1,86 @@
+package com.aquinofroilan.tessera.service.notification
+
+import com.aquinofroilan.tessera.config.NotificationEmailProperties
+import com.aquinofroilan.tessera.model.Notification
+import org.springframework.stereotype.Component
+
+/**
+ * Renders a [Notification] into an [EmailContent] carrying both a plain-text
+ * body (always) and an HTML body (when the channel is configured to send it).
+ *
+ * The HTML template is intentionally simple: inline styles in table cells,
+ * brand palette baked in. Email clients can't be trusted with <style> tags
+ * or modern CSS so the layout is table-based on purpose.
+ */
+@Component
+class NotificationEmailRenderer(
+    private val properties: NotificationEmailProperties,
+) {
+    fun render(notification: Notification): EmailContent =
+        EmailContent(
+            subject = notification.title,
+            plainText = renderPlainText(notification),
+            html = if (properties.html) renderHtml(notification) else null,
+        )
+
+    private fun renderPlainText(notification: Notification): String {
+        val sb = StringBuilder()
+        notification.body?.let { sb.append(it).append("\n\n") }
+        notification.link?.let { sb.append("Open: ").append(it).append('\n') }
+        if (sb.isEmpty()) sb.append(notification.title)
+        return sb.toString().trimEnd()
+    }
+
+    private fun renderHtml(notification: Notification): String {
+        val body = notification.body?.let { escape(it) }
+        val link = notification.link?.let { escape(it) }
+        val title = escape(notification.title)
+        val senderName = escape(properties.senderName)
+
+        return """
+            <!doctype html>
+            <html>
+              <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <title>$title</title>
+              </head>
+              <body style="margin:0;padding:0;background:#f6f1e6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f6f1e6;padding:32px 16px;">
+                  <tr>
+                    <td align="center">
+                      <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:560px;background:#ffffff;border-radius:8px;border:1px solid #e8e0d0;">
+                        <tr>
+                          <td style="padding:24px 32px 16px 32px;border-bottom:1px solid #e8e0d0;">
+                            <div style="font-family:'Georgia',serif;font-size:14px;color:#b93a1d;letter-spacing:0.02em;">$senderName</div>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td style="padding:28px 32px 8px 32px;">
+                            <h1 style="margin:0 0 12px 0;font-family:'Georgia',serif;font-size:22px;font-weight:380;color:#17160f;line-height:1.25;">$title</h1>
+                          </td>
+                        </tr>
+                        ${if (body != null) """<tr><td style="padding:0 32px 24px 32px;font-size:15px;color:#3d3a30;line-height:1.55;">$body</td></tr>""" else ""}
+                        ${if (link != null) """<tr><td style="padding:0 32px 28px 32px;"><a href="$link" style="display:inline-block;padding:10px 18px;background:#17160f;color:#f6f1e6;text-decoration:none;border-radius:999px;font-size:14px;">Open in Tessera</a></td></tr>""" else ""}
+                        <tr>
+                          <td style="padding:18px 32px 22px 32px;border-top:1px solid #e8e0d0;font-size:11px;color:#888477;letter-spacing:0.04em;text-transform:uppercase;">
+                            You're getting this because you have notifications enabled for this kind of event. Update your preferences in Tessera.
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </body>
+            </html>
+            """.trimIndent()
+    }
+
+    private fun escape(value: String): String =
+        value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&#39;")
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/SmtpEmailSender.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/SmtpEmailSender.kt
@@ -1,19 +1,24 @@
 package com.aquinofroilan.tessera.service.notification
 
 import com.aquinofroilan.tessera.config.NotificationEmailProperties
+import jakarta.mail.internet.InternetAddress
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.annotation.Primary
-import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Component
 
 /**
- * Hands a [SimpleMailMessage] to Spring's [JavaMailSender]. Only loaded when
- * a [JavaMailSender] bean exists — that's the Spring Boot mail autoconfig
- * signal that \`spring.mail.host\` (etc.) was actually provided.
+ * Hands a [jakarta.mail.internet.MimeMessage] to Spring's [JavaMailSender].
+ * When the rendered [EmailContent] has an HTML body the message is sent as
+ * multipart/alternative so receiving clients can pick the format they
+ * support; otherwise plain-text only.
  *
- * Marked @Primary so when this bean is present it wins over [NoOpEmailSender].
+ * Only loaded when a [JavaMailSender] bean exists — that's the Spring Boot
+ * mail autoconfig signal that \`spring.mail.host\` (etc.) was actually
+ * provided. Marked @Primary so when this bean is present it wins over
+ * [NoOpEmailSender].
  */
 @Component
 @Primary
@@ -26,23 +31,28 @@ class SmtpEmailSender(
 
     override fun send(
         to: String,
-        subject: String,
-        textBody: String,
+        content: EmailContent,
     ): Boolean {
-        val message =
-            SimpleMailMessage().apply {
-                from = formatFrom(properties.senderName, properties.from)
-                setTo(to)
-                this.subject = subject
-                this.text = textBody
-            }
+        val message = mailSender.createMimeMessage()
+        val helper = MimeMessageHelper(message, content.html != null, "UTF-8")
+        helper.setFrom(buildFrom())
+        helper.setTo(to)
+        helper.setSubject(content.subject)
+        if (content.html != null) {
+            // The plain-text body is the multipart alternative; clients that
+            // can't render HTML fall back to it.
+            helper.setText(content.plainText, content.html)
+        } else {
+            helper.setText(content.plainText, false)
+        }
         mailSender.send(message)
-        log.debug("Sent notification email to {} (subject='{}')", to, subject)
+        log.debug("Sent notification email to {} (subject='{}', html={})", to, content.subject, content.html != null)
         return true
     }
 
-    private fun formatFrom(
-        name: String,
-        address: String,
-    ): String = if (name.isBlank()) address else "$name <$address>"
+    private fun buildFrom(): InternetAddress {
+        val address = InternetAddress(properties.from)
+        if (properties.senderName.isNotBlank()) address.personal = properties.senderName
+        return address
+    }
 }

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailDispatcherTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailDispatcherTest.kt
@@ -51,6 +51,7 @@ class NotificationEmailDispatcherTest {
                 outboxRepository,
                 notificationRepository,
                 emailSender,
+                NotificationEmailRenderer(NotificationEmailProperties()),
                 NotificationEmailProperties(),
             )
     }
@@ -58,7 +59,7 @@ class NotificationEmailDispatcherTest {
     @Test
     fun `successful send marks the row SENT with sent_at`() {
         givenPending(row(notificationId = notification.id))
-        whenever(emailSender.send(any(), any(), any())).thenReturn(true)
+        whenever(emailSender.send(any(), any<EmailContent>())).thenReturn(true)
 
         dispatcher.drain()
 
@@ -72,7 +73,7 @@ class NotificationEmailDispatcherTest {
     @Test
     fun `intentional skip from the sender marks the row SKIPPED`() {
         givenPending(row(notificationId = notification.id))
-        whenever(emailSender.send(any(), any(), any())).thenReturn(false)
+        whenever(emailSender.send(any(), any<EmailContent>())).thenReturn(false)
 
         dispatcher.drain()
 
@@ -84,7 +85,7 @@ class NotificationEmailDispatcherTest {
     @Test
     fun `transport failure with attempts left reschedules with linear backoff`() {
         givenPending(row(notificationId = notification.id))
-        whenever(emailSender.send(any(), any(), any()))
+        whenever(emailSender.send(any(), any<EmailContent>()))
             .thenThrow(RuntimeException("connection refused"))
 
         val beforeUtc = LocalDateTime.now(ZoneOffset.UTC)
@@ -101,7 +102,7 @@ class NotificationEmailDispatcherTest {
     @Test
     fun `transport failure on the last allowed attempt marks the row FAILED`() {
         givenPending(row(notificationId = notification.id, attempts = 4))
-        whenever(emailSender.send(any(), any(), any()))
+        whenever(emailSender.send(any(), any<EmailContent>()))
             .thenThrow(RuntimeException("550 mailbox unavailable"))
 
         dispatcher.drain()
@@ -123,7 +124,7 @@ class NotificationEmailDispatcherTest {
 
         val saved = capture()
         assertThat(saved.status).isEqualTo(EmailDeliveryStatus.FAILED)
-        verify(emailSender, org.mockito.Mockito.never()).send(any(), any(), any())
+        verify(emailSender, org.mockito.Mockito.never()).send(any(), any<EmailContent>())
     }
 
     @Test
@@ -132,7 +133,7 @@ class NotificationEmailDispatcherTest {
 
         dispatcher.drain()
 
-        verify(emailSender, org.mockito.Mockito.never()).send(any(), any(), any())
+        verify(emailSender, org.mockito.Mockito.never()).send(any(), any<EmailContent>())
         verify(outboxRepository, org.mockito.Mockito.never()).save(any<NotificationEmailOutbox>())
     }
 

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailRendererTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailRendererTest.kt
@@ -88,8 +88,8 @@ class NotificationEmailRendererTest {
         link: String? = null,
     ): Notification =
         Notification(
-            organizationId = "org-1",
-            recipientUserId = "user-1",
+            organizationId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000100"),
+            recipientUserId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000101"),
             category = NotificationCategory.APPROVAL,
             kind = "test.kind",
             title = title,

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailRendererTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/notification/NotificationEmailRendererTest.kt
@@ -1,0 +1,99 @@
+package com.aquinofroilan.tessera.service.notification
+
+import com.aquinofroilan.tessera.config.NotificationEmailProperties
+import com.aquinofroilan.tessera.model.Notification
+import com.aquinofroilan.tessera.model.NotificationCategory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class NotificationEmailRendererTest {
+    @Test
+    fun `subject mirrors the notification title`() {
+        val renderer = NotificationEmailRenderer(NotificationEmailProperties())
+
+        val content = renderer.render(notification(title = "Your leave request was approved"))
+
+        assertThat(content.subject).isEqualTo("Your leave request was approved")
+    }
+
+    @Test
+    fun `plain text body composes body and link with a fallback to the title`() {
+        val renderer = NotificationEmailRenderer(NotificationEmailProperties())
+
+        val rich =
+            renderer.render(
+                notification(
+                    title = "Purchase request PR-001 approved",
+                    body = "Ready to convert into a PO.",
+                    link = "/procurement/purchase-requests/pr-1",
+                ),
+            )
+        assertThat(rich.plainText).contains("Ready to convert into a PO.")
+        assertThat(rich.plainText).contains("Open: /procurement/purchase-requests/pr-1")
+
+        val bare = renderer.render(notification(title = "Heads up", body = null, link = null))
+        assertThat(bare.plainText).isEqualTo("Heads up")
+    }
+
+    @Test
+    fun `html body is emitted when enabled and includes the title and CTA`() {
+        val renderer = NotificationEmailRenderer(NotificationEmailProperties())
+
+        val content =
+            renderer.render(
+                notification(
+                    title = "Your leave was approved",
+                    body = "Aug 1 - 3.",
+                    link = "/hr/leave-requests/lr-1",
+                ),
+            )
+
+        assertThat(content.html).isNotNull()
+        assertThat(content.html!!).contains("Your leave was approved")
+        assertThat(content.html!!).contains("/hr/leave-requests/lr-1")
+        assertThat(content.html!!).contains("Open in Tessera")
+    }
+
+    @Test
+    fun `html body is omitted when the channel is configured plain-text only`() {
+        val renderer = NotificationEmailRenderer(NotificationEmailProperties(html = false))
+
+        val content = renderer.render(notification(title = "Plain only"))
+
+        assertThat(content.html).isNull()
+    }
+
+    @Test
+    fun `html escapes user-supplied content to prevent injection`() {
+        val renderer = NotificationEmailRenderer(NotificationEmailProperties())
+
+        val content =
+            renderer.render(
+                notification(
+                    title = "<script>evil</script>",
+                    body = "a & b < c",
+                    link = "https://example.com/?q=\"x\"",
+                ),
+            )
+
+        assertThat(content.html!!).doesNotContain("<script>evil</script>")
+        assertThat(content.html!!).contains("&lt;script&gt;evil&lt;/script&gt;")
+        assertThat(content.html!!).contains("a &amp; b &lt; c")
+        assertThat(content.html!!).contains("https://example.com/?q=&quot;x&quot;")
+    }
+
+    private fun notification(
+        title: String,
+        body: String? = null,
+        link: String? = null,
+    ): Notification =
+        Notification(
+            organizationId = "org-1",
+            recipientUserId = "user-1",
+            category = NotificationCategory.APPROVAL,
+            kind = "test.kind",
+            title = title,
+            body = body,
+            link = link,
+        )
+}


### PR DESCRIPTION
Closes #257. Stacks on **#256** (workflow rules).

## What ships
- **`EmailContent`** struct (subject + plainText + optional html) replaces the three-arg send signature; transports decide whether to emit multipart.
- **`SmtpEmailSender`** switches from `SimpleMailMessage` to `MimeMessage` + `MimeMessageHelper`. Multipart/alternative when html is non-null; clients render whichever format they support. From address built via `InternetAddress` so the sender name lands in the header.
- **`NotificationEmailRenderer`** composes both bodies. Plain text mirrors the prior dispatcher-inline logic; HTML uses a branded table-based template with inline styles (email clients strip `<style>` blocks). User content is escaped — covered by a test for the `<script>` injection case.
- **`tessera.notifications.email.html`** (default true) is the kill switch when an admin wants plain-text only.

## Tests
- New `NotificationEmailRendererTest` (5 cases: subject, plain-text composition, HTML emission, html=false toggle, HTML escaping).
- `NotificationEmailDispatcherTest` signature updated to the new send shape.