### PR TITLE
feat(notifications): SSE stream for live unread-count updates (#261)

### DIFF
--- a/src/main/kotlin/com/aquinofroilan/tessera/controller/NotificationStreamController.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/controller/NotificationStreamController.kt
@@ -1,0 +1,63 @@
+package com.aquinofroilan.tessera.controller
+
+import com.aquinofroilan.tessera.security.AuthenticationContext
+import com.aquinofroilan.tessera.service.NotificationService
+import com.aquinofroilan.tessera.service.notification.NotificationStreamRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+/**
+ * Server-sent events stream that backs the live unread-count bell.
+ * Each connection is a long-lived [SseEmitter] held in
+ * [NotificationStreamRegistry]; the registry pushes 'unread' and
+ * 'notification' events whenever [NotificationService.publish] saves a
+ * row for the caller.
+ *
+ * The endpoint immediately pushes the current unread count so the
+ * client doesn't have to make a second request to bootstrap.
+ */
+@RestController
+@RequestMapping("/notifications")
+class NotificationStreamController(
+    private val notificationService: NotificationService,
+    private val streamRegistry: NotificationStreamRegistry,
+    private val authContext: AuthenticationContext,
+) {
+    private val log = LoggerFactory.getLogger(NotificationStreamController::class.java)
+
+    @GetMapping("/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    @PreAuthorize("isAuthenticated()")
+    fun stream(): SseEmitter {
+        val orgId =
+            authContext.organizationId()
+                ?: throw IllegalStateException("Stream endpoint called without an org context — auth filter misconfigured")
+        val userId =
+            authContext.userId()
+                ?: throw IllegalStateException("Stream endpoint called without a user context — auth filter misconfigured")
+
+        // 30-minute idle timeout; browsers auto-reconnect on EventSource
+        // disconnect so this is effectively a heartbeat ceiling, not a
+        // session lifetime.
+        val emitter = SseEmitter(STREAM_TIMEOUT_MS)
+        streamRegistry.register(userId, orgId, emitter)
+
+        try {
+            val unread = notificationService.unreadCountFor(userId, orgId)
+            emitter.send(SseEmitter.event().name("unread").data(mapOf("unread" to unread)))
+        } catch (e: Exception) {
+            log.warn("Failed to push initial unread count for user {}: {}", userId, e.message)
+            emitter.completeWithError(e)
+        }
+
+        return emitter
+    }
+
+    companion object {
+        private const val STREAM_TIMEOUT_MS: Long = 30L * 60_000
+    }
+}

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/NotificationService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/NotificationService.kt
@@ -5,6 +5,7 @@ import com.aquinofroilan.tessera.exception.ResourceNotFoundException
 import com.aquinofroilan.tessera.model.Notification
 import com.aquinofroilan.tessera.repository.NotificationRepository
 import com.aquinofroilan.tessera.service.notification.NotificationEmailEnqueuer
+import com.aquinofroilan.tessera.service.notification.NotificationStreamRegistry
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -13,14 +14,16 @@ import java.time.ZoneOffset
 /**
  * In-app notification feed. Any service can call [publish] to drop a row
  * for the recipient; the feed endpoint reads it back. Email delivery is
- * fanned out via [NotificationEmailEnqueuer] inside the same transaction
- * (sub-PR #2). Per-user preferences (#3) and event-driven hooks (#4) land
- * in later sub-PRs.
+ * fanned out via [NotificationEmailEnqueuer] inside the same transaction;
+ * the live bell-badge SSE stream is fanned out via [NotificationStreamRegistry]
+ * after save (best-effort — a backend hiccup in the registry doesn't roll
+ * back the source transaction).
  */
 @Service
 class NotificationService(
     private val notificationRepository: NotificationRepository,
     private val emailEnqueuer: NotificationEmailEnqueuer,
+    private val streamRegistry: NotificationStreamRegistry,
 ) {
     @Transactional
     fun publish(
@@ -40,6 +43,9 @@ class NotificationService(
                 ),
             )
         emailEnqueuer.enqueue(saved)
+        val unread = unreadCountFor(saved.recipientUserId, saved.organizationId)
+        streamRegistry.broadcastNotification(saved.recipientUserId, saved.organizationId, saved)
+        streamRegistry.broadcastUnread(saved.recipientUserId, saved.organizationId, unread)
         return saved
     }
 
@@ -77,17 +83,26 @@ class NotificationService(
             throw ResourceNotFoundException("Notification $id not found")
         }
         if (notification.readAt != null) return notification
-        return notificationRepository.save(notification.copy(readAt = LocalDateTime.now(ZoneOffset.UTC)))
+        val updated = notificationRepository.save(notification.copy(readAt = LocalDateTime.now(ZoneOffset.UTC)))
+        val unread = unreadCountFor(recipientUserId, organizationId)
+        streamRegistry.broadcastUnread(recipientUserId, organizationId, unread)
+        return updated
     }
 
     @Transactional
     fun markAllRead(
         recipientUserId: java.util.UUID,
         organizationId: java.util.UUID,
-    ): Int =
-        notificationRepository.markAllReadFor(
-            recipientUserId,
-            organizationId,
-            LocalDateTime.now(ZoneOffset.UTC),
-        )
+    ): Int {
+        val touched =
+            notificationRepository.markAllReadFor(
+                recipientUserId,
+                organizationId,
+                LocalDateTime.now(ZoneOffset.UTC),
+            )
+        if (touched > 0) {
+            streamRegistry.broadcastUnread(recipientUserId, organizationId, 0L)
+        }
+        return touched
+    }
 }

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationStreamRegistry.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/notification/NotificationStreamRegistry.kt
@@ -1,0 +1,88 @@
+package com.aquinofroilan.tessera.service.notification
+
+import com.aquinofroilan.tessera.dto.NotificationResponse
+import com.aquinofroilan.tessera.model.Notification
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * In-memory fan-out for the bell-badge SSE stream. One entry per
+ * (recipient user, organization) tuple holds every active emitter for
+ * that user across browser tabs / sessions. Auto-cleans when an emitter
+ * completes, times out, or errors.
+ *
+ * Single-process only — a horizontal scale-out would need a Redis pubsub
+ * or similar to fan messages between instances. For a hobby ERP this is
+ * intentionally simple.
+ */
+@Component
+class NotificationStreamRegistry {
+    private val log = LoggerFactory.getLogger(NotificationStreamRegistry::class.java)
+    private val emittersByKey = ConcurrentHashMap<Key, CopyOnWriteArrayList<SseEmitter>>()
+
+    fun register(
+        userId: java.util.UUID,
+        organizationId: java.util.UUID,
+        emitter: SseEmitter,
+    ) {
+        val key = Key(userId, organizationId)
+        val bag = emittersByKey.computeIfAbsent(key) { CopyOnWriteArrayList() }
+        bag.add(emitter)
+
+        val cleanup =
+            Runnable {
+                bag.remove(emitter)
+                if (bag.isEmpty()) emittersByKey.remove(key, bag)
+            }
+        emitter.onCompletion(cleanup)
+        emitter.onTimeout(cleanup)
+        emitter.onError {
+            log.debug("SSE emitter for user {} errored: {}", userId, it.message)
+            cleanup.run()
+        }
+    }
+
+    fun broadcastUnread(
+        userId: java.util.UUID,
+        organizationId: java.util.UUID,
+        unread: Long,
+    ) {
+        sendAll(userId, organizationId, "unread", mapOf("unread" to unread))
+    }
+
+    fun broadcastNotification(
+        userId: java.util.UUID,
+        organizationId: java.util.UUID,
+        notification: Notification,
+    ) {
+        sendAll(userId, organizationId, "notification", NotificationResponse.from(notification))
+    }
+
+    private fun sendAll(
+        userId: java.util.UUID,
+        organizationId: java.util.UUID,
+        eventName: String,
+        payload: Any,
+    ) {
+        val key = Key(userId, organizationId)
+        val bag = emittersByKey[key] ?: return
+        bag.forEach { emitter ->
+            try {
+                emitter.send(SseEmitter.event().name(eventName).data(payload))
+            } catch (e: Exception) {
+                log.debug("Dropping dead SSE emitter for user {}: {}", userId, e.message)
+                bag.remove(emitter)
+                emitter.completeWithError(e)
+            }
+        }
+        if (bag.isEmpty()) emittersByKey.remove(key, bag)
+    }
+
+    private data class Key(
+        val userId: java.util.UUID,
+        val organizationId: java.util.UUID,
+    )
+}

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/NotificationServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/NotificationServiceTest.kt
@@ -6,6 +6,7 @@ import com.aquinofroilan.tessera.model.Notification
 import com.aquinofroilan.tessera.model.NotificationCategory
 import com.aquinofroilan.tessera.repository.NotificationRepository
 import com.aquinofroilan.tessera.service.notification.NotificationEmailEnqueuer
+import com.aquinofroilan.tessera.service.notification.NotificationStreamRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -22,6 +23,7 @@ import java.util.Optional
 class NotificationServiceTest {
     private lateinit var repository: NotificationRepository
     private lateinit var emailEnqueuer: NotificationEmailEnqueuer
+    private lateinit var streamRegistry: NotificationStreamRegistry
     private lateinit var service: NotificationService
 
     private val orgId = java.util.UUID.fromString("00000000-0000-0000-0000-000000000001")
@@ -31,8 +33,9 @@ class NotificationServiceTest {
     fun setup() {
         repository = mock(NotificationRepository::class.java)
         emailEnqueuer = mock(NotificationEmailEnqueuer::class.java)
+        streamRegistry = mock(NotificationStreamRegistry::class.java)
         whenever(repository.save(any<Notification>())).thenAnswer { it.arguments[0] }
-        service = NotificationService(repository, emailEnqueuer)
+        service = NotificationService(repository, emailEnqueuer, streamRegistry)
     }
 
     @Test


### PR DESCRIPTION
Closes #261. Stacks on **#260**.

## What ships
- **`NotificationStreamRegistry`** — in-memory `ConcurrentHashMap<(userId, orgId), CopyOnWriteArrayList<SseEmitter>>` with auto-cleanup on completion / timeout / error. Single-process; a horizontal scale-out would need Redis pubsub.
- **`GET /notifications/stream`** (`isAuthenticated`, `text/event-stream`) — 30-minute SseEmitter (browsers auto-reconnect on EventSource disconnect). Immediately pushes the current unread count so the client doesn't need a second bootstrap request.
- **`NotificationService`** broadcasts on three actions:
  - `publish` → `notification` event with the row + `unread` with the new count
  - `markRead` → `unread` with the new count
  - `markAllRead` → `unread` = 0 when any row was touched
- Broadcast is best-effort and inline with the source transaction; on a hiccup the SSE clients may briefly overshoot, but the next page load reconciles via the GET endpoints.

## Used by
Frontend real-time bell PR (next).