### PR TITLE
Refactor: Migrate to UUIDv7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ production, staging ]
 
 env:
-  JAVA_VERSION: '21'
+  JAVA_VERSION: '26'
   JAVA_DISTRIBUTION: 'temurin'
 
 jobs:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ description = "Tessera an ERP System"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(26)
     }
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
@@ -50,6 +50,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-health:4.0.1")
     implementation("org.aspectj:aspectjweaver")
     implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
+    implementation("com.github.f4b6a3:uuid-creator:6.1.1")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-authorization-server")
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Account.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Account.kt
@@ -38,7 +38,7 @@ enum class AccountType {
 class Account(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var code: String,
     var name: String,
     var description: String? = null,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/ApiKey.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/ApiKey.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 class ApiKey(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var name: String,
     @Column(name = "key_hash")
     var keyHash: String,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/AttendanceRecord.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/AttendanceRecord.kt
@@ -26,7 +26,7 @@ enum class AttendanceStatus {
 class AttendanceRecord(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "employee_id", columnDefinition = "uuid")
     var employeeId: java.util.UUID,
     @Column(name = "work_date")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Bill.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Bill.kt
@@ -41,7 +41,7 @@ enum class PaymentMethod {
 class BillLine(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     var lineNumber: Int = 0,
     @Column(name = "account_id", columnDefinition = "uuid")
@@ -60,7 +60,7 @@ class BillLine(
 class Bill(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "bill_number")
     var billNumber: String,
     @Column(name = "vendor_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/BillOfMaterials.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/BillOfMaterials.kt
@@ -31,7 +31,7 @@ enum class BomStatus {
 data class BomLine(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: java.util.UUID = java.util.UUID.randomUUID(),
+    val id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     val lineNumber: Int,
     @Column(name = "component_product_id", columnDefinition = "uuid")
@@ -53,7 +53,7 @@ data class BomLine(
 data class BillOfMaterials(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: java.util.UUID = java.util.UUID.randomUUID(),
+    val id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "organization_id", columnDefinition = "uuid")
     val organizationId: java.util.UUID,
     @Column(name = "product_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/BillPayment.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/BillPayment.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 class BillPayment(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "bill_id", columnDefinition = "uuid")
     var billId: java.util.UUID,
     @Column(name = "payment_date")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Customer.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Customer.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class Customer(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var name: String,
     @Column(name = "contact_name")
     var contactName: String? = null,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Department.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Department.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class Department(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var code: String,
     var name: String,
     var description: String? = null,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Employee.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Employee.kt
@@ -26,7 +26,7 @@ enum class EmploymentStatus {
 class Employee(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "employee_number")
     var employeeNumber: String,
     @Column(name = "first_name")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/EmployeeCompensation.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/EmployeeCompensation.kt
@@ -26,7 +26,7 @@ enum class PayPeriod {
 class EmployeeCompensation(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "employee_id", columnDefinition = "uuid")
     var employeeId: java.util.UUID,
     @Column(name = "position_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/ExchangeRate.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/ExchangeRate.kt
@@ -26,7 +26,7 @@ enum class ExchangeRateSource {
 class ExchangeRate(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "organization_id", columnDefinition = "uuid")
     var organizationId: java.util.UUID,
     @Column(name = "from_currency", columnDefinition = "char(3)")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/FiscalYear.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/FiscalYear.kt
@@ -35,7 +35,7 @@ enum class FiscalPeriodStatus {
 class FiscalPeriod(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "period_number")
     var periodNumber: Int,
     var name: String,
@@ -61,7 +61,7 @@ class FiscalPeriod(
 class FiscalYear(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var name: String,
     @Column(name = "start_date")
     var startDate: LocalDate,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/InventoryCostLayer.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/InventoryCostLayer.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class InventoryCostLayer(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "organization_id", columnDefinition = "uuid")
     var organizationId: java.util.UUID,
     @Column(name = "product_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/InventoryReorderRule.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/InventoryReorderRule.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 class InventoryReorderRule(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "organization_id", columnDefinition = "uuid")
     var organizationId: java.util.UUID,
     @Column(name = "product_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/InventoryWaSnapshot.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/InventoryWaSnapshot.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class InventoryWaSnapshot(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "organization_id", columnDefinition = "uuid")
     var organizationId: java.util.UUID,
     @Column(name = "product_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Invitation.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Invitation.kt
@@ -25,7 +25,7 @@ enum class InvitationStatus {
 class Invitation(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var email: String,
     @Column(name = "organization_id", columnDefinition = "uuid")
     var organizationId: java.util.UUID,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Invoice.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Invoice.kt
@@ -33,7 +33,7 @@ enum class InvoiceStatus {
 class InvoiceLine(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     var lineNumber: Int = 0,
     @Column(name = "account_id", columnDefinition = "uuid")
@@ -52,7 +52,7 @@ class InvoiceLine(
 class Invoice(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "invoice_number")
     var invoiceNumber: String,
     @Column(name = "customer_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/InvoiceReceipt.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/InvoiceReceipt.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 class InvoiceReceipt(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "invoice_id", columnDefinition = "uuid")
     var invoiceId: java.util.UUID,
     @Column(name = "receipt_date")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/JournalEntry.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/JournalEntry.kt
@@ -36,7 +36,7 @@ enum class JournalEntrySource {
 class JournalEntryLine(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     var lineNumber: Int = 0,
     @Column(name = "account_id", columnDefinition = "uuid")
@@ -56,7 +56,7 @@ class JournalEntryLine(
 class JournalEntry(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "entry_number")
     var entryNumber: String,
     var date: LocalDate,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/LeaveRequest.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/LeaveRequest.kt
@@ -27,7 +27,7 @@ enum class LeaveRequestStatus {
 class LeaveRequest(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "employee_id", columnDefinition = "uuid")
     var employeeId: java.util.UUID,
     @Column(name = "leave_type_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/LeaveType.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/LeaveType.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class LeaveType(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var code: String,
     var name: String,
     var paid: Boolean = true,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/LoginLinkToken.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/LoginLinkToken.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 class LoginLinkToken(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "token_hash")
     var tokenHash: String,
     @Column(name = "user_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Organizations.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Organizations.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class Organizations(
     @Id
     @Column(name = "uuid", columnDefinition = "uuid")
-    var uuid: java.util.UUID = UUID.randomUUID(),
+    var uuid: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "org_slug")
     var orgSlug: String,
     var name: String,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/PasswordResetToken.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/PasswordResetToken.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 class PasswordResetToken(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "token_hash")
     var tokenHash: String,
     @Column(name = "user_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/PayrollRun.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/PayrollRun.kt
@@ -32,7 +32,7 @@ enum class PayrollRunStatus {
 class PayrollRunLine(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     var lineNumber: Int = 0,
     @Column(name = "employee_id", columnDefinition = "uuid")
@@ -53,7 +53,7 @@ class PayrollRunLine(
 class PayrollRun(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "run_number")
     var runNumber: String,
     @Column(name = "period_start")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Position.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Position.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class Position(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var code: String,
     var title: String,
     @Column(name = "department_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Product.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Product.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 class Product(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var sku: String,
     var name: String,
     var description: String? = null,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Project.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Project.kt
@@ -34,7 +34,7 @@ enum class ProjectBillingType {
 class Project(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "project_number")
     var projectNumber: String,
     var name: String,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectBudget.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectBudget.kt
@@ -27,7 +27,7 @@ enum class ProjectCostCategory {
 class ProjectBudget(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "project_id", columnDefinition = "uuid")
     var projectId: java.util.UUID,
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectTask.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/ProjectTask.kt
@@ -27,7 +27,7 @@ enum class TaskStatus {
 class ProjectTask(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "project_id", columnDefinition = "uuid")
     var projectId: java.util.UUID,
     @Column(name = "parent_task_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/PurchaseOrder.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/PurchaseOrder.kt
@@ -34,7 +34,7 @@ enum class PurchaseOrderStatus {
 class PurchaseOrderLine(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     var lineNumber: Int = 0,
     @Column(name = "product_id", columnDefinition = "uuid")
@@ -61,7 +61,7 @@ class PurchaseOrderLine(
 class PurchaseOrder(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "po_number")
     var poNumber: String,
     @Column(name = "vendor_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/PurchaseRequest.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/PurchaseRequest.kt
@@ -33,7 +33,7 @@ enum class PurchaseRequestStatus {
 class PurchaseRequestLine(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     var lineNumber: Int = 0,
     @Column(name = "product_id", columnDefinition = "uuid")
@@ -54,7 +54,7 @@ class PurchaseRequestLine(
 class PurchaseRequest(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "pr_number")
     var prNumber: String,
     @Column(name = "organization_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Quotation.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Quotation.kt
@@ -34,7 +34,7 @@ enum class QuotationStatus {
 data class QuotationLine(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: java.util.UUID = java.util.UUID.randomUUID(),
+    val id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     val lineNumber: Int = 0,
     @Column(name = "product_id", columnDefinition = "uuid")
@@ -57,7 +57,7 @@ data class QuotationLine(
 data class Quotation(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: java.util.UUID = java.util.UUID.randomUUID(),
+    val id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "quote_number")
     val quoteNumber: String,
     @Column(name = "customer_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/RefreshToken.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/RefreshToken.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 class RefreshToken(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "token_hash")
     var tokenHash: String,
     @Column(name = "user_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Role.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Role.kt
@@ -28,7 +28,7 @@ enum class RoleLevel {
 class Role(
     @Id
     @Column(name = "uuid", columnDefinition = "uuid")
-    var uuid: java.util.UUID = UUID.randomUUID(),
+    var uuid: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var name: String,
     var description: String,
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/RoleAssignment.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/RoleAssignment.kt
@@ -14,7 +14,7 @@ class RoleAssignment(
     var organizationId: java.util.UUID? = null,
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Routing.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Routing.kt
@@ -31,7 +31,10 @@ enum class RoutingStatus {
 data class RoutingOperation(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: String = UUID.randomUUID().toString(),
+    val id: String =
+        java.util.UUID
+            .ofEpochMillis(System.currentTimeMillis())
+            .toString(),
     @Column(name = "operation_number")
     val operationNumber: Int,
     @Column(name = "work_center_id", columnDefinition = "uuid")
@@ -54,7 +57,10 @@ data class RoutingOperation(
 data class Routing(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: String = UUID.randomUUID().toString(),
+    val id: String =
+        java.util.UUID
+            .ofEpochMillis(System.currentTimeMillis())
+            .toString(),
     @Column(name = "organization_id", columnDefinition = "uuid")
     val organizationId: String,
     @Column(name = "product_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/SalesOrder.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/SalesOrder.kt
@@ -34,7 +34,7 @@ enum class SalesOrderStatus {
 class SalesOrderLine(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "line_number")
     var lineNumber: Int = 0,
     @Column(name = "product_id", columnDefinition = "uuid")
@@ -61,7 +61,7 @@ class SalesOrderLine(
 class SalesOrder(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "so_number")
     var soNumber: String,
     @Column(name = "customer_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/SessionToken.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/SessionToken.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 class SessionToken(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var token: String,
     @Column(name = "user_id", columnDefinition = "uuid")
     var userId: java.util.UUID,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/StockMovement.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/StockMovement.kt
@@ -27,7 +27,7 @@ enum class StockMovementType {
 class StockMovement(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "organization_id", columnDefinition = "uuid")
     var organizationId: java.util.UUID,
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/StockOnHand.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/StockOnHand.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 class StockOnHand(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "organization_id", columnDefinition = "uuid")
     var organizationId: java.util.UUID,
     @Column(name = "product_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/TaxGroup.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/TaxGroup.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 class TaxGroup(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var name: String,
     var code: String,
     @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/TaxRate.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/TaxRate.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 class TaxRate(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var name: String,
     var code: String,
     var percentage: BigDecimal,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/TimeEntry.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/TimeEntry.kt
@@ -28,7 +28,7 @@ enum class TimeEntryStatus {
 class TimeEntry(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     @Column(name = "employee_id", columnDefinition = "uuid")
     var employeeId: java.util.UUID,
     @Column(name = "project_id", columnDefinition = "uuid")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/User.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/User.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 class User(
     @Id
     @Column(name = "uuid", columnDefinition = "uuid")
-    var uuid: java.util.UUID = UUID.randomUUID(),
+    var uuid: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var username: String,
     var email: String,
     @Column(name = "first_name")

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Vendor.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Vendor.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class Vendor(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var name: String,
     @Column(name = "contact_name")
     var contactName: String? = null,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/Warehouse.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/Warehouse.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 class Warehouse(
     @Id
     @Column(columnDefinition = "uuid")
-    var id: java.util.UUID = UUID.randomUUID(),
+    var id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
     var code: String,
     var name: String,
     var description: String? = null,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/WorkCenter.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/WorkCenter.kt
@@ -28,7 +28,10 @@ enum class WorkCenterType {
 data class WorkCenter(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: String = UUID.randomUUID().toString(),
+    val id: String =
+        java.util.UUID
+            .ofEpochMillis(System.currentTimeMillis())
+            .toString(),
     @Column(name = "organization_id", columnDefinition = "uuid")
     val organizationId: String,
     val code: String,

--- a/src/main/kotlin/com/aquinofroilan/tessera/model/WorkOrder.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/model/WorkOrder.kt
@@ -41,7 +41,10 @@ enum class WorkOrderOperationStatus {
 data class WorkOrderComponent(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: String = UUID.randomUUID().toString(),
+    val id: String =
+        java.util.UUID
+            .ofEpochMillis(System.currentTimeMillis())
+            .toString(),
     @Column(name = "line_number")
     val lineNumber: Int,
     @Column(name = "component_product_id", columnDefinition = "uuid")
@@ -64,7 +67,10 @@ data class WorkOrderComponent(
 data class WorkOrderOperation(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: String = UUID.randomUUID().toString(),
+    val id: String =
+        java.util.UUID
+            .ofEpochMillis(System.currentTimeMillis())
+            .toString(),
     @Column(name = "operation_number")
     val operationNumber: Int,
     @Column(name = "work_center_id", columnDefinition = "uuid")
@@ -88,7 +94,10 @@ data class WorkOrderOperation(
 data class WorkOrder(
     @Id
     @Column(columnDefinition = "uuid")
-    val id: String = UUID.randomUUID().toString(),
+    val id: String =
+        java.util.UUID
+            .ofEpochMillis(System.currentTimeMillis())
+            .toString(),
     @Column(name = "organization_id", columnDefinition = "uuid")
     val organizationId: String,
     @Column(name = "wo_number")

--- a/src/main/kotlin/com/aquinofroilan/tessera/repository/StockOnHandQueries.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/repository/StockOnHandQueries.kt
@@ -69,7 +69,7 @@ open class StockOnHandQueriesImpl(
         val updated =
             jdbc.update(
                 sql,
-                UUID.randomUUID(),
+                java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
                 organizationId,
                 productId,
                 warehouseId,

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/BillService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/BillService.kt
@@ -326,7 +326,7 @@ class BillService(
         val apAccount = getApAccount(organizationId)
         val cashAccount = getCashAccount(organizationId)
 
-        val paymentId = UUID.randomUUID()
+        val paymentId = java.util.UUID.ofEpochMillis(System.currentTimeMillis())
         val baseDecimals = currencyService.getCurrency(getBaseCurrency(organizationId)).decimalPlaces
         val newAmountPaid = bill.amountPaid.add(request.amount)
         val fullyPaid = newAmountPaid.compareTo(bill.totalAmount) >= 0

--- a/src/main/kotlin/com/aquinofroilan/tessera/service/InvoiceService.kt
+++ b/src/main/kotlin/com/aquinofroilan/tessera/service/InvoiceService.kt
@@ -329,7 +329,7 @@ class InvoiceService(
         val arAccount = getArAccount(organizationId)
         val cashAccount = getCashAccount(organizationId)
 
-        val receiptId = UUID.randomUUID()
+        val receiptId = java.util.UUID.ofEpochMillis(System.currentTimeMillis())
         val baseDecimals = currencyService.getCurrency(getBaseCurrency(organizationId)).decimalPlaces
         val newAmountReceived = invoice.amountReceived.add(request.amount)
         val fullyPaid = newAmountReceived.compareTo(invoice.totalAmount) >= 0

--- a/src/test/kotlin/com/aquinofroilan/tessera/repository/StockOnHandConcurrencyIT.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/repository/StockOnHandConcurrencyIT.kt
@@ -25,9 +25,9 @@ class StockOnHandConcurrencyIT {
     @Autowired
     private lateinit var stockOnHandRepository: StockOnHandRepository
 
-    private val orgId = UUID.randomUUID()
-    private val productId = UUID.randomUUID()
-    private val warehouseId = UUID.randomUUID()
+    private val orgId = java.util.UUID.ofEpochMillis(System.currentTimeMillis())
+    private val productId = java.util.UUID.ofEpochMillis(System.currentTimeMillis())
+    private val warehouseId = java.util.UUID.ofEpochMillis(System.currentTimeMillis())
 
     @BeforeEach
     fun setup() {
@@ -78,7 +78,7 @@ class StockOnHandConcurrencyIT {
             INSERT INTO stock_on_hand (id, organization_id, product_id, warehouse_id, quantity, created_at)
             VALUES (?, ?, ?, ?, ?, current_timestamp)
             """.trimIndent(),
-            UUID.randomUUID(),
+            java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
             orgId,
             productId,
             warehouseId,
@@ -178,7 +178,7 @@ class StockOnHandConcurrencyIT {
     }
 
     private fun insertProduct(): java.util.UUID {
-        val pid = UUID.randomUUID()
+        val pid = java.util.UUID.ofEpochMillis(System.currentTimeMillis())
         jdbcTemplate.update(
             """
             INSERT INTO products

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/AccountServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/AccountServiceTest.kt
@@ -489,7 +489,7 @@ class AccountServiceTest {
     }
 
     private fun createMockAccount(
-        id: UUID = java.util.UUID.randomUUID(),
+        id: UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         code: String = "1000",
         name: String = "Cash",
         type: AccountType = AccountType.ASSET,

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/AuthServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/AuthServiceTest.kt
@@ -63,7 +63,11 @@ class AuthServiceTest {
         passwordEncoder = mock(PasswordEncoder::class.java)
 
         `when`(tokenHasher.hash(any())).thenAnswer { "hashed-${it.arguments[0]}" }
-        `when`(tokenHasher.generate(any())).thenAnswer { UUID.randomUUID().toString() }
+        `when`(tokenHasher.generate(any())).thenAnswer {
+            java.util.UUID
+                .ofEpochMillis(System.currentTimeMillis())
+                .toString()
+        }
 
         authService =
             AuthService(

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/BillServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/BillServiceTest.kt
@@ -162,7 +162,8 @@ class BillServiceTest {
     @Test
     fun `approve should post journal entry and update status`() {
         val bill = createBill()
-        val apAccount = createAccount(java.util.UUID.randomUUID(), "2000", "Accounts Payable", AccountType.LIABILITY)
+        val apAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2000", "Accounts Payable", AccountType.LIABILITY)
         val mockEntry =
             JournalEntry(
                 id = java.util.UUID.fromString("dea446cc-a162-314e-a549-c9aa550c0496"),
@@ -261,8 +262,9 @@ class BillServiceTest {
     @Test
     fun `recordPayment should create payment and update bill status`() {
         val bill = createBill(status = BillStatus.APPROVED)
-        val apAccount = createAccount(java.util.UUID.randomUUID(), "2000", "Accounts Payable", AccountType.LIABILITY)
-        val cashAccount = createAccount(java.util.UUID.randomUUID(), "1000", "Cash", AccountType.ASSET)
+        val apAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2000", "Accounts Payable", AccountType.LIABILITY)
+        val cashAccount = createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1000", "Cash", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(billRepository.findById(java.util.UUID.fromString("479097cc-f290-3bdb-a7c2-238728591c3d"))).thenReturn(Optional.of(bill))
@@ -296,8 +298,9 @@ class BillServiceTest {
     @Test
     fun `recordPayment should mark bill as PAID when fully paid`() {
         val bill = createBill(status = BillStatus.APPROVED)
-        val apAccount = createAccount(java.util.UUID.randomUUID(), "2000", "Accounts Payable", AccountType.LIABILITY)
-        val cashAccount = createAccount(java.util.UUID.randomUUID(), "1000", "Cash", AccountType.ASSET)
+        val apAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2000", "Accounts Payable", AccountType.LIABILITY)
+        val cashAccount = createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1000", "Cash", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(billRepository.findById(java.util.UUID.fromString("479097cc-f290-3bdb-a7c2-238728591c3d"))).thenReturn(Optional.of(bill))
@@ -453,8 +456,10 @@ class BillServiceTest {
                 totalAmount = BigDecimal("542.50"),
                 taxAmount = BigDecimal("42.50"),
             )
-        val apAccount = createAccount(java.util.UUID.randomUUID(), "2000", "Accounts Payable", AccountType.LIABILITY)
-        val taxInputAccount = createAccount(java.util.UUID.randomUUID(), "2310", "Tax Input Credits", AccountType.ASSET)
+        val apAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2000", "Accounts Payable", AccountType.LIABILITY)
+        val taxInputAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2310", "Tax Input Credits", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(billRepository.findById(java.util.UUID.fromString("479097cc-f290-3bdb-a7c2-238728591c3d"))).thenReturn(Optional.of(bill))
@@ -493,7 +498,7 @@ class BillServiceTest {
     }
 
     private fun createVendor(
-        id: UUID = java.util.UUID.randomUUID(),
+        id: UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         isActive: Boolean = true,
     ) = Vendor(
         id = id,
@@ -505,7 +510,7 @@ class BillServiceTest {
     )
 
     private fun createAccount(
-        id: UUID = java.util.UUID.randomUUID(),
+        id: UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         code: String,
         name: String,
         type: AccountType,
@@ -621,7 +626,8 @@ class BillServiceTest {
                 exchangeRate = BigDecimal("0.018"),
                 baseCurrencyAmount = BigDecimal("180.00"),
             )
-        val apAccount = createAccount(java.util.UUID.randomUUID(), "2000", "Accounts Payable", AccountType.LIABILITY)
+        val apAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2000", "Accounts Payable", AccountType.LIABILITY)
         val mockEntry = createMockJournalEntry()
 
         `when`(billRepository.findById(java.util.UUID.fromString("479097cc-f290-3bdb-a7c2-238728591c3d"))).thenReturn(Optional.of(bill))
@@ -651,8 +657,9 @@ class BillServiceTest {
                 baseCurrencyAmount = BigDecimal("54.00"),
                 baseCurrencyAmountPaid = BigDecimal("36.01"),
             )
-        val apAccount = createAccount(java.util.UUID.randomUUID(), "2000", "Accounts Payable", AccountType.LIABILITY)
-        val cashAccount = createAccount(java.util.UUID.randomUUID(), "1000", "Cash", AccountType.ASSET)
+        val apAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2000", "Accounts Payable", AccountType.LIABILITY)
+        val cashAccount = createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1000", "Cash", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(billRepository.findById(java.util.UUID.fromString("479097cc-f290-3bdb-a7c2-238728591c3d"))).thenReturn(Optional.of(bill))
@@ -690,8 +697,9 @@ class BillServiceTest {
                 exchangeRate = BigDecimal("0.018"),
                 baseCurrencyAmount = BigDecimal("180.00"),
             )
-        val apAccount = createAccount(java.util.UUID.randomUUID(), "2000", "Accounts Payable", AccountType.LIABILITY)
-        val cashAccount = createAccount(java.util.UUID.randomUUID(), "1000", "Cash", AccountType.ASSET)
+        val apAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2000", "Accounts Payable", AccountType.LIABILITY)
+        val cashAccount = createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1000", "Cash", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(billRepository.findById(java.util.UUID.fromString("479097cc-f290-3bdb-a7c2-238728591c3d"))).thenReturn(Optional.of(bill))

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/FinancialReportServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/FinancialReportServiceTest.kt
@@ -241,7 +241,7 @@ class FinancialReportServiceTest {
     }
 
     private fun account(
-        id: UUID = java.util.UUID.randomUUID(),
+        id: UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         code: String,
         type: AccountType,
     ) = Account(
@@ -253,7 +253,7 @@ class FinancialReportServiceTest {
     )
 
     private fun entry(
-        id: UUID = java.util.UUID.randomUUID(),
+        id: UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         date: LocalDate,
         lines: List<JournalEntryLine>,
     ) = JournalEntry(

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/FiscalYearServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/FiscalYearServiceTest.kt
@@ -678,7 +678,7 @@ class FiscalYearServiceTest {
     }
 
     private fun createFiscalYear(
-        id: java.util.UUID = java.util.UUID.randomUUID(),
+        id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         name: String = "FY 2026",
         startDate: LocalDate = LocalDate.of(2026, 1, 1),
         endDate: LocalDate = LocalDate.of(2026, 12, 31),

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/InventoryCostingServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/InventoryCostingServiceTest.kt
@@ -61,7 +61,7 @@ class InventoryCostingServiceTest {
         unitCost: BigDecimal? = null,
         warehouse: java.util.UUID = warehouseId,
         transferTo: java.util.UUID? = null,
-        id: java.util.UUID = java.util.UUID.randomUUID(),
+        id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         occurredAt: LocalDateTime = LocalDateTime.now(),
     ) = StockMovement(
         id = id,
@@ -267,7 +267,7 @@ class InventoryCostingServiceTest {
         original: BigDecimal,
         remaining: BigDecimal,
         unitCost: BigDecimal,
-        id: java.util.UUID = java.util.UUID.randomUUID(),
+        id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         occurredOffsetSec: Long = 0,
     ) = InventoryCostLayer(
         id = id,

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/InventoryPostingServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/InventoryPostingServiceTest.kt
@@ -70,7 +70,7 @@ class InventoryPostingServiceTest {
         stubOrg(enabled = true)
 
         service.postMovement(
-            movement(StockMovementType.TRANSFER, BigDecimal("3"), transferTo = java.util.UUID.randomUUID()),
+            movement(StockMovementType.TRANSFER, BigDecimal("3"), transferTo = java.util.UUID.ofEpochMillis(System.currentTimeMillis())),
             BigDecimal("30.00"),
         )
 

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/InventoryReportsServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/InventoryReportsServiceTest.kt
@@ -176,7 +176,7 @@ class InventoryReportsServiceTest {
         quantity: BigDecimal,
         warehouseId: UUID = java.util.UUID.fromString("c91d2c12-b2b4-3634-a3bb-d0ff561af4ff"),
         transferTo: java.util.UUID? = null,
-        id: java.util.UUID = java.util.UUID.randomUUID(),
+        id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         occurredOffsetSec: Long = 0,
     ) = StockMovement(
         id = id,

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/InvoiceServiceTest.kt
@@ -161,7 +161,8 @@ class InvoiceServiceTest {
     @Test
     fun `approve should post journal entry and update status`() {
         val invoice = createInvoice()
-        val arAccount = createAccount(java.util.UUID.randomUUID(), "1100", "Accounts Receivable", AccountType.ASSET)
+        val arAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1100", "Accounts Receivable", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(
@@ -265,8 +266,9 @@ class InvoiceServiceTest {
     @Test
     fun `recordReceipt should create receipt and update invoice status`() {
         val invoice = createInvoice(status = InvoiceStatus.APPROVED)
-        val arAccount = createAccount(java.util.UUID.randomUUID(), "1100", "Accounts Receivable", AccountType.ASSET)
-        val cashAccount = createAccount(java.util.UUID.randomUUID(), "1000", "Cash", AccountType.ASSET)
+        val arAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1100", "Accounts Receivable", AccountType.ASSET)
+        val cashAccount = createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1000", "Cash", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(
@@ -308,8 +310,9 @@ class InvoiceServiceTest {
     @Test
     fun `recordReceipt should mark invoice as PAID when fully paid`() {
         val invoice = createInvoice(status = InvoiceStatus.APPROVED)
-        val arAccount = createAccount(java.util.UUID.randomUUID(), "1100", "Accounts Receivable", AccountType.ASSET)
-        val cashAccount = createAccount(java.util.UUID.randomUUID(), "1000", "Cash", AccountType.ASSET)
+        val arAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1100", "Accounts Receivable", AccountType.ASSET)
+        val cashAccount = createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1000", "Cash", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(
@@ -483,8 +486,10 @@ class InvoiceServiceTest {
                 totalAmount = BigDecimal("2170.00"),
                 taxAmount = BigDecimal("170.00"),
             )
-        val arAccount = createAccount(java.util.UUID.randomUUID(), "1100", "Accounts Receivable", AccountType.ASSET)
-        val taxPayableAccount = createAccount(java.util.UUID.randomUUID(), "2300", "Sales Tax Payable", AccountType.LIABILITY)
+        val arAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1100", "Accounts Receivable", AccountType.ASSET)
+        val taxPayableAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "2300", "Sales Tax Payable", AccountType.LIABILITY)
         val mockEntry = createMockJournalEntry()
 
         `when`(
@@ -525,7 +530,7 @@ class InvoiceServiceTest {
     }
 
     private fun createAccount(
-        id: UUID = java.util.UUID.randomUUID(),
+        id: UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         code: String,
         name: String,
         type: AccountType,
@@ -641,7 +646,8 @@ class InvoiceServiceTest {
                 exchangeRate = BigDecimal("0.018"),
                 baseCurrencyAmount = BigDecimal("180.00"),
             )
-        val arAccount = createAccount(java.util.UUID.randomUUID(), "1100", "Accounts Receivable", AccountType.ASSET)
+        val arAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1100", "Accounts Receivable", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(
@@ -671,8 +677,9 @@ class InvoiceServiceTest {
                 exchangeRate = BigDecimal("0.018"),
                 baseCurrencyAmount = BigDecimal("180.00"),
             )
-        val arAccount = createAccount(java.util.UUID.randomUUID(), "1100", "Accounts Receivable", AccountType.ASSET)
-        val cashAccount = createAccount(java.util.UUID.randomUUID(), "1000", "Cash", AccountType.ASSET)
+        val arAccount =
+            createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1100", "Accounts Receivable", AccountType.ASSET)
+        val cashAccount = createAccount(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "1000", "Cash", AccountType.ASSET)
         val mockEntry = createMockJournalEntry()
 
         `when`(

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/JournalEntryServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/JournalEntryServiceTest.kt
@@ -918,7 +918,7 @@ class JournalEntryServiceTest {
     }
 
     private fun createMockAccount(
-        id: java.util.UUID = java.util.UUID.randomUUID(),
+        id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         code: String = "1000",
         name: String = "Cash",
         type: AccountType = AccountType.ASSET,

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/PayrollRunServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/PayrollRunServiceTest.kt
@@ -161,14 +161,14 @@ class PayrollRunServiceTest {
                 eq(orgId),
                 any(),
             ),
-        ).thenReturn(comp(java.util.UUID.randomUUID(), "120000", PayPeriod.ANNUAL)) // → 10000/mo
+        ).thenReturn(comp(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "120000", PayPeriod.ANNUAL)) // → 10000/mo
         whenever(
             compensationService.currentCompensationOrNull(
                 eq(java.util.UUID.fromString("9c45c2f1-1761-3daa-ad31-1ff8703ae846")),
                 eq(orgId),
                 any(),
             ),
-        ).thenReturn(comp(java.util.UUID.randomUUID(), "5000", PayPeriod.MONTHLY)) // → 5000/mo
+        ).thenReturn(comp(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "5000", PayPeriod.MONTHLY)) // → 5000/mo
 
         val run = service.createPayrollRun(request(), orgId, java.util.UUID.fromString("d4763ac6-a6a6-34ed-aeb4-dd91bdcf7fbb"))
 
@@ -189,14 +189,21 @@ class PayrollRunServiceTest {
                 eq(orgId),
                 any(),
             ),
-        ).thenReturn(comp(java.util.UUID.randomUUID(), "8000", PayPeriod.MONTHLY, currency = "EUR")) // skipped (currency)
+        ).thenReturn(
+            comp(
+                java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
+                "8000",
+                PayPeriod.MONTHLY,
+                currency = "EUR",
+            ),
+        ) // skipped (currency)
         whenever(
             compensationService.currentCompensationOrNull(
                 eq(java.util.UUID.fromString("9c45c2f1-1761-3daa-ad31-1ff8703ae846")),
                 eq(orgId),
                 any(),
             ),
-        ).thenReturn(comp(java.util.UUID.randomUUID(), "50", PayPeriod.HOURLY)) // skipped (hourly)
+        ).thenReturn(comp(java.util.UUID.ofEpochMillis(System.currentTimeMillis()), "50", PayPeriod.HOURLY)) // skipped (hourly)
 
         assertThatThrownBy { service.createPayrollRun(request(), orgId, java.util.UUID.fromString("d4763ac6-a6a6-34ed-aeb4-dd91bdcf7fbb")) }
             .isInstanceOf(BusinessRuleException::class.java)

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectBillingServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectBillingServiceTest.kt
@@ -74,7 +74,7 @@ class ProjectBillingServiceTest {
         billable: Boolean = true,
         invoiced: Boolean = false,
     ) = TimeEntry(
-        id = java.util.UUID.randomUUID(),
+        id = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         employeeId = java.util.UUID.fromString("00262aa5-14d7-3a01-b098-d7e370f001b2"),
         projectId = projectId,
         entryDate = day,

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectTaskServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/ProjectTaskServiceTest.kt
@@ -154,7 +154,12 @@ class ProjectTaskServiceTest {
         whenever(
             repository.findById(java.util.UUID.fromString("00000000-0000-0000-0000-000000000001")),
         ).thenReturn(
-            Optional.of(task(java.util.UUID.fromString("00000000-0000-0000-0000-000000000001"), project = java.util.UUID.randomUUID())),
+            Optional.of(
+                task(
+                    java.util.UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                    project = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
+                ),
+            ),
         )
         assertThatThrownBy { service.getTask(projectId, java.util.UUID.fromString("00000000-0000-0000-0000-000000000001"), orgId) }
             .isInstanceOf(ResourceNotFoundException::class.java)

--- a/src/test/kotlin/com/aquinofroilan/tessera/service/VendorServiceTest.kt
+++ b/src/test/kotlin/com/aquinofroilan/tessera/service/VendorServiceTest.kt
@@ -74,7 +74,7 @@ class VendorServiceTest {
 
     @Test
     fun `list should return active vendors`() {
-        val vendors = listOf(createVendor(), createVendor(id = java.util.UUID.randomUUID()))
+        val vendors = listOf(createVendor(), createVendor(id = java.util.UUID.ofEpochMillis(System.currentTimeMillis())))
         `when`(vendorRepository.findByOrganizationIdAndIsActive(orgId, true)).thenReturn(vendors)
 
         val result = vendorService.listVendors(orgId)
@@ -137,7 +137,7 @@ class VendorServiceTest {
     }
 
     private fun createVendor(
-        id: java.util.UUID = java.util.UUID.randomUUID(),
+        id: java.util.UUID = java.util.UUID.ofEpochMillis(System.currentTimeMillis()),
         name: String = "Acme Corp",
         orgId: java.util.UUID = this.orgId,
         isActive: Boolean = true,


### PR DESCRIPTION
Upgrades the toolchain to Java 26 and replaces all usages of UUID.randomUUID() with java.util.UUID.ofEpochMillis(System.currentTimeMillis()) to natively leverage UUIDv7, improving database insert performance and B-Tree indexing without requiring third-party libraries.